### PR TITLE
feat(chat): complete core Chat SDK parity surfaces

### DIFF
--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -12,6 +12,13 @@ This package is still pre-1.0, so parity work is allowed to make breaking change
 3. `Jido.Chat.Adapter.post_message/4` is now the canonical outbound entry point. Adapters should expect `Jido.Chat.PostPayload` values that may include text, markdown, cards, streams, attachments, and `Jido.Chat.FileUpload` values.
 4. Capability declarations should be explicit. Adapter packages should declare the surfaces they support in `capabilities/0`, especially for `send_file`, `stream`, `open_modal`, `cards`, `modals`, `multi_file`, `post_ephemeral`, and `assistant_events`.
 
+## Scope Clarification
+
+- `jido_chat` is the adapter/data-model package. It owns canonical structs, adapter contracts, typed handles, and fallback behavior.
+- `jido_messaging` is the runtime/orchestration layer. It owns supervision, ingress plumbing, delivery queues, retries, room/session state, and bridge lifecycle.
+- `Jido.Chat.StateAdapter` and `Jido.Chat.Concurrency` still exist in `jido_chat` today so the lightweight `Jido.Chat` facade can run locally or embedded without a larger runtime.
+- Do not treat `jido_chat` as the long-term production process-tree package. That is outside this package's intended scope.
+
 ## New Core Surfaces
 
 - `Jido.Chat.Markdown`
@@ -27,10 +34,11 @@ This package is still pre-1.0, so parity work is allowed to make breaking change
 - Single-upload payloads can fall back through `send_file/3` with caption and metadata preserved.
 - Multi-upload payloads are still capability-gated. Without an adapter-native batch upload surface, the core package returns `{:error, :multiple_attachments_unsupported}` instead of guessing.
 - Structured stream fallback now preserves step and plan text and can use placeholder-plus-edit behavior when adapters expose `edit_message/4`.
-- `Jido.Chat.AI.to_messages/2` is framework-agnostic on purpose. It produces stable role/content maps without binding the package to a specific Elixir AI client.
+- `Jido.Chat.AI.to_messages/2` is framework-agnostic on purpose. It produces stable role/content maps without binding the package to a specific Elixir AI client or mirroring TypeScript naming exactly.
+- The presence of `StateAdapter` / `Concurrency` in this package should be read as lightweight compatibility support, not as the final runtime boundary for production systems.
 
 ## Remaining Deliberate Gaps
 
-- The core package ships the concurrency contract and an in-memory adapter, but it does not yet ship a distributed lock adapter.
+- The core package ships lightweight concurrency hooks and an in-memory adapter, but production distributed coordination belongs in `jido_messaging`.
 - Stream fallback currently collapses structured chunks to text; it does not attempt markdown healing or table buffering.
 - Native card rendering, modal rendering, and transport-specific webhook semantics remain adapter-owned responsibilities.

--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -1,0 +1,36 @@
+# Jido.Chat Migration Notes
+
+This package is still pre-1.0, so parity work is allowed to make breaking changes when it improves the long-term contract.
+
+## Breaking Changes For Adapter Authors
+
+1. `Jido.Chat.StateAdapter` now requires three new callbacks:
+   - `lock/5`
+   - `release_lock/3`
+   - `force_release_lock/2`
+2. State adapter snapshots must now round-trip `locks` and `pending_locks` alongside subscriptions, dedupe state, thread state, and channel state.
+3. `Jido.Chat.Adapter.post_message/4` is now the canonical outbound entry point. Adapters should expect `Jido.Chat.PostPayload` values that may include text, markdown, cards, streams, attachments, and `Jido.Chat.FileUpload` values.
+4. Capability declarations should be explicit. Adapter packages should declare the surfaces they support in `capabilities/0`, especially for `send_file`, `stream`, `open_modal`, `cards`, `modals`, `multi_file`, `post_ephemeral`, and `assistant_events`.
+
+## New Core Surfaces
+
+- `Jido.Chat.Markdown`
+- `Jido.Chat.Card`
+- `Jido.Chat.Modal`
+- `Jido.Chat.ModalResponse`
+- `Jido.Chat.StreamChunk`
+- `Jido.Chat.Concurrency`
+- `Jido.Chat.AI`
+
+## Behavioral Notes
+
+- Single-upload payloads can fall back through `send_file/3` with caption and metadata preserved.
+- Multi-upload payloads are still capability-gated. Without an adapter-native batch upload surface, the core package returns `{:error, :multiple_attachments_unsupported}` instead of guessing.
+- Structured stream fallback now preserves step and plan text and can use placeholder-plus-edit behavior when adapters expose `edit_message/4`.
+- `Jido.Chat.AI.to_messages/2` is framework-agnostic on purpose. It produces stable role/content maps without binding the package to a specific Elixir AI client.
+
+## Remaining Deliberate Gaps
+
+- The core package ships the concurrency contract and an in-memory adapter, but it does not yet ship a distributed lock adapter.
+- Stream fallback currently collapses structured chunks to text; it does not attempt markdown healing or table buffering.
+- Native card rendering, modal rendering, and transport-specific webhook semantics remain adapter-owned responsibilities.

--- a/PARITY_MATRIX.md
+++ b/PARITY_MATRIX.md
@@ -1,59 +1,45 @@
-# Jido.Chat Parity Matrix (Phase 2 Completion Batch)
+# Jido.Chat Parity Matrix
 
-This matrix tracks practical parity against the Vercel Chat SDK surface using explicit capability classes:
+Target: functional parity with the Vercel Chat SDK core surfaces as of `chat` `4.25.0`.
 
-- `native`: platform/adapter implements direct behavior.
-- `fallback`: behavior is provided via a deterministic fallback path.
-- `unsupported`: explicit typed unsupported behavior (`{:error, :unsupported}`).
+Status meanings:
 
-## Core (`jido_chat`)
+- `native`: owned directly by `jido_chat`.
+- `fallback`: owned by `jido_chat`, but completed through a deterministic fallback path.
+- `adapter-specific`: the core package defines the contract, while platform adapters decide the transport or rendering behavior.
+- `unsupported`: the core package returns an explicit unsupported result instead of guessing.
 
-| Surface | Status |
-|---|---|
-| `Jido.Chat` lifecycle + routing (`new/initialize/shutdown`, mention/message/subscribed) | native |
-| Typed event routing (`process_event/4` + `process_*` wrappers) | native |
-| Typed webhook API (`handle_webhook_request/4`, `webhooks/1`) | native |
-| Typed file/media normalization + outbound `send_file` contract | native |
-| Serialization/revival (`to_map/from_map/reviver`) for core handles | native |
-| Thread/channel state helpers (pure struct) | native |
-| `Thread`/`ChannelRef` stream helpers | native |
-| `SentMessage` lifecycle (`edit/delete/reactions`) | native |
-| Adapter capability matrix + conformance validation | native |
+## Core-Owned Surfaces
 
-## Telegram (`jido_chat_telegram`)
+| Surface | Core Contract | Adapter Requirement | Status | Notes |
+|---|---|---|---|---|
+| Lifecycle and routing | `Jido.Chat`, `process_event/4`, typed handlers | normalize inbound payloads | native | mention, message, slash, action, reaction, modal, assistant events |
+| Outbound payload model | `Postable`, `PostPayload`, `FileUpload`, `StreamChunk` | optional `post_message/3` for native rich delivery | native | text, markdown, raw, card, stream, attachment, file inputs |
+| Single-file fallback delivery | `Adapter.post_message/4` fallback to `send_file/3` | implement `send_file/3` | fallback | caption and metadata are preserved |
+| Multi-file delivery | capability gating in core | declare and implement adapter-native batch behavior | adapter-specific | otherwise returns `{:error, :multiple_attachments_unsupported}` |
+| Markdown/card/modal modeling | `Markdown`, `Card`, `Modal`, `ModalResponse` | render or translate for platform UI | native | core owns canonical payload shape and fallback text |
+| Modal open helpers | `Thread.open_modal/3`, `ChannelRef.open_modal/3`, event helpers | implement `open_modal/3` for native behavior | fallback | explicit `{:error, :unsupported}` when unavailable |
+| Typed event envelopes | `EventEnvelope` plus normalized event structs | parse platform webhook or gateway payloads | native | event structs now carry richer thread/channel/message context |
+| Stream posting | `PostPayload.stream/2`, `Adapter.stream/4` | optional `stream/3` for native streaming | fallback | placeholder-plus-edit fallback uses `edit_message/4` when present |
+| Overlapping-message concurrency | `Concurrency`, `StateAdapter`, chat-level lock helpers | custom state adapters for distributed coordination | native | memory adapter supports reject, queue, debounce, concurrent |
+| Serialization/revival | `to_map/from_map`, `Serialization.revive/1` | preserve adapter module identity | native | snapshots now include lock state |
+| Capability negotiation | `CapabilityMatrix`, `Capabilities`, `Adapter.validate_capabilities/1` | declare explicit statuses in `capabilities/0` | native | native/fallback/unsupported are surfaced intentionally |
+| AI history conversion | `Jido.Chat.AI.to_messages/2` | none | native | chronological sorting, role mapping, multipart attachment conversion |
 
-| Capability | Status | Notes |
+## Adapter-Owned Responsibilities
+
+| Surface | Why It Stays Adapter-Owned | Notes |
 |---|---|---|
-| send/edit/delete message | native | ExGram transport |
-| typing | native | `sendChatAction` |
-| metadata fetch | native | `getChat` |
-| open DM | native | Telegram user/chat id model |
-| reactions add/remove | native | `setMessageReaction` |
-| webhook secret verification | native | `x-telegram-bot-api-secret-token` |
-| parse webhook event families (`message`, `edited_message`, `callback_query`, `message_reaction`) | native | normalized to typed events |
-| ephemeral message | fallback | DM fallback path |
-| message history (`fetch_messages`, `fetch_channel_messages`) | unsupported | Bot API limit in this adapter scope |
-| thread listing (`list_threads`) | unsupported | platform/model mismatch |
-| modal APIs | unsupported | no native Telegram modal surface |
+| Native card rendering | platform UI primitives differ too much | core provides canonical card payloads and fallback text |
+| Native modal rendering and submit semantics | modal transport and response contracts are platform-specific | core owns modal payloads and lifecycle result types |
+| Webhook verification and signature policy | each provider defines its own transport security model | core provides typed request/response wrappers |
+| Thread/message/channel fetch details | pagination and identifiers are provider-specific | core owns normalized output structs |
+| Reactions, typing, DM open, thread open/list | transport operations vary by provider | capability matrix exposes native vs fallback support |
 
-## Discord (`jido_chat_discord`)
+## Remaining Deliberate Gaps
 
-| Capability | Status | Notes |
-|---|---|---|
-| send/edit/delete message | native | Nostrum transport |
-| typing | native | channel typing API |
-| metadata/thread/message fetch | native | normalized outputs |
-| reactions add/remove | native | message reaction API |
-| list threads | native | normalized thread page |
-| webhook interaction parsing (slash/action/modal submit) | native | typed event envelopes |
-| gateway helper routing (message/reaction/modal close) | native | forwards to `process_*` |
-| signature verification | native | Ed25519 + timestamp fail-closed path |
-| interaction ephemeral | native | interaction response flags |
-| fallback ephemeral (non-interaction) | fallback | DM fallback |
-| modal close (webhook-native) | unsupported | handled as synthetic gateway event |
+Repository tracking for parity follow-up work lives under Beadwork epic `jchat-w38`.
 
-## Migration Notes
-
-- `Jido.Chat.Message` is the normalized Chat SDK-style message object.
-- thread-scoped runtime persistence now lives in `jido_messaging` via `Jido.Messaging.Message`, `Jido.Messaging.Thread`, and `Jido.Messaging.Context`.
-- legacy compatibility wrappers and migration-only message structs have been removed.
+- `jido_chat` ships the concurrency contract and the in-memory state adapter, but not a distributed lock adapter.
+- Stream fallback currently renders structured chunks to text; it does not do markdown healing or table buffering.
+- Platform-native card and modal rendering remain intentionally adapter-specific even though the payload model is now shared.

--- a/PARITY_MATRIX.md
+++ b/PARITY_MATRIX.md
@@ -1,11 +1,14 @@
-# Jido.Chat Parity Matrix
+# Jido.Chat Package Parity Matrix
 
-Target: functional parity with the Vercel Chat SDK core surfaces as of `chat` `4.25.0`.
+Target: functional parity with the Vercel Chat SDK adapter and data-model surfaces as of `chat` `4.25.0`.
+
+This matrix is package-scoped. It describes what belongs in `jido_chat`, not what belongs in the full runtime stack.
 
 Status meanings:
 
 - `native`: owned directly by `jido_chat`.
 - `fallback`: owned by `jido_chat`, but completed through a deterministic fallback path.
+- `transitional`: implemented in `jido_chat` today for lightweight/local use, but better owned by a higher runtime layer such as `jido_messaging` for production systems.
 - `adapter-specific`: the core package defines the contract, while platform adapters decide the transport or rendering behavior.
 - `unsupported`: the core package returns an explicit unsupported result instead of guessing.
 
@@ -13,7 +16,7 @@ Status meanings:
 
 | Surface | Core Contract | Adapter Requirement | Status | Notes |
 |---|---|---|---|---|
-| Lifecycle and routing | `Jido.Chat`, `process_event/4`, typed handlers | normalize inbound payloads | native | mention, message, slash, action, reaction, modal, assistant events |
+| Lightweight lifecycle and routing | `Jido.Chat`, `process_event/4`, typed handlers | normalize inbound payloads | native | pure struct/event-loop helpers, not a supervised runtime |
 | Outbound payload model | `Postable`, `PostPayload`, `FileUpload`, `StreamChunk` | optional `post_message/3` for native rich delivery | native | text, markdown, raw, card, stream, attachment, file inputs |
 | Single-file fallback delivery | `Adapter.post_message/4` fallback to `send_file/3` | implement `send_file/3` | fallback | caption and metadata are preserved |
 | Multi-file delivery | capability gating in core | declare and implement adapter-native batch behavior | adapter-specific | otherwise returns `{:error, :multiple_attachments_unsupported}` |
@@ -21,10 +24,21 @@ Status meanings:
 | Modal open helpers | `Thread.open_modal/3`, `ChannelRef.open_modal/3`, event helpers | implement `open_modal/3` for native behavior | fallback | explicit `{:error, :unsupported}` when unavailable |
 | Typed event envelopes | `EventEnvelope` plus normalized event structs | parse platform webhook or gateway payloads | native | event structs now carry richer thread/channel/message context |
 | Stream posting | `PostPayload.stream/2`, `Adapter.stream/4` | optional `stream/3` for native streaming | fallback | placeholder-plus-edit fallback uses `edit_message/4` when present |
-| Overlapping-message concurrency | `Concurrency`, `StateAdapter`, chat-level lock helpers | custom state adapters for distributed coordination | native | memory adapter supports reject, queue, debounce, concurrent |
-| Serialization/revival | `to_map/from_map`, `Serialization.revive/1` | preserve adapter module identity | native | snapshots now include lock state |
+| Lightweight state/concurrency hooks | `Concurrency`, `StateAdapter`, chat-level lock helpers | custom state adapters for local or embedded use | transitional | present for lightweight `Jido.Chat` flows today; production runtime ownership belongs in `jido_messaging` |
+| Serialization/revival | `to_map/from_map`, `Serialization.revive/1` | preserve adapter module identity | native | typed structs round-trip; runtime state ownership is transitional |
 | Capability negotiation | `CapabilityMatrix`, `Capabilities`, `Adapter.validate_capabilities/1` | declare explicit statuses in `capabilities/0` | native | native/fallback/unsupported are surfaced intentionally |
-| AI history conversion | `Jido.Chat.AI.to_messages/2` | none | native | chronological sorting, role mapping, multipart attachment conversion |
+| AI history conversion | `Jido.Chat.AI.to_messages/2` | none | native | structurally compatible with Chat SDK / AI SDK message shapes, but intentionally Elixir-native |
+
+## Runtime-Owned Outside This Package
+
+| Surface | Runtime Owner | Notes |
+|---|---|---|
+| Supervision tree and process lifecycle | `jido_messaging` | bridges, rooms, agents, reconnect workers, partitions |
+| Webhook Plug / HTTP ingress | `jido_messaging` | `jido_chat` should stay transport-agnostic |
+| Outbound queueing, retries, backpressure | `jido_messaging` | not part of the adapter contract |
+| Room/participant/thread resolution | `jido_messaging` | application/runtime concern |
+| Session routing, moderation, onboarding, security | `jido_messaging` | orchestration and policy layer |
+| Production persistence and distributed coordination | `jido_messaging` | `jido_chat` only ships lightweight hooks today |
 
 ## Adapter-Owned Responsibilities
 
@@ -40,6 +54,6 @@ Status meanings:
 
 Repository tracking for parity follow-up work lives under Beadwork epic `jchat-w38`.
 
-- `jido_chat` ships the concurrency contract and the in-memory state adapter, but not a distributed lock adapter.
+- `jido_chat` still ships lightweight concurrency hooks and the in-memory state adapter even though production ownership belongs higher in the stack.
 - Stream fallback currently renders structured chunks to text; it does not do markdown healing or table buffering.
 - Platform-native card and modal rendering remain intentionally adapter-specific even though the payload model is now shared.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jido.Chat
 
-`jido_chat` is the core Chat SDK-style surface for `Jido.Chat` adapters.
+`jido_chat` is the core adapter contract and canonical data model for `Jido.Chat` integrations.
 
 ## Experimental Status
 
@@ -9,15 +9,20 @@ This package is experimental and pre-1.0. APIs and behavior will change.
 `Jido.Chat` is an Elixir implementation aligned to the Vercel Chat SDK
 ([chat-sdk.dev/docs](https://www.chat-sdk.dev/docs)).
 
+This package is intentionally scoped to the adapter layer:
+
+- `jido_chat` owns typed content/event models, adapter contracts, typed thread/channel handles, and deterministic fallback behavior.
+- `jido_messaging` owns supervised runtime concerns such as webhook ingress, delivery queues, retries, room/session state, bridge lifecycle, and process trees.
+
 It provides:
 
-- `Jido.Chat` as the pure struct + bot loop
+- `Jido.Chat` as a lightweight struct + event-loop facade for local/in-memory flows
 - typed thread and channel handles (`Thread`, `ChannelRef`)
 - canonical outbound payloads (`Postable`, `PostPayload`, `FileUpload`, `StreamChunk`)
 - rich content models (`Markdown`, `Card`, `Modal`, `ModalResponse`)
 - typed normalized inbound/event payloads (`Incoming`, `Message`, `SentMessage`, `Response`, `EventEnvelope`)
 - explicit adapter capability negotiation and fallback behavior (`Jido.Chat.Adapter`, `CapabilityMatrix`)
-- pluggable state and overlapping-message concurrency (`StateAdapter`, `Concurrency`)
+- lightweight state and concurrency hooks used by `Jido.Chat` today (`StateAdapter`, `Concurrency`)
 - framework-agnostic AI history conversion (`Jido.Chat.AI`)
 
 ## Installation
@@ -42,9 +47,9 @@ upload hook used by the core fallback path for single-upload posts.
 
 1. Implement the required `Jido.Chat.Adapter` callbacks for your transport.
 2. Declare explicit surface support through `capabilities/0` instead of relying on callback inference.
-3. If you ship a custom `Jido.Chat.StateAdapter`, implement `lock/5`, `release_lock/3`, and `force_release_lock/2`, and persist `locks` plus `pending_locks` in snapshots.
+3. If you build directly on the lightweight `Jido.Chat` facade and ship a custom `Jido.Chat.StateAdapter`, implement `lock/5`, `release_lock/3`, and `force_release_lock/2`, and persist `locks` plus `pending_locks` in snapshots.
 4. Treat `Jido.Chat.PostPayload` as the canonical outbound contract. It can now carry text, markdown, raw payloads, cards, streams, attachments, and `FileUpload` values.
-5. Run `mix quality` before publishing adapter changes; the core test suite now exercises stream fallback, file fallback, modal payload rendering, concurrency, and AI conversion.
+5. Run `mix quality` before publishing adapter changes. Use `mix cover` when you want the current raw line-coverage signal; this package does not claim exhaustive coverage yet.
 
 ## Usage (Core Loop)
 
@@ -62,12 +67,20 @@ chat =
 ## Additional Core Helpers
 
 ```elixir
-chat =
-  Jido.Chat.new()
-  |> Jido.Chat.configure_concurrency(strategy: :queue)
-
 ai_messages = Jido.Chat.AI.to_messages(history, include_names: true)
+
+payload =
+  Jido.Chat.PostPayload.new(%{
+    text: "Hello",
+    files: [%{path: "/tmp/report.pdf", filename: "report.pdf"}]
+  })
 ```
+
+## Scope Notes
+
+- `Jido.Chat` includes lightweight subscription/state/concurrency hooks today so the core facade can run locally without a larger runtime.
+- Production ingress, retries, room/session state, and supervised delivery orchestration belong in `jido_messaging`, not this package.
+- The AI conversion helpers are structurally compatible with Chat SDK / AI SDK message shapes, but they keep Elixir-native naming and callback conventions.
 
 ## Reference Docs
 

--- a/README.md
+++ b/README.md
@@ -5,15 +5,20 @@
 ## Experimental Status
 
 This package is experimental and pre-1.0. APIs and behavior will change.
+
 `Jido.Chat` is an Elixir implementation aligned to the Vercel Chat SDK
 ([chat-sdk.dev/docs](https://www.chat-sdk.dev/docs)).
 
 It provides:
 
-- `Jido.Chat` (pure struct + function bot loop)
-- typed normalized payloads (`Incoming`, `Message`, `SentMessage`, `Response`, `EventEnvelope`)
-- typed handles (`Thread`, `ChannelRef`)
-- canonical adapter behavior (`Jido.Chat.Adapter`)
+- `Jido.Chat` as the pure struct + bot loop
+- typed thread and channel handles (`Thread`, `ChannelRef`)
+- canonical outbound payloads (`Postable`, `PostPayload`, `FileUpload`, `StreamChunk`)
+- rich content models (`Markdown`, `Card`, `Modal`, `ModalResponse`)
+- typed normalized inbound/event payloads (`Incoming`, `Message`, `SentMessage`, `Response`, `EventEnvelope`)
+- explicit adapter capability negotiation and fallback behavior (`Jido.Chat.Adapter`, `CapabilityMatrix`)
+- pluggable state and overlapping-message concurrency (`StateAdapter`, `Concurrency`)
+- framework-agnostic AI history conversion (`Jido.Chat.AI`)
 
 ## Installation
 
@@ -31,7 +36,15 @@ end
 `Jido.Chat.ChannelRef` and `Jido.Chat.Thread` are the typed handles for room and thread operations.
 Adapters can expose native rich posting through `post_message/3`, which receives the full
 typed `Jido.Chat.PostPayload` including attachments. `send_file/3` remains the low-level
-upload hook used by the core fallback path for older adapters.
+upload hook used by the core fallback path for single-upload posts.
+
+## Adapter Author Checklist
+
+1. Implement the required `Jido.Chat.Adapter` callbacks for your transport.
+2. Declare explicit surface support through `capabilities/0` instead of relying on callback inference.
+3. If you ship a custom `Jido.Chat.StateAdapter`, implement `lock/5`, `release_lock/3`, and `force_release_lock/2`, and persist `locks` plus `pending_locks` in snapshots.
+4. Treat `Jido.Chat.PostPayload` as the canonical outbound contract. It can now carry text, markdown, raw payloads, cards, streams, attachments, and `FileUpload` values.
+5. Run `mix quality` before publishing adapter changes; the core test suite now exercises stream fallback, file fallback, modal payload rendering, concurrency, and AI conversion.
 
 ## Usage (Core Loop)
 
@@ -46,8 +59,17 @@ chat =
   end)
 ```
 
-## Parity Matrix
+## Additional Core Helpers
 
-Adapter/core parity status is tracked in:
+```elixir
+chat =
+  Jido.Chat.new()
+  |> Jido.Chat.configure_concurrency(strategy: :queue)
 
-- `../PARITY_MATRIX.md`
+ai_messages = Jido.Chat.AI.to_messages(history, include_names: true)
+```
+
+## Reference Docs
+
+- [Parity Matrix](PARITY_MATRIX.md)
+- [Migration Notes](MIGRATION_NOTES.md)

--- a/lib/jido/chat/action_event.ex
+++ b/lib/jido/chat/action_event.ex
@@ -3,18 +3,26 @@ defmodule Jido.Chat.ActionEvent do
   Normalized action/button event payload placeholder for Phase 2.
   """
 
-  alias Jido.Chat.Author
+  alias Jido.Chat.{Author, ChannelRef, Message, Modal, ModalResult, Thread, Wire}
 
   @schema Zoi.struct(
             __MODULE__,
             %{
+              adapter: Zoi.any() |> Zoi.nullish(),
               adapter_name: Zoi.atom() |> Zoi.nullish(),
               thread_id: Zoi.string() |> Zoi.nullish(),
+              channel_id: Zoi.string() |> Zoi.nullish(),
               message_id: Zoi.string() |> Zoi.nullish(),
               action_id: Zoi.string() |> Zoi.nullish(),
               value: Zoi.string() |> Zoi.nullish(),
               trigger_id: Zoi.string() |> Zoi.nullish(),
               user: Zoi.struct(Author) |> Zoi.nullish(),
+              thread: Zoi.struct(Thread) |> Zoi.nullish(),
+              channel: Zoi.struct(ChannelRef) |> Zoi.nullish(),
+              message: Zoi.struct(Message) |> Zoi.nullish(),
+              related_thread: Zoi.struct(Thread) |> Zoi.nullish(),
+              related_channel: Zoi.struct(ChannelRef) |> Zoi.nullish(),
+              related_message: Zoi.struct(Message) |> Zoi.nullish(),
               raw: Zoi.map() |> Zoi.default(%{}),
               metadata: Zoi.map() |> Zoi.default(%{})
             },
@@ -30,5 +38,85 @@ defmodule Jido.Chat.ActionEvent do
   def schema, do: @schema
 
   @doc "Creates a normalized action event payload."
-  def new(attrs) when is_map(attrs), do: Jido.Chat.Schema.parse!(__MODULE__, @schema, attrs)
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_author()
+    |> normalize_handles()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Opens a modal using the action event context."
+  def open_modal(event, payload, opts \\ [])
+
+  @spec open_modal(t(), Modal.t() | map(), keyword()) :: {:ok, ModalResult.t()} | {:error, term()}
+  def open_modal(%__MODULE__{thread: %Thread{} = thread}, payload, opts) do
+    Thread.open_modal(thread, payload, opts)
+  end
+
+  def open_modal(%__MODULE__{channel: %ChannelRef{} = channel}, payload, opts) do
+    ChannelRef.open_modal(channel, payload, opts)
+  end
+
+  def open_modal(%__MODULE__{}, _payload, _opts), do: {:error, :missing_modal_target}
+
+  @doc "Serializes the action event into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = event) do
+    event
+    |> Map.from_struct()
+    |> serialize_handles()
+    |> Wire.to_plain()
+    |> Map.put("__type__", "action_event")
+  end
+
+  @doc "Builds an action event from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_author(%{user: %Author{}} = attrs), do: attrs
+  defp normalize_author(%{"user" => %Author{}} = attrs), do: attrs
+
+  defp normalize_author(attrs) do
+    case attrs[:user] || attrs["user"] do
+      %{} = user -> Map.delete(attrs, "user") |> Map.put(:user, Author.new(user))
+      _ -> attrs
+    end
+  end
+
+  defp normalize_handles(attrs) do
+    attrs
+    |> normalize_handle(:thread, Thread)
+    |> normalize_handle(:channel, ChannelRef)
+    |> normalize_handle(:message, Message)
+    |> normalize_handle(:related_thread, Thread)
+    |> normalize_handle(:related_channel, ChannelRef)
+    |> normalize_handle(:related_message, Message)
+  end
+
+  defp normalize_handle(attrs, key, mod) do
+    case attrs[key] || attrs[Atom.to_string(key)] do
+      %{__struct__: ^mod} = value ->
+        attrs |> Map.delete(Atom.to_string(key)) |> Map.put(key, value)
+
+      %{} = value ->
+        attrs |> Map.delete(Atom.to_string(key)) |> Map.put(key, mod.new(value))
+
+      _ ->
+        attrs
+    end
+  end
+
+  defp serialize_handles(map) do
+    map
+    |> Map.update!(:adapter, &Wire.encode_module/1)
+    |> Map.update!(:thread, fn value -> serialize_handle(value, &Thread.to_map/1) end)
+    |> Map.update!(:channel, fn value -> serialize_handle(value, &ChannelRef.to_map/1) end)
+    |> Map.update!(:message, fn value -> serialize_handle(value, &Message.to_map/1) end)
+    |> Map.update!(:related_thread, fn value -> serialize_handle(value, &Thread.to_map/1) end)
+    |> Map.update!(:related_channel, fn value -> serialize_handle(value, &ChannelRef.to_map/1) end)
+    |> Map.update!(:related_message, fn value -> serialize_handle(value, &Message.to_map/1) end)
+  end
+
+  defp serialize_handle(nil, _fun), do: nil
+  defp serialize_handle(value, fun), do: fun.(value)
 end

--- a/lib/jido/chat/adapter.ex
+++ b/lib/jido/chat/adapter.ex
@@ -6,11 +6,11 @@ defmodule Jido.Chat.Adapter do
   """
 
   alias Jido.Chat.{
-    Attachment,
     CapabilityMatrix,
     ChannelInfo,
     EventEnvelope,
     EphemeralMessage,
+    FileUpload,
     FetchOptions,
     Incoming,
     ModalResult,
@@ -46,7 +46,7 @@ defmodule Jido.Chat.Adapter do
   @type thread_page_result :: {:ok, ThreadPage.t()} | {:error, term()}
   @type ephemeral_result :: {:ok, EphemeralMessage.t()} | {:error, term()}
   @type modal_result :: {:ok, ModalResult.t()} | {:error, term()}
-  @type file_input :: Attachment.input()
+  @type file_input :: FileUpload.input()
 
   @callback channel_type() :: atom()
   @callback transform_incoming(raw_payload()) :: incoming_result() | {:ok, map()}
@@ -317,6 +317,7 @@ defmodule Jido.Chat.Adapter do
   def post_message(adapter_module, external_room_id, %PostPayload{} = payload, opts) do
     scope = Keyword.get(opts, :scope, :thread)
     adapter_opts = Keyword.delete(opts, :scope)
+    upload_candidates = PostPayload.upload_candidates(payload)
 
     cond do
       function_exported?(adapter_module, :post_message, 3) ->
@@ -325,21 +326,31 @@ defmodule Jido.Chat.Adapter do
           {:ok, normalize_response(adapter_module, response)}
         end
 
-      payload.attachments in [nil, []] and scope == :channel ->
-        post_channel_message(adapter_module, external_room_id, payload.text || "", adapter_opts)
+      upload_candidates in [nil, []] and scope == :channel ->
+        post_channel_message(
+          adapter_module,
+          external_room_id,
+          PostPayload.display_text(payload) || "",
+          adapter_opts
+        )
 
-      payload.attachments in [nil, []] ->
-        send_message(adapter_module, external_room_id, payload.text || "", adapter_opts)
+      upload_candidates in [nil, []] ->
+        send_message(
+          adapter_module,
+          external_room_id,
+          PostPayload.display_text(payload) || "",
+          adapter_opts
+        )
 
-      match?([_single], payload.attachments) ->
-        [attachment] = payload.attachments
+      match?([_single], upload_candidates) ->
+        [upload] = upload_candidates
 
         file_opts =
           adapter_opts
           |> maybe_put_caption(payload)
           |> maybe_put_metadata(payload.metadata)
 
-        send_file(adapter_module, external_room_id, attachment, file_opts)
+        send_file(adapter_module, external_room_id, upload, file_opts)
 
       true ->
         {:error, :multiple_attachments_unsupported}
@@ -1047,13 +1058,19 @@ defmodule Jido.Chat.Adapter do
   defp capability_callback(:format_webhook_response), do: {:format_webhook_response, 2}
   defp capability_callback(_), do: nil
 
-  defp maybe_put_caption(opts, %PostPayload{text: nil}), do: opts
-  defp maybe_put_caption(opts, %PostPayload{text: ""}), do: opts
+  defp maybe_put_caption(opts, %PostPayload{} = payload) do
+    case PostPayload.display_text(payload) do
+      nil ->
+        opts
 
-  defp maybe_put_caption(opts, %PostPayload{text: text}) do
-    opts
-    |> Keyword.put_new(:caption, text)
-    |> Keyword.put_new(:text, text)
+      "" ->
+        opts
+
+      text ->
+        opts
+        |> Keyword.put_new(:caption, text)
+        |> Keyword.put_new(:text, text)
+    end
   end
 
   defp maybe_put_metadata(opts, metadata) when metadata in [%{}, nil], do: opts

--- a/lib/jido/chat/adapter.ex
+++ b/lib/jido/chat/adapter.ex
@@ -17,6 +17,7 @@ defmodule Jido.Chat.Adapter do
     Message,
     MessagePage,
     PostPayload,
+    Postable,
     Response,
     WebhookRequest,
     WebhookResponse,
@@ -277,6 +278,7 @@ defmodule Jido.Chat.Adapter do
         format_webhook_response:
           support_status(adapter_module, :format_webhook_response, 2, :fallback)
       }
+      |> ensure_capability_defaults(adapter_module)
     end
   end
 
@@ -519,28 +521,81 @@ defmodule Jido.Chat.Adapter do
   @spec post_ephemeral(module(), external_room_id(), external_user_id(), String.t(), keyword()) ::
           ephemeral_result()
   def post_ephemeral(adapter_module, external_room_id, external_user_id, text, opts \\ []) do
-    if function_exported?(adapter_module, :post_ephemeral, 4) do
-      with {:ok, message} <-
-             adapter_module.post_ephemeral(external_room_id, external_user_id, text, opts) do
-        {:ok, normalize_ephemeral(adapter_module, message, external_room_id, false)}
-      end
-    else
-      fallback_to_dm = Keyword.get(opts, :fallback_to_dm, false)
+    post_ephemeral_message(
+      adapter_module,
+      external_room_id,
+      external_user_id,
+      PostPayload.text(text),
+      opts
+    )
+  end
 
-      if fallback_to_dm and function_exported?(adapter_module, :open_dm, 2) do
-        with {:ok, dm_room_id} <- adapter_module.open_dm(external_user_id, opts),
-             {:ok, response} <- send_message(adapter_module, dm_room_id, text, opts) do
-          {:ok,
-           EphemeralMessage.new(%{
-             id: response.external_message_id || Jido.Chat.ID.generate!(),
-             thread_id: fallback_thread_id(adapter_module, dm_room_id),
-             used_fallback: true,
-             raw: response.raw,
-             metadata: %{source_room_id: external_room_id}
-           })}
-        end
-      else
-        {:error, :unsupported}
+  @doc "Posts an ephemeral payload using the canonical outbound payload contract."
+  @spec post_ephemeral_message(
+          module(),
+          external_room_id(),
+          external_user_id(),
+          String.t() | Postable.t() | PostPayload.t() | map(),
+          keyword()
+        ) :: ephemeral_result()
+  def post_ephemeral_message(
+        adapter_module,
+        external_room_id,
+        external_user_id,
+        input,
+        opts \\ []
+      ) do
+    with {:ok, payload} <- normalize_post_payload_input(input) do
+      upload_candidates = PostPayload.upload_candidates(payload)
+      text = PostPayload.display_text(payload) || ""
+      base_opts = maybe_put_metadata(opts, payload.metadata)
+      fallback_to_dm = Keyword.get(base_opts, :fallback_to_dm, false)
+
+      cond do
+        upload_candidates == [] and function_exported?(adapter_module, :post_ephemeral, 4) ->
+          with {:ok, message} <-
+                 adapter_module.post_ephemeral(
+                   external_room_id,
+                   external_user_id,
+                   text,
+                   base_opts
+                 ) do
+            {:ok,
+             normalize_ephemeral(
+               adapter_module,
+               message,
+               external_room_id,
+               false,
+               payload,
+               base_opts
+             )}
+          end
+
+        fallback_to_dm and function_exported?(adapter_module, :open_dm, 2) ->
+          dm_opts = Keyword.delete(base_opts, :fallback_to_dm)
+
+          with {:ok, dm_room_id} <- adapter_module.open_dm(external_user_id, base_opts),
+               {:ok, response} <- post_message(adapter_module, dm_room_id, payload, dm_opts) do
+            {:ok,
+             EphemeralMessage.new(%{
+               id: response.external_message_id || Jido.Chat.ID.generate!(),
+               thread_id: fallback_thread_id(adapter_module, dm_room_id),
+               text: text,
+               formatted: payload.formatted || text,
+               used_fallback: true,
+               raw: response.raw,
+               attachments: PostPayload.outbound_attachments(payload),
+               metadata:
+                 %{source_room_id: external_room_id, delivery: :dm_fallback}
+                 |> Map.merge(payload.metadata || %{})
+             })}
+          end
+
+        upload_candidates != [] ->
+          {:error, :ephemeral_attachments_unsupported}
+
+        true ->
+          {:error, :unsupported}
       end
     end
   end
@@ -761,6 +816,8 @@ defmodule Jido.Chat.Adapter do
     if function_exported?(adapter_module, callback, arity), do: :native, else: fallback
   end
 
+  defp supported_status?(status), do: status in [:native, :fallback]
+
   defp normalize_capability_matrix(matrix) when is_map(matrix),
     do: matrix |> then(&CapabilityMatrix.new(%{capabilities: &1})) |> CapabilityMatrix.as_map()
 
@@ -886,11 +943,20 @@ defmodule Jido.Chat.Adapter do
          _adapter_module,
          %EphemeralMessage{} = message,
          _external_room_id,
-         _used_fallback
+         _used_fallback,
+         _payload,
+         _opts
        ),
        do: message
 
-  defp normalize_ephemeral(adapter_module, message, external_room_id, used_fallback)
+  defp normalize_ephemeral(
+         adapter_module,
+         message,
+         external_room_id,
+         used_fallback,
+         payload,
+         opts
+       )
        when is_map(message) do
     thread_id =
       message[:thread_id] || message["thread_id"] ||
@@ -904,9 +970,19 @@ defmodule Jido.Chat.Adapter do
     EphemeralMessage.new(%{
       id: to_string(id),
       thread_id: to_string(thread_id),
+      text: message[:text] || message["text"] || PostPayload.display_text(payload),
+      formatted:
+        message[:formatted] || message["formatted"] || payload.formatted ||
+          PostPayload.display_text(payload),
       used_fallback: message[:used_fallback] || message["used_fallback"] || used_fallback,
       raw: message[:raw] || message["raw"],
-      metadata: message[:metadata] || message["metadata"] || %{}
+      attachments:
+        message[:attachments] || message["attachments"] ||
+          PostPayload.outbound_attachments(payload),
+      metadata:
+        (message[:metadata] || message["metadata"] || %{})
+        |> Map.merge(payload.metadata || %{})
+        |> Map.merge(metadata_from_opts(opts))
     })
   end
 
@@ -960,6 +1036,12 @@ defmodule Jido.Chat.Adapter do
     do: "#{adapter_type(adapter_module)}:#{external_room_id}"
 
   defp ensure_capability_defaults(matrix, adapter_module) do
+    single_upload_supported? =
+      supported_status?(matrix[:send_file]) or supported_status?(matrix[:post_message])
+
+    multi_upload_supported? =
+      supported_status?(matrix[:multi_file]) or supported_status?(matrix[:post_message])
+
     defaults = %{
       initialize: support_status(adapter_module, :initialize, 1, :fallback),
       shutdown: support_status(adapter_module, :shutdown, 1, :fallback),
@@ -987,7 +1069,23 @@ defmodule Jido.Chat.Adapter do
       verify_webhook: support_status(adapter_module, :verify_webhook, 2, :fallback),
       parse_event: support_status(adapter_module, :parse_event, 2, :fallback),
       format_webhook_response:
-        support_status(adapter_module, :format_webhook_response, 2, :fallback)
+        support_status(adapter_module, :format_webhook_response, 2, :fallback),
+      text: :native,
+      image: if(single_upload_supported?, do: :fallback, else: :unsupported),
+      audio: if(single_upload_supported?, do: :fallback, else: :unsupported),
+      video: if(single_upload_supported?, do: :fallback, else: :unsupported),
+      file: if(single_upload_supported?, do: :fallback, else: :unsupported),
+      multi_file: if(multi_upload_supported?, do: :fallback, else: :unsupported),
+      markdown: :unsupported,
+      cards: :unsupported,
+      modals: support_status(adapter_module, :open_modal, 3),
+      ephemeral:
+        cond do
+          function_exported?(adapter_module, :post_ephemeral, 4) -> :native
+          function_exported?(adapter_module, :open_dm, 2) -> :fallback
+          true -> :unsupported
+        end,
+      assistant_events: :unsupported
     }
 
     Map.merge(defaults, matrix)
@@ -1004,6 +1102,33 @@ defmodule Jido.Chat.Adapter do
   end
 
   defp normalize_webhook_request(other, _opts), do: WebhookRequest.new(%{payload: %{raw: other}})
+
+  defp normalize_post_payload_input(%PostPayload{} = payload), do: {:ok, payload}
+
+  defp normalize_post_payload_input(%Postable{} = postable),
+    do: {:ok, Postable.to_payload(postable)}
+
+  defp normalize_post_payload_input(input) when is_binary(input),
+    do: {:ok, PostPayload.text(input)}
+
+  defp normalize_post_payload_input(input) when is_map(input) do
+    try do
+      {:ok, input |> Postable.new() |> Postable.to_payload()}
+    rescue
+      _ -> {:error, :invalid_postable}
+    end
+  end
+
+  defp normalize_post_payload_input(_input), do: {:error, :invalid_postable}
+
+  defp metadata_from_opts(opts) when is_list(opts) do
+    case Keyword.get(opts, :metadata) do
+      metadata when is_map(metadata) -> metadata
+      _other -> %{}
+    end
+  end
+
+  defp metadata_from_opts(_opts), do: %{}
 
   defp normalize_event_envelope(_adapter_module, %EventEnvelope{} = envelope), do: envelope
 

--- a/lib/jido/chat/adapter.ex
+++ b/lib/jido/chat/adapter.ex
@@ -24,6 +24,7 @@ defmodule Jido.Chat.Adapter do
     Response,
     WebhookRequest,
     WebhookResponse,
+    StreamChunk,
     Thread,
     ThreadPage
   }
@@ -386,8 +387,32 @@ defmodule Jido.Chat.Adapter do
         {:ok, normalize_response(adapter_module, response)}
       end
     else
-      text = chunks |> Enum.map(&to_string/1) |> Enum.join("")
-      send_message(adapter_module, external_room_id, text, opts)
+      fallback_chunks = Enum.to_list(chunks)
+      fallback_text = stream_fallback_text(fallback_chunks)
+      fallback_mode = Keyword.get(opts, :fallback_mode, default_stream_fallback(adapter_module))
+      placeholder_text = Keyword.get(opts, :placeholder_text, "Working...")
+      update_every = Keyword.get(opts, :update_every, 1)
+      stream_opts = Keyword.drop(opts, [:fallback_mode, :placeholder_text, :update_every])
+
+      cond do
+        fallback_mode == :post_edit and function_exported?(adapter_module, :edit_message, 4) ->
+          with {:ok, initial_response} <-
+                 send_message(adapter_module, external_room_id, placeholder_text, stream_opts),
+               {:ok, final_response} <-
+                 stream_post_edit_fallback(
+                   adapter_module,
+                   external_room_id,
+                   initial_response,
+                   fallback_chunks,
+                   stream_opts,
+                   update_every
+                 ) do
+            {:ok, final_response}
+          end
+
+        true ->
+          send_message(adapter_module, external_room_id, fallback_text, stream_opts)
+      end
     end
   end
 
@@ -1063,6 +1088,117 @@ defmodule Jido.Chat.Adapter do
 
   defp fallback_thread_id(adapter_module, external_room_id),
     do: "#{adapter_type(adapter_module)}:#{external_room_id}"
+
+  defp default_stream_fallback(adapter_module) do
+    if function_exported?(adapter_module, :edit_message, 4), do: :post_edit, else: :final
+  end
+
+  defp stream_post_edit_fallback(
+         adapter_module,
+         external_room_id,
+         initial_response,
+         chunks,
+         stream_opts,
+         update_every
+       ) do
+    total = length(chunks)
+    update_every = if is_integer(update_every) and update_every > 0, do: update_every, else: 1
+
+    chunks
+    |> Enum.with_index(1)
+    |> Enum.reduce_while({:ok, "", initial_response}, fn {chunk, index},
+                                                         {:ok, acc_text, response} ->
+      next_text = acc_text <> render_stream_chunk(chunk)
+      should_update = rem(index, update_every) == 0 or index == total
+
+      if should_update do
+        case edit_message(
+               adapter_module,
+               external_room_id,
+               initial_response.external_message_id,
+               next_text,
+               stream_opts
+             ) do
+          {:ok, next_response} ->
+            {:cont,
+             {:ok, next_text, with_stream_metadata(next_response, :post_edit, total, next_text)}}
+
+          {:error, _reason} = error ->
+            {:halt, error}
+        end
+      else
+        {:cont, {:ok, next_text, response}}
+      end
+    end)
+    |> case do
+      {:ok, _text, response} ->
+        {:ok, response}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp with_stream_metadata(%Response{} = response, mode, chunk_count, final_text) do
+    metadata =
+      (response.metadata || %{})
+      |> Map.put(:stream_fallback, mode)
+      |> Map.put(:chunk_count, chunk_count)
+      |> Map.put(:final_text, final_text)
+
+    %{response | metadata: metadata}
+  end
+
+  defp stream_fallback_text(chunks) do
+    chunks
+    |> Enum.map(&render_stream_chunk/1)
+    |> Enum.join("")
+  end
+
+  defp render_stream_chunk(%StreamChunk{} = chunk) do
+    case chunk.kind do
+      :text -> chunk.text || ""
+      :markdown -> chunk.text || ""
+      :status -> bracketed_chunk(chunk)
+      :plan -> plan_chunk(chunk)
+      :step_start -> step_chunk(chunk)
+      :step_finish -> "\n"
+      :data -> ""
+    end
+  end
+
+  defp render_stream_chunk(chunk) when is_map(chunk),
+    do: chunk |> StreamChunk.new() |> render_stream_chunk()
+
+  defp render_stream_chunk(chunk), do: to_string(chunk)
+
+  defp bracketed_chunk(%StreamChunk{} = chunk) do
+    case StreamChunk.fallback_text(chunk) do
+      nil -> ""
+      "" -> ""
+      text -> "\n[#{text}]\n"
+    end
+  end
+
+  defp plan_chunk(%StreamChunk{} = chunk) do
+    case chunk.payload do
+      items when is_list(items) ->
+        "\n" <>
+          (items
+           |> Enum.map_join("\n", fn item -> "- " <> to_string(item) end)) <> "\n"
+
+      _other ->
+        bracketed_chunk(chunk)
+    end
+  end
+
+  defp step_chunk(%StreamChunk{} = chunk) do
+    case StreamChunk.fallback_text(chunk) do
+      nil -> ""
+      "" -> ""
+      text -> "\n\n#{text}\n"
+    end
+  end
 
   defp normalize_markdown_payload(%Markdown{} = markdown), do: markdown
   defp normalize_markdown_payload(%{} = markdown), do: Markdown.new(markdown)

--- a/lib/jido/chat/adapter.ex
+++ b/lib/jido/chat/adapter.ex
@@ -248,7 +248,7 @@ defmodule Jido.Chat.Adapter do
   @doc "Returns capability matrix for adapter-native vs fallback support."
   @spec capabilities(module()) :: capability_matrix()
   def capabilities(adapter_module) do
-    if function_exported?(adapter_module, :capabilities, 0) do
+    if callback_exported?(adapter_module, :capabilities, 0) do
       adapter_module.capabilities()
       |> normalize_capability_matrix()
       |> ensure_capability_defaults(adapter_module)
@@ -892,6 +892,13 @@ defmodule Jido.Chat.Adapter do
     external_thread_id =
       thread[:external_thread_id] || thread["external_thread_id"] || opts[:external_thread_id]
 
+    metadata =
+      (thread[:metadata] || thread["metadata"] || %{})
+      |> maybe_put_thread_metadata(
+        :delivery_external_room_id,
+        thread[:delivery_external_room_id] || thread["delivery_external_room_id"]
+      )
+
     Thread.new(%{
       id:
         thread[:id] || thread["id"] ||
@@ -904,7 +911,7 @@ defmodule Jido.Chat.Adapter do
       external_thread_id: external_thread_id,
       channel_id: thread[:channel_id] || thread["channel_id"],
       is_dm: thread[:is_dm] || thread["is_dm"] || false,
-      metadata: thread[:metadata] || thread["metadata"] || %{}
+      metadata: metadata
     })
   end
 
@@ -969,6 +976,9 @@ defmodule Jido.Chat.Adapter do
 
   defp normalize_thread_page(%ThreadPage{} = page), do: page
   defp normalize_thread_page(page) when is_map(page), do: ThreadPage.new(page)
+
+  defp maybe_put_thread_metadata(metadata, _key, nil), do: metadata
+  defp maybe_put_thread_metadata(metadata, key, value), do: Map.put(metadata, key, value)
 
   defp normalize_ephemeral(
          _adapter_module,
@@ -1256,8 +1266,8 @@ defmodule Jido.Chat.Adapter do
       modals: support_status(adapter_module, :open_modal, 3),
       ephemeral:
         cond do
-          function_exported?(adapter_module, :post_ephemeral, 4) -> :native
-          function_exported?(adapter_module, :open_dm, 2) -> :fallback
+          callback_exported?(adapter_module, :post_ephemeral, 4) -> :native
+          callback_exported?(adapter_module, :open_dm, 2) -> :fallback
           true -> :unsupported
         end,
       assistant_events: :unsupported
@@ -1357,6 +1367,10 @@ defmodule Jido.Chat.Adapter do
   defp capability_callback(:parse_event), do: {:parse_event, 2}
   defp capability_callback(:format_webhook_response), do: {:format_webhook_response, 2}
   defp capability_callback(_), do: nil
+
+  defp callback_exported?(adapter_module, callback, arity) do
+    Code.ensure_loaded?(adapter_module) and function_exported?(adapter_module, callback, arity)
+  end
 
   defp maybe_put_caption(opts, %PostPayload{} = payload) do
     case PostPayload.display_text(payload) do

--- a/lib/jido/chat/adapter.ex
+++ b/lib/jido/chat/adapter.ex
@@ -6,6 +6,7 @@ defmodule Jido.Chat.Adapter do
   """
 
   alias Jido.Chat.{
+    Card,
     CapabilityMatrix,
     ChannelInfo,
     EventEnvelope,
@@ -13,6 +14,8 @@ defmodule Jido.Chat.Adapter do
     FileUpload,
     FetchOptions,
     Incoming,
+    Markdown,
+    Modal,
     ModalResult,
     Message,
     MessagePage,
@@ -601,9 +604,12 @@ defmodule Jido.Chat.Adapter do
   end
 
   @doc "Opens adapter-native modal when supported."
-  @spec open_modal(module(), external_room_id(), map(), keyword()) ::
+  @spec open_modal(module(), external_room_id(), Modal.t() | map(), keyword()) ::
           modal_result()
-  def open_modal(adapter_module, external_room_id, payload, opts \\ []) when is_map(payload) do
+  def open_modal(adapter_module, external_room_id, payload, opts \\ [])
+      when is_map(payload) or is_struct(payload, Modal) do
+    payload = normalize_modal_payload(payload)
+
     if function_exported?(adapter_module, :open_modal, 3) do
       with {:ok, result} <- adapter_module.open_modal(external_room_id, payload, opts) do
         {:ok, normalize_modal_result(result, external_room_id)}
@@ -1009,6 +1015,29 @@ defmodule Jido.Chat.Adapter do
     })
   end
 
+  @doc "Returns a stable adapter-facing Markdown representation."
+  @spec render_markdown(Markdown.t() | map() | String.t(), keyword()) :: String.t()
+  def render_markdown(markdown, _opts \\ []) do
+    markdown
+    |> normalize_markdown_payload()
+    |> Markdown.stringify()
+  end
+
+  @doc "Returns a stable adapter-facing card payload."
+  @spec render_card(Card.t() | map(), keyword()) :: map()
+  def render_card(card, _opts \\ []) do
+    card
+    |> normalize_card_payload()
+    |> Card.to_adapter_payload()
+  end
+
+  @doc "Returns a stable adapter-facing modal payload."
+  @spec render_modal(Modal.t() | map(), keyword()) :: map()
+  def render_modal(modal, _opts \\ []) do
+    modal
+    |> normalize_modal_payload()
+  end
+
   defp default_channel_info(adapter_module, external_room_id) do
     ChannelInfo.new(%{
       id: to_string(external_room_id),
@@ -1034,6 +1063,16 @@ defmodule Jido.Chat.Adapter do
 
   defp fallback_thread_id(adapter_module, external_room_id),
     do: "#{adapter_type(adapter_module)}:#{external_room_id}"
+
+  defp normalize_markdown_payload(%Markdown{} = markdown), do: markdown
+  defp normalize_markdown_payload(%{} = markdown), do: Markdown.new(markdown)
+  defp normalize_markdown_payload(value) when is_binary(value), do: Markdown.parse(value)
+
+  defp normalize_card_payload(%Card{} = card), do: card
+  defp normalize_card_payload(%{} = card), do: Card.new(card)
+
+  defp normalize_modal_payload(%Modal{} = modal), do: Modal.to_adapter_payload(modal)
+  defp normalize_modal_payload(%{} = modal), do: modal
 
   defp ensure_capability_defaults(matrix, adapter_module) do
     single_upload_supported? =

--- a/lib/jido/chat/ai.ex
+++ b/lib/jido/chat/ai.ex
@@ -1,0 +1,202 @@
+defmodule Jido.Chat.AI do
+  @moduledoc """
+  Framework-agnostic conversion helpers for turning chat history into AI-ready messages.
+  """
+
+  alias Jido.Chat.{Media, Message}
+
+  @type ai_content_part :: map()
+  @type ai_message :: %{
+          required(:role) => String.t(),
+          required(:content) => String.t() | [ai_content_part()]
+        }
+
+  @doc "Converts normalized chat messages into AI-friendly role/content maps."
+  @spec to_messages([Message.t() | map()], keyword()) :: [ai_message()]
+  def to_messages(messages, opts \\ []) when is_list(messages) do
+    messages
+    |> Enum.map(&normalize_message/1)
+    |> sort_messages()
+    |> Enum.map(&to_ai_message(&1, opts))
+  end
+
+  @doc "Alias for `to_messages/2`."
+  @spec to_ai_messages([Message.t() | map()], keyword()) :: [ai_message()]
+  def to_ai_messages(messages, opts \\ []), do: to_messages(messages, opts)
+
+  defp normalize_message(%Message{} = message), do: message
+  defp normalize_message(message) when is_map(message), do: Message.new(message)
+
+  defp sort_messages(messages) do
+    messages
+    |> Enum.with_index()
+    |> Enum.sort_by(fn {message, index} -> {message_sort_key(message), index} end)
+    |> Enum.map(&elem(&1, 0))
+  end
+
+  defp message_sort_key(%Message{created_at: %DateTime{} = dt}),
+    do: DateTime.to_unix(dt, :microsecond)
+
+  defp message_sort_key(%Message{created_at: %NaiveDateTime{} = dt}),
+    do: NaiveDateTime.to_iso8601(dt)
+
+  defp message_sort_key(%Message{created_at: created_at}) when is_integer(created_at),
+    do: created_at
+
+  defp message_sort_key(%Message{created_at: created_at}) when is_binary(created_at),
+    do: created_at
+
+  defp message_sort_key(_message), do: :infinity
+
+  defp to_ai_message(%Message{} = message, opts) do
+    parts =
+      []
+      |> maybe_add_text_part(message.text || message.formatted)
+      |> Kernel.++(attachment_parts(message, opts))
+
+    ai_message =
+      %{
+        role: role_for(message),
+        content:
+          if(length(parts) <= 1 and text_only_parts?(parts), do: single_text(parts), else: parts)
+      }
+      |> maybe_put_name(message, opts)
+
+    transform_message(ai_message, message, opts)
+  end
+
+  defp maybe_add_text_part(parts, nil), do: parts
+  defp maybe_add_text_part(parts, ""), do: parts
+  defp maybe_add_text_part(parts, text), do: parts ++ [%{type: "text", text: text}]
+
+  defp attachment_parts(%Message{attachments: attachments} = message, opts) do
+    Enum.flat_map(attachments || [], fn
+      %Media{} = attachment ->
+        attachment_to_parts(attachment, message, opts)
+
+      attachment when is_map(attachment) ->
+        attachment |> Media.normalize() |> attachment_to_parts(message, opts)
+
+      _other ->
+        []
+    end)
+  end
+
+  defp attachment_to_parts(%Media{kind: :image} = attachment, _message, _opts) do
+    [
+      %{
+        type: "image",
+        url: attachment.url,
+        media_type: attachment.media_type,
+        metadata: attachment.metadata || %{}
+      }
+    ]
+  end
+
+  defp attachment_to_parts(%Media{kind: :file} = attachment, message, opts) do
+    if text_like_file?(attachment) do
+      case resolve_file_text(attachment, opts) do
+        nil ->
+          unsupported_attachment_parts(attachment, message, opts)
+
+        text ->
+          [%{type: "text", text: text, filename: attachment.filename}]
+      end
+    else
+      unsupported_attachment_parts(attachment, message, opts)
+    end
+  end
+
+  defp attachment_to_parts(%Media{} = attachment, message, opts) do
+    unsupported_attachment_parts(attachment, message, opts)
+  end
+
+  defp unsupported_attachment_parts(attachment, message, opts) do
+    case opts[:unsupported_attachment] do
+      nil ->
+        []
+
+      callback when is_function(callback, 2) ->
+        case callback.(attachment, message) do
+          nil -> []
+          :skip -> []
+          value when is_binary(value) -> [%{type: "text", text: value}]
+          value when is_map(value) -> [value]
+          values when is_list(values) -> values
+          _other -> []
+        end
+
+      _other ->
+        []
+    end
+  end
+
+  defp resolve_file_text(%Media{metadata: metadata} = attachment, opts) do
+    case metadata[:data] || metadata["data"] do
+      data when is_binary(data) ->
+        data
+
+      _ ->
+        case opts[:fetch_attachment] do
+          callback when is_function(callback, 1) ->
+            case callback.(attachment) do
+              {:ok, value} when is_binary(value) -> value
+              value when is_binary(value) -> value
+              _other -> nil
+            end
+
+          _ ->
+            nil
+        end
+    end
+  end
+
+  defp text_like_file?(%Media{media_type: media_type, filename: filename}) do
+    cond do
+      is_binary(media_type) and String.starts_with?(media_type, "text/") ->
+        true
+
+      is_binary(media_type) and media_type in ["application/json", "application/xml"] ->
+        true
+
+      is_binary(filename) and Path.extname(filename) in [".txt", ".md", ".json", ".csv", ".xml"] ->
+        true
+
+      true ->
+        false
+    end
+  end
+
+  defp role_for(%Message{metadata: metadata, author: author}) do
+    role = metadata[:role] || metadata["role"]
+
+    cond do
+      role in [:system, "system"] -> "system"
+      role in [:assistant, "assistant"] -> "assistant"
+      role in [:user, "user"] -> "user"
+      author && author.is_me -> "assistant"
+      true -> "user"
+    end
+  end
+
+  defp maybe_put_name(message, %Message{author: author}, opts) do
+    if opts[:include_names] && author do
+      Map.put(message, :name, author.user_name || author.full_name)
+    else
+      message
+    end
+  end
+
+  defp transform_message(ai_message, message, opts) do
+    case opts[:transform] do
+      callback when is_function(callback, 2) -> callback.(ai_message, message)
+      callback when is_function(callback, 1) -> callback.(ai_message)
+      _ -> ai_message
+    end
+  end
+
+  defp text_only_parts?(parts), do: Enum.all?(parts, &match?(%{type: "text"}, &1))
+  defp single_text([]), do: ""
+  defp single_text([%{text: text}]), do: text
+  defp single_text(parts), do: Enum.map_join(parts, "\n", &Map.get(&1, :text, ""))
+end

--- a/lib/jido/chat/ai.ex
+++ b/lib/jido/chat/ai.ex
@@ -11,9 +11,21 @@ defmodule Jido.Chat.AI do
           required(:content) => String.t() | [ai_content_part()]
         }
 
-  @doc "Converts normalized chat messages into AI-friendly role/content maps."
-  @spec to_messages([Message.t() | map()], keyword()) :: [ai_message()]
+  @doc """
+  Converts normalized chat messages into AI-friendly role/content maps.
+
+  Options stay Elixir-native by default, but Chat SDK-style camelCase aliases are
+  accepted to make cross-port migration less brittle:
+
+  - `include_names` or `includeNames`
+  - `transform` or `transformMessage`
+  - `unsupported_attachment` or `onUnsupportedAttachment`
+  - `fetch_attachment` or `fetchAttachment`
+  """
+  @spec to_messages([Message.t() | map()], keyword() | map()) :: [ai_message()]
   def to_messages(messages, opts \\ []) when is_list(messages) do
+    opts = normalize_opts(opts)
+
     messages
     |> Enum.map(&normalize_message/1)
     |> sort_messages()
@@ -21,7 +33,7 @@ defmodule Jido.Chat.AI do
   end
 
   @doc "Alias for `to_messages/2`."
-  @spec to_ai_messages([Message.t() | map()], keyword()) :: [ai_message()]
+  @spec to_ai_messages([Message.t() | map()], keyword() | map()) :: [ai_message()]
   def to_ai_messages(messages, opts \\ []), do: to_messages(messages, opts)
 
   defp normalize_message(%Message{} = message), do: message
@@ -112,7 +124,11 @@ defmodule Jido.Chat.AI do
   end
 
   defp unsupported_attachment_parts(attachment, message, opts) do
-    case opts[:unsupported_attachment] do
+    case option(opts, [
+           :unsupported_attachment,
+           :on_unsupported_attachment,
+           :onUnsupportedAttachment
+         ]) do
       nil ->
         []
 
@@ -137,7 +153,7 @@ defmodule Jido.Chat.AI do
         data
 
       _ ->
-        case opts[:fetch_attachment] do
+        case option(opts, [:fetch_attachment, :fetchAttachment]) do
           callback when is_function(callback, 1) ->
             case callback.(attachment) do
               {:ok, value} when is_binary(value) -> value
@@ -180,7 +196,7 @@ defmodule Jido.Chat.AI do
   end
 
   defp maybe_put_name(message, %Message{author: author}, opts) do
-    if opts[:include_names] && author do
+    if option(opts, [:include_names, :includeNames]) && author do
       Map.put(message, :name, author.user_name || author.full_name)
     else
       message
@@ -188,11 +204,21 @@ defmodule Jido.Chat.AI do
   end
 
   defp transform_message(ai_message, message, opts) do
-    case opts[:transform] do
+    case option(opts, [:transform, :transform_message, :transformMessage]) do
       callback when is_function(callback, 2) -> callback.(ai_message, message)
       callback when is_function(callback, 1) -> callback.(ai_message)
       _ -> ai_message
     end
+  end
+
+  defp normalize_opts(opts) when is_list(opts), do: Map.new(opts)
+  defp normalize_opts(opts) when is_map(opts), do: opts
+  defp normalize_opts(_opts), do: %{}
+
+  defp option(opts, keys) when is_map(opts) do
+    Enum.find_value(keys, fn key ->
+      Map.get(opts, key) || Map.get(opts, Atom.to_string(key))
+    end)
   end
 
   defp text_only_parts?(parts), do: Enum.all?(parts, &match?(%{type: "text"}, &1))

--- a/lib/jido/chat/assistant_context_changed_event.ex
+++ b/lib/jido/chat/assistant_context_changed_event.ex
@@ -3,12 +3,23 @@ defmodule Jido.Chat.AssistantContextChangedEvent do
   Normalized assistant-context-changed event.
   """
 
+  alias Jido.Chat.{ChannelRef, Message, Thread, Wire}
+
   @schema Zoi.struct(
             __MODULE__,
             %{
+              adapter: Zoi.any() |> Zoi.nullish(),
               adapter_name: Zoi.atom() |> Zoi.nullish(),
               thread_id: Zoi.string(),
+              channel_id: Zoi.string() |> Zoi.nullish(),
+              message_id: Zoi.string() |> Zoi.nullish(),
               context: Zoi.map() |> Zoi.default(%{}),
+              thread: Zoi.struct(Thread) |> Zoi.nullish(),
+              channel: Zoi.struct(ChannelRef) |> Zoi.nullish(),
+              message: Zoi.struct(Message) |> Zoi.nullish(),
+              related_thread: Zoi.struct(Thread) |> Zoi.nullish(),
+              related_channel: Zoi.struct(ChannelRef) |> Zoi.nullish(),
+              related_message: Zoi.struct(Message) |> Zoi.nullish(),
               metadata: Zoi.map() |> Zoi.default(%{}),
               raw: Zoi.map() |> Zoi.default(%{})
             },
@@ -24,5 +35,60 @@ defmodule Jido.Chat.AssistantContextChangedEvent do
   def schema, do: @schema
 
   @doc "Creates a normalized assistant context changed event."
-  def new(attrs) when is_map(attrs), do: Jido.Chat.Schema.parse!(__MODULE__, @schema, attrs)
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_handles()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Serializes the assistant event into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = event) do
+    event
+    |> Map.from_struct()
+    |> serialize_handles()
+    |> Wire.to_plain()
+    |> Map.put("__type__", "assistant_context_changed_event")
+  end
+
+  @doc "Builds the assistant event from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_handles(attrs) do
+    attrs
+    |> normalize_handle(:thread, Thread)
+    |> normalize_handle(:channel, ChannelRef)
+    |> normalize_handle(:message, Message)
+    |> normalize_handle(:related_thread, Thread)
+    |> normalize_handle(:related_channel, ChannelRef)
+    |> normalize_handle(:related_message, Message)
+  end
+
+  defp normalize_handle(attrs, key, mod) do
+    case attrs[key] || attrs[Atom.to_string(key)] do
+      %{__struct__: ^mod} = value ->
+        attrs |> Map.delete(Atom.to_string(key)) |> Map.put(key, value)
+
+      %{} = value ->
+        attrs |> Map.delete(Atom.to_string(key)) |> Map.put(key, mod.new(value))
+
+      _ ->
+        attrs
+    end
+  end
+
+  defp serialize_handles(map) do
+    map
+    |> Map.update!(:adapter, &Wire.encode_module/1)
+    |> Map.update!(:thread, fn value -> serialize_handle(value, &Thread.to_map/1) end)
+    |> Map.update!(:channel, fn value -> serialize_handle(value, &ChannelRef.to_map/1) end)
+    |> Map.update!(:message, fn value -> serialize_handle(value, &Message.to_map/1) end)
+    |> Map.update!(:related_thread, fn value -> serialize_handle(value, &Thread.to_map/1) end)
+    |> Map.update!(:related_channel, fn value -> serialize_handle(value, &ChannelRef.to_map/1) end)
+    |> Map.update!(:related_message, fn value -> serialize_handle(value, &Message.to_map/1) end)
+  end
+
+  defp serialize_handle(nil, _fun), do: nil
+  defp serialize_handle(value, fun), do: fun.(value)
 end

--- a/lib/jido/chat/assistant_thread_started_event.ex
+++ b/lib/jido/chat/assistant_thread_started_event.ex
@@ -3,11 +3,22 @@ defmodule Jido.Chat.AssistantThreadStartedEvent do
   Normalized assistant-thread-started event.
   """
 
+  alias Jido.Chat.{ChannelRef, Message, Thread, Wire}
+
   @schema Zoi.struct(
             __MODULE__,
             %{
+              adapter: Zoi.any() |> Zoi.nullish(),
               adapter_name: Zoi.atom() |> Zoi.nullish(),
               thread_id: Zoi.string(),
+              channel_id: Zoi.string() |> Zoi.nullish(),
+              message_id: Zoi.string() |> Zoi.nullish(),
+              thread: Zoi.struct(Thread) |> Zoi.nullish(),
+              channel: Zoi.struct(ChannelRef) |> Zoi.nullish(),
+              message: Zoi.struct(Message) |> Zoi.nullish(),
+              related_thread: Zoi.struct(Thread) |> Zoi.nullish(),
+              related_channel: Zoi.struct(ChannelRef) |> Zoi.nullish(),
+              related_message: Zoi.struct(Message) |> Zoi.nullish(),
               metadata: Zoi.map() |> Zoi.default(%{}),
               raw: Zoi.map() |> Zoi.default(%{})
             },
@@ -23,5 +34,60 @@ defmodule Jido.Chat.AssistantThreadStartedEvent do
   def schema, do: @schema
 
   @doc "Creates a normalized assistant thread started event."
-  def new(attrs) when is_map(attrs), do: Jido.Chat.Schema.parse!(__MODULE__, @schema, attrs)
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_handles()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Serializes the assistant event into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = event) do
+    event
+    |> Map.from_struct()
+    |> serialize_handles()
+    |> Wire.to_plain()
+    |> Map.put("__type__", "assistant_thread_started_event")
+  end
+
+  @doc "Builds the assistant event from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_handles(attrs) do
+    attrs
+    |> normalize_handle(:thread, Thread)
+    |> normalize_handle(:channel, ChannelRef)
+    |> normalize_handle(:message, Message)
+    |> normalize_handle(:related_thread, Thread)
+    |> normalize_handle(:related_channel, ChannelRef)
+    |> normalize_handle(:related_message, Message)
+  end
+
+  defp normalize_handle(attrs, key, mod) do
+    case attrs[key] || attrs[Atom.to_string(key)] do
+      %{__struct__: ^mod} = value ->
+        attrs |> Map.delete(Atom.to_string(key)) |> Map.put(key, value)
+
+      %{} = value ->
+        attrs |> Map.delete(Atom.to_string(key)) |> Map.put(key, mod.new(value))
+
+      _ ->
+        attrs
+    end
+  end
+
+  defp serialize_handles(map) do
+    map
+    |> Map.update!(:adapter, &Wire.encode_module/1)
+    |> Map.update!(:thread, fn value -> serialize_handle(value, &Thread.to_map/1) end)
+    |> Map.update!(:channel, fn value -> serialize_handle(value, &ChannelRef.to_map/1) end)
+    |> Map.update!(:message, fn value -> serialize_handle(value, &Message.to_map/1) end)
+    |> Map.update!(:related_thread, fn value -> serialize_handle(value, &Thread.to_map/1) end)
+    |> Map.update!(:related_channel, fn value -> serialize_handle(value, &ChannelRef.to_map/1) end)
+    |> Map.update!(:related_message, fn value -> serialize_handle(value, &Message.to_map/1) end)
+  end
+
+  defp serialize_handle(nil, _fun), do: nil
+  defp serialize_handle(value, fun), do: fun.(value)
 end

--- a/lib/jido/chat/attachment.ex
+++ b/lib/jido/chat/attachment.ex
@@ -4,7 +4,7 @@ defmodule Jido.Chat.Attachment do
   """
 
   alias Jido.Chat.Content.{Audio, File, Image, Video}
-  alias Jido.Chat.Media
+  alias Jido.Chat.{FileUpload, Media}
 
   @schema Zoi.struct(
             __MODULE__,
@@ -28,6 +28,7 @@ defmodule Jido.Chat.Attachment do
 
   @type input ::
           t()
+          | FileUpload.t()
           | Media.t()
           | Image.t()
           | Audio.t()
@@ -51,6 +52,10 @@ defmodule Jido.Chat.Attachment do
   @doc "Normalizes supported outbound attachment inputs into a canonical attachment struct."
   @spec normalize(input()) :: t()
   def normalize(%__MODULE__{} = attachment), do: attachment
+
+  def normalize(%FileUpload{} = file_upload) do
+    new(Map.from_struct(file_upload))
+  end
 
   def normalize(%Media{} = media) do
     metadata = media.metadata || %{}

--- a/lib/jido/chat/capabilities.ex
+++ b/lib/jido/chat/capabilities.ex
@@ -2,40 +2,12 @@ defmodule Jido.Chat.Capabilities do
   @moduledoc """
   Capabilities negotiation for adapters and participants.
 
-  Provides functions to check and filter content based on channel capabilities,
-  preventing content type mismatches between channels and participants.
-
-  ## Supported Capabilities
-
-  - `:text` - Plain text messages
-  - `:image` - Image attachments
-  - `:audio` - Audio files and voice messages
-  - `:video` - Video attachments
-  - `:file` - Generic file attachments
-  - `:tool_use` - Tool/action invocation blocks
-  - `:streaming` - Incremental message updates
-  - `:reactions` - Message reactions
-  - `:threads` - Threaded conversations
-  - `:typing` - Typing indicators
-  - `:presence` - Presence status updates
-  - `:read_receipts` - Delivery and read receipts
-
-  ## Examples
-
-      # Check if a channel can deliver content
-      iex> Capabilities.can_deliver?([:text, :image], %Content.Image{url: "..."})
-      true
-
-      iex> Capabilities.can_deliver?([:text], %Content.Image{url: "..."})
-      false
-
-      # Filter content to what a channel supports
-      iex> content = [%Content.Text{text: "Hi"}, %Content.Image{url: "..."}]
-      iex> Capabilities.filter_content(content, [:text])
-      [%Content.Text{text: "Hi"}]
+  Provides functions to check and filter inbound content blocks and outbound
+  post payloads based on channel capabilities.
   """
 
-  alias Jido.Chat.Content.{Text, Image, Audio, Video, File, ToolUse, ToolResult}
+  alias Jido.Chat.{Adapter, Attachment, FileUpload, PostPayload, Postable}
+  alias Jido.Chat.Content.{Audio, File, Image, Text, ToolResult, ToolUse, Video}
 
   @type capability ::
           :text
@@ -43,6 +15,11 @@ defmodule Jido.Chat.Capabilities do
           | :audio
           | :video
           | :file
+          | :multi_file
+          | :markdown
+          | :cards
+          | :modals
+          | :ephemeral
           | :tool_use
           | :streaming
           | :reactions
@@ -50,6 +27,7 @@ defmodule Jido.Chat.Capabilities do
           | :typing
           | :presence
           | :read_receipts
+          | :assistant_events
 
   @type capabilities :: [capability()]
 
@@ -59,48 +37,32 @@ defmodule Jido.Chat.Capabilities do
     :audio,
     :video,
     :file,
+    :multi_file,
+    :markdown,
+    :cards,
+    :modals,
+    :ephemeral,
     :tool_use,
     :streaming,
     :reactions,
     :threads,
     :typing,
     :presence,
-    :read_receipts
+    :read_receipts,
+    :assistant_events
   ]
 
-  @doc """
-  Returns all supported capability atoms.
-  """
-  @spec all :: capabilities()
+  @doc "Returns all supported capability atoms."
+  @spec all() :: capabilities()
   def all, do: @all_capabilities
 
-  @doc """
-  Checks if a capability is in the list of capabilities.
-
-  ## Examples
-
-      iex> Capabilities.supports?([:text, :image], :text)
-      true
-
-      iex> Capabilities.supports?([:text], :image)
-      false
-  """
+  @doc "Checks if a capability is in the list of capabilities."
   @spec supports?(capabilities(), capability()) :: boolean()
   def supports?(capabilities, capability) when is_list(capabilities) and is_atom(capability) do
     capability in capabilities
   end
 
-  @doc """
-  Returns the list of capabilities required for a content type.
-
-  ## Examples
-
-      iex> Capabilities.content_requires(%Content.Text{text: "hello"})
-      [:text]
-
-      iex> Capabilities.content_requires(%Content.Image{url: "..."})
-      [:image]
-  """
+  @doc "Returns the list of capabilities required for an inbound content block."
   @spec content_requires(struct()) :: capabilities()
   def content_requires(%Text{}), do: [:text]
   def content_requires(%Image{}), do: [:image]
@@ -111,79 +73,74 @@ defmodule Jido.Chat.Capabilities do
   def content_requires(%ToolResult{}), do: [:text]
   def content_requires(_), do: [:text]
 
-  @doc """
-  Checks if a channel can deliver the given content.
+  @doc "Checks if a channel can deliver the given outbound postable payload."
+  @spec can_deliver?(capabilities(), Postable.t() | PostPayload.t() | map()) :: boolean()
+  def can_deliver?(channel_caps, %Postable{} = postable) when is_list(channel_caps) do
+    can_deliver?(channel_caps, Postable.to_payload(postable))
+  end
 
-  Returns true if the channel capabilities include all requirements for the content.
+  def can_deliver?(channel_caps, %PostPayload{} = payload) when is_list(channel_caps) do
+    uploads_supported? =
+      payload
+      |> upload_requires()
+      |> Enum.all?(&supports?(channel_caps, &1))
 
-  ## Examples
+    content_supported? =
+      case payload.kind do
+        :stream ->
+          supports?(channel_caps, :streaming)
 
-      iex> Capabilities.can_deliver?([:text, :image], %Content.Text{text: "hello"})
-      true
+        :card ->
+          supports?(channel_caps, :cards) or
+            (supports?(channel_caps, :text) and is_binary(payload.fallback_text || payload.text))
 
-      iex> Capabilities.can_deliver?([:text], %Content.Image{url: "..."})
-      false
-  """
+        :markdown ->
+          supports?(channel_caps, :markdown) or supports?(channel_caps, :text)
+
+        _other ->
+          supports?(channel_caps, :text)
+      end
+
+    uploads_supported? and content_supported?
+  end
+
+  def can_deliver?(channel_caps, payload)
+      when is_list(channel_caps) and is_map(payload) and not is_struct(payload) do
+    try do
+      payload
+      |> PostPayload.new()
+      |> then(&can_deliver?(channel_caps, &1))
+    rescue
+      _ -> false
+    end
+  end
+
   @spec can_deliver?(capabilities(), struct()) :: boolean()
   def can_deliver?(channel_caps, content) when is_list(channel_caps) do
     required = content_requires(content)
     Enum.all?(required, &supports?(channel_caps, &1))
   end
 
-  @doc """
-  Filters a list of content to only what the channel supports.
-
-  Returns a list containing only content that the channel can deliver.
-
-  ## Examples
-
-      iex> content = [%Content.Text{text: "Hi"}, %Content.Image{url: "..."}]
-      iex> Capabilities.filter_content(content, [:text])
-      [%Content.Text{text: "Hi"}]
-  """
-  @spec filter_content([struct()], capabilities()) :: [struct()]
+  @doc "Filters a list of content or outbound payloads to only what the channel supports."
+  @spec filter_content([term()], capabilities()) :: [term()]
   def filter_content(content_list, channel_caps)
       when is_list(content_list) and is_list(channel_caps) do
     Enum.filter(content_list, &can_deliver?(channel_caps, &1))
   end
 
-  @doc """
-  Returns a list of content that the channel cannot deliver.
-
-  ## Examples
-
-      iex> content = [%Content.Text{text: "Hi"}, %Content.Image{url: "..."}]
-      iex> Capabilities.unsupported_content(content, [:text])
-      [%Content.Image{url: "..."}]
-  """
-  @spec unsupported_content([struct()], capabilities()) :: [struct()]
+  @doc "Returns a list of content or outbound payloads that the channel cannot deliver."
+  @spec unsupported_content([term()], capabilities()) :: [term()]
   def unsupported_content(content_list, channel_caps)
       when is_list(content_list) and is_list(channel_caps) do
     Enum.reject(content_list, &can_deliver?(channel_caps, &1))
   end
 
-  @doc """
-  Returns the content capabilities for an adapter module.
-
-  Legacy channel wrappers have been removed. This helper now accepts the canonical
-  `Jido.Chat.Adapter` module and derives a content-focused capability list from the
-  adapter surface. When an adapter only exposes the operational capability matrix,
-  the content fallback remains `[:text]`.
-
-  ## Examples
-
-      iex> Capabilities.channel_capabilities(Jido.Chat.Discord.Adapter)
-      [:text, :reactions, :threads]
-  """
+  @doc "Returns the delivery-focused capability list for an adapter module."
   @spec channel_capabilities(module()) :: capabilities()
   def channel_capabilities(adapter_module) when is_atom(adapter_module) do
-    cond do
-      function_exported?(adapter_module, :capabilities, 0) ->
-        normalize_adapter_capabilities(adapter_module.capabilities())
-
-      true ->
-        [:text]
-    end
+    adapter_module
+    |> Adapter.capabilities()
+    |> normalize_adapter_capabilities()
   end
 
   defp normalize_adapter_capabilities(capabilities) when is_list(capabilities) do
@@ -197,14 +154,34 @@ defmodule Jido.Chat.Capabilities do
 
   defp normalize_adapter_capabilities(capabilities) when is_map(capabilities) do
     media_supported? =
-      supported_status?(capabilities[:post_message]) or
-        supported_status?(capabilities[:send_file])
+      supported_status?(capabilities[:image]) or
+        supported_status?(capabilities[:audio]) or
+        supported_status?(capabilities[:video]) or
+        supported_status?(capabilities[:file]) or
+        supported_status?(capabilities[:send_file]) or
+        supported_status?(capabilities[:post_message])
+
+    multi_file_supported? =
+      supported_status?(capabilities[:multi_file]) or
+        supported_status?(capabilities[:post_message])
 
     [:text]
     |> maybe_add_capability(:image, media_supported?)
     |> maybe_add_capability(:audio, media_supported?)
     |> maybe_add_capability(:video, media_supported?)
     |> maybe_add_capability(:file, media_supported?)
+    |> maybe_add_capability(:multi_file, multi_file_supported?)
+    |> maybe_add_capability(:markdown, supported_status?(capabilities[:markdown]))
+    |> maybe_add_capability(:cards, supported_status?(capabilities[:cards]))
+    |> maybe_add_capability(
+      :modals,
+      supported_status?(capabilities[:modals]) or supported_status?(capabilities[:open_modal])
+    )
+    |> maybe_add_capability(
+      :ephemeral,
+      supported_status?(capabilities[:ephemeral]) or
+        supported_status?(capabilities[:post_ephemeral])
+    )
     |> maybe_add_capability(
       :threads,
       supported_status?(capabilities[:open_thread]) or
@@ -217,9 +194,30 @@ defmodule Jido.Chat.Capabilities do
     )
     |> maybe_add_capability(:typing, supported_status?(capabilities[:start_typing]))
     |> maybe_add_capability(:streaming, supported_status?(capabilities[:stream]))
+    |> maybe_add_capability(:assistant_events, supported_status?(capabilities[:assistant_events]))
   end
 
   defp normalize_adapter_capabilities(_), do: [:text]
+
+  defp upload_requires(%PostPayload{} = payload) do
+    uploads = PostPayload.upload_candidates(payload)
+
+    uploads
+    |> Enum.flat_map(&upload_requires/1)
+    |> maybe_require_multi_file(length(uploads))
+  end
+
+  defp upload_requires(%Attachment{kind: kind}), do: upload_requires(kind)
+  defp upload_requires(%FileUpload{kind: kind}), do: upload_requires(kind)
+  defp upload_requires(:image), do: [:image]
+  defp upload_requires(:audio), do: [:audio]
+  defp upload_requires(:video), do: [:video]
+  defp upload_requires(_kind), do: [:file]
+
+  defp maybe_require_multi_file(capabilities, count) when count > 1,
+    do: Enum.uniq([:multi_file | capabilities])
+
+  defp maybe_require_multi_file(capabilities, _count), do: Enum.uniq(capabilities)
 
   defp supported_status?(status), do: status in [:native, :fallback]
 

--- a/lib/jido/chat/capabilities.ex
+++ b/lib/jido/chat/capabilities.ex
@@ -138,9 +138,18 @@ defmodule Jido.Chat.Capabilities do
   @doc "Returns the delivery-focused capability list for an adapter module."
   @spec channel_capabilities(module()) :: capabilities()
   def channel_capabilities(adapter_module) when is_atom(adapter_module) do
-    adapter_module
-    |> Adapter.capabilities()
-    |> normalize_adapter_capabilities()
+    capabilities =
+      if Code.ensure_loaded?(adapter_module) and
+           function_exported?(adapter_module, :capabilities, 0) do
+        case adapter_module.capabilities() do
+          caps when is_list(caps) -> caps
+          _ -> Adapter.capabilities(adapter_module)
+        end
+      else
+        Adapter.capabilities(adapter_module)
+      end
+
+    normalize_adapter_capabilities(capabilities)
   end
 
   defp normalize_adapter_capabilities(capabilities) when is_list(capabilities) do

--- a/lib/jido/chat/card.ex
+++ b/lib/jido/chat/card.ex
@@ -1,0 +1,410 @@
+defmodule Jido.Chat.Card do
+  @moduledoc """
+  Canonical cross-platform card model with fallback rendering helpers.
+  """
+
+  alias Jido.Chat.Card.Component
+  alias Jido.Chat.Markdown
+  alias Jido.Chat.Wire
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              id: Zoi.string() |> Zoi.nullish(),
+              title: Zoi.string() |> Zoi.nullish(),
+              summary: Zoi.string() |> Zoi.nullish(),
+              markdown: Zoi.any() |> Zoi.nullish(),
+              components: Zoi.list() |> Zoi.default([]),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+  @type component :: Component.t()
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the schema for cards."
+  def schema, do: @schema
+
+  @doc "Creates a canonical card."
+  @spec new(t() | map()) :: t()
+  def new(%__MODULE__{} = card), do: card
+
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_markdown()
+    |> normalize_components()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Normalizes card input."
+  @spec normalize(t() | map()) :: t()
+  def normalize(%__MODULE__{} = card), do: card
+  def normalize(map) when is_map(map), do: new(map)
+
+  @doc "Adds a component to the end of a card."
+  @spec add(t(), component() | map() | String.t()) :: t()
+  def add(%__MODULE__{} = card, component) do
+    %{card | components: card.components ++ [Component.normalize(component)]}
+  end
+
+  @doc "Builds a text component."
+  @spec text(String.t(), keyword() | map()) :: component()
+  def text(value, opts \\ []) when is_binary(value) do
+    opts = normalize_opts(opts)
+    Component.new(%{kind: :text, text: value, markdown: opts[:markdown] || opts["markdown"]})
+  end
+
+  @doc "Builds a section component."
+  @spec section(keyword() | map()) :: component()
+  def section(attrs) when is_list(attrs) or is_map(attrs) do
+    attrs = normalize_opts(attrs)
+
+    Component.new(%{
+      kind: :section,
+      title: attrs[:title] || attrs["title"],
+      text: attrs[:text] || attrs["text"],
+      markdown: attrs[:markdown] || attrs["markdown"],
+      items: attrs[:items] || attrs["items"] || []
+    })
+  end
+
+  @doc "Builds a field component."
+  @spec field(String.t(), String.t(), keyword() | map()) :: component()
+  def field(label, value, opts \\ []) when is_binary(label) do
+    opts = normalize_opts(opts)
+    Component.new(%{kind: :field, label: label, text: value, metadata: opts[:metadata] || %{}})
+  end
+
+  @doc "Builds a grouped fields component."
+  @spec fields([component() | map()], keyword() | map()) :: component()
+  def fields(items, opts \\ []) when is_list(items) do
+    opts = normalize_opts(opts)
+    Component.new(%{kind: :fields, title: opts[:title], items: items})
+  end
+
+  @doc "Builds a button component."
+  @spec button(String.t(), String.t(), keyword() | map()) :: component()
+  def button(label, action_id, opts \\ []) when is_binary(label) and is_binary(action_id) do
+    opts = normalize_opts(opts)
+
+    Component.new(%{
+      kind: :button,
+      id: action_id,
+      label: label,
+      value: opts[:value] || opts["value"],
+      style: opts[:style] || opts["style"],
+      disabled: opts[:disabled] || opts["disabled"] || false,
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a link button component."
+  @spec link_button(String.t(), String.t(), keyword() | map()) :: component()
+  def link_button(label, url, opts \\ []) when is_binary(label) and is_binary(url) do
+    opts = normalize_opts(opts)
+
+    Component.new(%{
+      kind: :link_button,
+      label: label,
+      url: url,
+      style: opts[:style] || opts["style"],
+      disabled: opts[:disabled] || opts["disabled"] || false,
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a text link component."
+  @spec link(String.t(), String.t(), keyword() | map()) :: component()
+  def link(label, url, opts \\ []) when is_binary(label) and is_binary(url) do
+    opts = normalize_opts(opts)
+    Component.new(%{kind: :link, label: label, url: url, metadata: opts[:metadata] || %{}})
+  end
+
+  @doc "Builds an actions component."
+  @spec actions([component() | map()], keyword() | map()) :: component()
+  def actions(items, opts \\ []) when is_list(items) do
+    opts = normalize_opts(opts)
+    Component.new(%{kind: :actions, title: opts[:title], items: items})
+  end
+
+  @doc "Builds a select option component."
+  @spec select_option(String.t(), String.t(), keyword() | map()) :: component()
+  def select_option(label, value, opts \\ []) when is_binary(label) and is_binary(value) do
+    opts = normalize_opts(opts)
+
+    Component.new(%{
+      kind: :select_option,
+      label: label,
+      value: value,
+      text: opts[:text] || opts["text"],
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a select component."
+  @spec select(String.t(), [component() | map()], keyword() | map()) :: component()
+  def select(action_id, options, opts \\ []) when is_binary(action_id) and is_list(options) do
+    opts = normalize_opts(opts)
+
+    Component.new(%{
+      kind: :select,
+      id: action_id,
+      label: opts[:label] || opts["label"],
+      title: opts[:title] || opts["title"],
+      value: opts[:value] || opts["value"],
+      options: options,
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a radio select component."
+  @spec radio_select(String.t(), [component() | map()], keyword() | map()) :: component()
+  def radio_select(action_id, options, opts \\ [])
+      when is_binary(action_id) and is_list(options) do
+    opts = normalize_opts(opts)
+
+    Component.new(%{
+      kind: :radio_select,
+      id: action_id,
+      label: opts[:label] || opts["label"],
+      title: opts[:title] || opts["title"],
+      value: opts[:value] || opts["value"],
+      options: options,
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a table component."
+  @spec table([String.t()], [[String.t()]], keyword() | map()) :: component()
+  def table(columns, rows, opts \\ []) when is_list(columns) and is_list(rows) do
+    opts = normalize_opts(opts)
+
+    Component.new(%{
+      kind: :table,
+      title: opts[:title] || opts["title"],
+      columns: columns,
+      rows: rows,
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds an image component."
+  @spec image(String.t(), keyword() | map()) :: component()
+  def image(url, opts \\ []) when is_binary(url) do
+    opts = normalize_opts(opts)
+
+    Component.new(%{
+      kind: :image,
+      image_url: url,
+      alt_text: opts[:alt_text] || opts["alt_text"],
+      title: opts[:title] || opts["title"],
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a divider component."
+  @spec divider() :: component()
+  def divider, do: Component.new(%{kind: :divider})
+
+  @doc "Renders the card to canonical Markdown."
+  @spec to_markdown(t()) :: Markdown.t()
+  def to_markdown(%__MODULE__{} = card) do
+    children =
+      []
+      |> maybe_prepend_title(card.title)
+      |> maybe_append_summary(card.summary)
+      |> maybe_append_markdown(card.markdown)
+      |> Kernel.++(Enum.flat_map(card.components, &component_to_markdown/1))
+
+    Markdown.root(children)
+  end
+
+  @doc "Returns the best text fallback for a card."
+  @spec fallback_text(t()) :: String.t()
+  def fallback_text(%__MODULE__{} = card) do
+    card
+    |> to_markdown()
+    |> Markdown.plain_text()
+    |> String.trim()
+  end
+
+  @doc "Returns a plain map suitable for adapter-specific rendering."
+  @spec to_adapter_payload(t()) :: map()
+  def to_adapter_payload(%__MODULE__{} = card) do
+    card
+    |> Map.from_struct()
+    |> Map.update!(:components, fn components ->
+      Enum.map(components, &component_to_plain/1)
+    end)
+    |> Map.update!(:markdown, fn
+      nil -> nil
+      %Markdown{} = markdown -> Markdown.stringify(markdown)
+      other -> other
+    end)
+    |> Wire.to_plain()
+  end
+
+  @doc "Serializes a card into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = card) do
+    card
+    |> Map.from_struct()
+    |> Map.update!(:components, &Enum.map(&1, fn component -> Component.to_map(component) end))
+    |> Map.update!(:markdown, fn
+      nil -> nil
+      %Markdown{} = markdown -> Markdown.to_map(markdown)
+      other -> other
+    end)
+    |> Wire.to_plain()
+    |> Map.put("__type__", "card")
+  end
+
+  @doc "Builds a card from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_markdown(attrs) do
+    case attrs[:markdown] || attrs["markdown"] do
+      nil ->
+        attrs
+
+      %Markdown{} = markdown ->
+        Map.put(attrs, :markdown, markdown)
+
+      %{} = markdown ->
+        Map.put(attrs, :markdown, Markdown.new(markdown))
+
+      value when is_binary(value) ->
+        Map.put(attrs, :markdown, Markdown.parse(value))
+    end
+  end
+
+  defp normalize_components(attrs) do
+    components = attrs[:components] || attrs["components"] || []
+
+    attrs
+    |> Map.delete("components")
+    |> Map.put(:components, Enum.map(components, &Component.normalize/1))
+  end
+
+  defp maybe_prepend_title(children, nil), do: children
+  defp maybe_prepend_title(children, title), do: children ++ [Markdown.heading(2, title)]
+
+  defp maybe_append_summary(children, nil), do: children
+  defp maybe_append_summary(children, summary), do: children ++ [Markdown.paragraph(summary)]
+
+  defp maybe_append_markdown(children, nil), do: children
+  defp maybe_append_markdown(children, %Markdown{root: root}), do: children ++ root.children
+
+  defp component_to_markdown(%Component{} = component) do
+    case component.kind do
+      :text ->
+        component_markdown_or_text(component)
+
+      :section ->
+        []
+        |> maybe_prepend_component_title(component.title)
+        |> maybe_append_component_text(component.text)
+        |> maybe_append_component_markdown(component.markdown)
+        |> Kernel.++(Enum.flat_map(component.items, &component_to_markdown/1))
+
+      :field ->
+        label = component.label || component.title || "Field"
+        value = component.text || component.value || ""
+        [Markdown.paragraph("#{label}: #{value}")]
+
+      :fields ->
+        heading = if component.title, do: [Markdown.heading(3, component.title)], else: []
+        heading ++ Enum.flat_map(component.items, &component_to_markdown/1)
+
+      :button ->
+        label = component.label || component.title || component.id || "Action"
+        [Markdown.list([Markdown.list_item(label)])]
+
+      :link_button ->
+        [
+          Markdown.list([
+            Markdown.list_item(Markdown.link(component.label || "Open", component.url || "#"))
+          ])
+        ]
+
+      :link ->
+        [
+          Markdown.paragraph([
+            Markdown.link(component.label || component.url || "Link", component.url || "#")
+          ])
+        ]
+
+      :actions ->
+        heading = if component.title, do: [Markdown.heading(3, component.title)], else: []
+        heading ++ Enum.flat_map(component.items, &component_to_markdown/1)
+
+      :select ->
+        label = component.label || component.title || component.id || "Select"
+        options = Enum.map(component.options, &select_option_label/1)
+        [Markdown.heading(4, label), Markdown.list(options)]
+
+      :radio_select ->
+        label = component.label || component.title || component.id || "Options"
+        options = Enum.map(component.options, &select_option_label/1)
+        [Markdown.heading(4, label), Markdown.list(options)]
+
+      :table ->
+        table_rows = [component.columns | component.rows]
+        [Markdown.table(table_rows)]
+
+      :image ->
+        label = component.alt_text || component.title || component.image_url || "image"
+        [Markdown.paragraph(label)]
+
+      :divider ->
+        [Markdown.divider()]
+
+      :select_option ->
+        [Markdown.paragraph(select_option_label(component))]
+    end
+  end
+
+  defp component_markdown_or_text(%Component{markdown: %Markdown{root: root}}), do: root.children
+
+  defp component_markdown_or_text(%Component{text: text}) when is_binary(text),
+    do: [Markdown.paragraph(text)]
+
+  defp component_markdown_or_text(_component), do: [Markdown.paragraph("")]
+
+  defp maybe_prepend_component_title(children, nil), do: children
+
+  defp maybe_prepend_component_title(children, title),
+    do: children ++ [Markdown.heading(3, title)]
+
+  defp maybe_append_component_text(children, nil), do: children
+  defp maybe_append_component_text(children, text), do: children ++ [Markdown.paragraph(text)]
+
+  defp maybe_append_component_markdown(children, nil), do: children
+
+  defp maybe_append_component_markdown(children, %Markdown{root: root}),
+    do: children ++ root.children
+
+  defp select_option_label(%Component{} = option),
+    do: option.label || option.text || option.value || "option"
+
+  defp component_to_plain(%Component{} = component) do
+    component
+    |> Map.from_struct()
+    |> Map.update!(:items, fn items -> Enum.map(items, &component_to_plain/1) end)
+    |> Map.update!(:options, fn options -> Enum.map(options, &component_to_plain/1) end)
+    |> Map.update!(:markdown, fn
+      nil -> nil
+      %Markdown{} = markdown -> Markdown.stringify(markdown)
+      other -> other
+    end)
+    |> Wire.to_plain()
+  end
+
+  defp normalize_opts(opts) when is_list(opts), do: Map.new(opts)
+  defp normalize_opts(opts) when is_map(opts), do: opts
+end

--- a/lib/jido/chat/card/component.ex
+++ b/lib/jido/chat/card/component.ex
@@ -1,0 +1,122 @@
+defmodule Jido.Chat.Card.Component do
+  @moduledoc """
+  Canonical card component used by `Jido.Chat.Card`.
+  """
+
+  alias Jido.Chat.Markdown
+  alias Jido.Chat.Wire
+
+  @kinds [
+    :text,
+    :section,
+    :fields,
+    :field,
+    :button,
+    :link_button,
+    :link,
+    :actions,
+    :select,
+    :select_option,
+    :radio_select,
+    :table,
+    :image,
+    :divider
+  ]
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              kind: Zoi.enum(@kinds),
+              id: Zoi.string() |> Zoi.nullish(),
+              title: Zoi.string() |> Zoi.nullish(),
+              label: Zoi.string() |> Zoi.nullish(),
+              text: Zoi.string() |> Zoi.nullish(),
+              url: Zoi.string() |> Zoi.nullish(),
+              value: Zoi.string() |> Zoi.nullish(),
+              image_url: Zoi.string() |> Zoi.nullish(),
+              alt_text: Zoi.string() |> Zoi.nullish(),
+              style: Zoi.string() |> Zoi.nullish(),
+              disabled: Zoi.boolean() |> Zoi.default(false),
+              markdown: Zoi.any() |> Zoi.nullish(),
+              items: Zoi.list() |> Zoi.default([]),
+              options: Zoi.list() |> Zoi.default([]),
+              columns: Zoi.list() |> Zoi.default([]),
+              rows: Zoi.list() |> Zoi.default([]),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+  @type input :: t() | map() | String.t()
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the schema for a card component."
+  def schema, do: @schema
+
+  @doc "Creates a canonical card component."
+  @spec new(t() | map()) :: t()
+  def new(%__MODULE__{} = component), do: component
+
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_markdown()
+    |> normalize_items()
+    |> normalize_options()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Normalizes component input."
+  @spec normalize(input()) :: t()
+  def normalize(%__MODULE__{} = component), do: component
+  def normalize(value) when is_binary(value), do: new(%{kind: :text, text: value})
+  def normalize(value) when is_map(value), do: new(value)
+
+  @doc "Serializes the component into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = component) do
+    component
+    |> Map.from_struct()
+    |> Map.update!(:items, &Enum.map(&1, fn item -> item |> normalize() |> to_map() end))
+    |> Map.update!(:options, &Enum.map(&1, fn option -> option |> normalize() |> to_map() end))
+    |> Map.update!(:markdown, fn
+      nil -> nil
+      %Markdown{} = markdown -> Markdown.to_map(markdown)
+      other -> other
+    end)
+    |> Wire.to_plain()
+    |> Map.put("__type__", "card_component")
+  end
+
+  @doc "Builds a component from serialized data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_markdown(attrs) do
+    case attrs[:markdown] || attrs["markdown"] do
+      nil ->
+        attrs
+
+      %Markdown{} = markdown ->
+        Map.put(attrs, :markdown, markdown)
+
+      %{} = markdown ->
+        Map.put(attrs, :markdown, Markdown.new(markdown))
+
+      value when is_binary(value) ->
+        Map.put(attrs, :markdown, Markdown.parse(value))
+    end
+  end
+
+  defp normalize_items(attrs) do
+    items = attrs[:items] || attrs["items"] || []
+    attrs |> Map.delete("items") |> Map.put(:items, Enum.map(items, &normalize/1))
+  end
+
+  defp normalize_options(attrs) do
+    options = attrs[:options] || attrs["options"] || []
+    attrs |> Map.delete("options") |> Map.put(:options, Enum.map(options, &normalize/1))
+  end
+end

--- a/lib/jido/chat/channel_ref.ex
+++ b/lib/jido/chat/channel_ref.ex
@@ -9,6 +9,7 @@ defmodule Jido.Chat.ChannelRef do
     ChannelInfo,
     FileUpload,
     MessagePage,
+    Modal,
     ModalResult,
     PostPayload,
     Postable,
@@ -92,8 +93,9 @@ defmodule Jido.Chat.ChannelRef do
   end
 
   @doc "Opens a modal in the channel when supported by the adapter."
-  @spec open_modal(t(), map(), keyword()) :: {:ok, ModalResult.t()} | {:error, term()}
-  def open_modal(%__MODULE__{} = channel, payload, opts \\ []) when is_map(payload) do
+  @spec open_modal(t(), Modal.t() | map(), keyword()) :: {:ok, ModalResult.t()} | {:error, term()}
+  def open_modal(%__MODULE__{} = channel, payload, opts \\ [])
+      when is_map(payload) or is_struct(payload, Modal) do
     Adapter.open_modal(channel.adapter, channel.external_id, payload, opts)
   end
 

--- a/lib/jido/chat/channel_ref.ex
+++ b/lib/jido/chat/channel_ref.ex
@@ -7,6 +7,7 @@ defmodule Jido.Chat.ChannelRef do
     Adapter,
     Attachment,
     ChannelInfo,
+    FileUpload,
     MessagePage,
     ModalResult,
     PostPayload,
@@ -46,16 +47,16 @@ defmodule Jido.Chat.ChannelRef do
   def post(channel, input, opts \\ [])
 
   def post(%__MODULE__{} = channel, text, opts) when is_binary(text),
-    do: text |> PostPayload.text() |> then(&post_payload(channel, &1, opts))
+    do: text |> PostPayload.text() |> then(&dispatch_post_payload(channel, &1, opts))
 
   def post(%__MODULE__{} = channel, %Postable{} = postable, opts),
-    do: postable |> Postable.to_payload() |> then(&post_payload(channel, &1, opts))
+    do: postable |> Postable.to_payload() |> then(&dispatch_post_payload(channel, &1, opts))
 
   def post(%__MODULE__{} = channel, postable_map, opts) when is_map(postable_map) do
     postable_map
     |> Postable.new()
     |> Postable.to_payload()
-    |> then(&post_payload(channel, &1, opts))
+    |> then(&dispatch_post_payload(channel, &1, opts))
   rescue
     _ -> {:error, :invalid_postable}
   end
@@ -69,7 +70,7 @@ defmodule Jido.Chat.ChannelRef do
   end
 
   @doc "Uploads a file to the channel when supported by the adapter."
-  @spec send_file(t(), Attachment.input(), keyword()) ::
+  @spec send_file(t(), FileUpload.input(), keyword()) ::
           {:ok, SentMessage.t()} | {:error, term()}
   def send_file(%__MODULE__{} = channel, file, opts \\ []) do
     with {:ok, response} <- Adapter.send_file(channel.adapter, channel.external_id, file, opts) do
@@ -229,15 +230,24 @@ defmodule Jido.Chat.ChannelRef do
          thread_id: channel.id,
          adapter: channel.adapter,
          external_room_id: channel.external_id,
-         text: payload.text,
-         formatted: payload.formatted || payload.text,
+         text: PostPayload.display_text(payload),
+         formatted: payload.formatted || PostPayload.display_text(payload),
          raw: payload.raw,
-         attachments: payload.attachments || [],
+         attachments: PostPayload.outbound_attachments(payload),
          metadata: payload.metadata,
          response: response,
          default_opts: default_opts
        })}
     end
+  end
+
+  defp dispatch_post_payload(%__MODULE__{} = channel, %PostPayload{kind: :stream} = payload, opts)
+       when not is_nil(payload.stream) do
+    post_stream(channel, payload.stream, opts)
+  end
+
+  defp dispatch_post_payload(%__MODULE__{} = channel, %PostPayload{} = payload, opts) do
+    post_payload(channel, payload, opts)
   end
 
   defp post_stream(%__MODULE__{} = channel, enumerable, opts) do
@@ -269,13 +279,19 @@ defmodule Jido.Chat.ChannelRef do
   defp normalize_fetch_opts(_other),
     do: Jido.Chat.FetchOptions.to_keyword(Jido.Chat.FetchOptions.new(%{}))
 
-  defp maybe_put_caption(opts, %PostPayload{text: nil}), do: opts
-  defp maybe_put_caption(opts, %PostPayload{text: ""}), do: opts
+  defp maybe_put_caption(opts, %PostPayload{} = payload) do
+    case PostPayload.display_text(payload) do
+      nil ->
+        opts
 
-  defp maybe_put_caption(opts, %PostPayload{text: text}) do
-    opts
-    |> Keyword.put_new(:caption, text)
-    |> Keyword.put_new(:text, text)
+      "" ->
+        opts
+
+      text ->
+        opts
+        |> Keyword.put_new(:caption, text)
+        |> Keyword.put_new(:text, text)
+    end
   end
 
   defp maybe_put_metadata(opts, metadata) when metadata in [%{}, nil], do: opts
@@ -285,14 +301,16 @@ defmodule Jido.Chat.ChannelRef do
   end
 
   defp post_default_opts(adapter, %PostPayload{} = payload, opts) do
+    upload_candidates = PostPayload.upload_candidates(payload)
+
     cond do
       function_exported?(adapter, :post_message, 3) ->
         {:ok, opts}
 
-      payload.attachments in [nil, []] ->
+      upload_candidates in [nil, []] ->
         {:ok, opts}
 
-      match?([_attachment], payload.attachments) ->
+      match?([_attachment], upload_candidates) ->
         {:ok,
          opts
          |> maybe_put_caption(payload)

--- a/lib/jido/chat/channel_ref.ex
+++ b/lib/jido/chat/channel_ref.ex
@@ -105,10 +105,41 @@ defmodule Jido.Chat.ChannelRef do
   end
 
   @doc "Posts an ephemeral message via adapter when supported."
-  @spec post_ephemeral(t(), String.t() | integer(), String.t(), keyword()) ::
+  @spec post_ephemeral(t(), String.t() | integer(), String.t() | Postable.t() | map(), keyword()) ::
           {:ok, Jido.Chat.EphemeralMessage.t()} | {:error, term()}
-  def post_ephemeral(%__MODULE__{} = channel, user_id, text, opts \\ []) when is_binary(text) do
-    Adapter.post_ephemeral(channel.adapter, channel.external_id, user_id, text, opts)
+  def post_ephemeral(channel, user_id, input, opts \\ [])
+
+  def post_ephemeral(%__MODULE__{} = channel, user_id, text, opts) when is_binary(text) do
+    Adapter.post_ephemeral_message(
+      channel.adapter,
+      channel.external_id,
+      user_id,
+      PostPayload.text(text),
+      opts
+    )
+  end
+
+  def post_ephemeral(%__MODULE__{} = channel, user_id, %Postable{} = postable, opts) do
+    Adapter.post_ephemeral_message(
+      channel.adapter,
+      channel.external_id,
+      user_id,
+      Postable.to_payload(postable),
+      opts
+    )
+  end
+
+  def post_ephemeral(%__MODULE__{} = channel, user_id, postable_map, opts)
+      when is_map(postable_map) do
+    Adapter.post_ephemeral_message(
+      channel.adapter,
+      channel.external_id,
+      user_id,
+      postable_map |> Postable.new() |> Postable.to_payload(),
+      opts
+    )
+  rescue
+    _ -> {:error, :invalid_postable}
   end
 
   @doc "Starts typing indicator on channel when supported."

--- a/lib/jido/chat/concurrency.ex
+++ b/lib/jido/chat/concurrency.ex
@@ -1,0 +1,32 @@
+defmodule Jido.Chat.Concurrency do
+  @moduledoc """
+  Chat-level overlapping-message concurrency configuration.
+  """
+
+  @strategies [:reject, :queue, :debounce, :concurrent]
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              strategy: Zoi.enum(@strategies) |> Zoi.default(:reject),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type strategy :: :reject | :queue | :debounce | :concurrent
+  @type t :: unquote(Zoi.type_spec(@schema))
+  @type pending_entry :: %{owner: String.t(), strategy: strategy(), metadata: map()}
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the schema for concurrency configuration."
+  def schema, do: @schema
+
+  @doc "Creates a normalized concurrency config."
+  @spec new(t() | map() | keyword()) :: t()
+  def new(%__MODULE__{} = config), do: config
+  def new(opts) when is_list(opts), do: opts |> Map.new() |> new()
+  def new(opts) when is_map(opts), do: Jido.Chat.Schema.parse!(__MODULE__, @schema, opts)
+end

--- a/lib/jido/chat/emoji.ex
+++ b/lib/jido/chat/emoji.ex
@@ -1,0 +1,81 @@
+defmodule Jido.Chat.Emoji do
+  @moduledoc """
+  Cross-platform emoji helper with a small default registry and custom overrides.
+  """
+
+  @defaults %{
+    thumbs_up: "👍",
+    thumbsup: "👍",
+    white_check_mark: "✅",
+    check: "✅",
+    x: "❌",
+    warning: "⚠️",
+    eyes: "👀",
+    rocket: "🚀",
+    tada: "🎉",
+    hourglass: "⏳"
+  }
+
+  @type registry :: %{optional(atom()) => String.t()}
+
+  @doc "Returns the built-in emoji registry."
+  @spec registry() :: registry()
+  def registry, do: @defaults
+
+  @doc "Adds or overrides a custom emoji entry in a registry."
+  @spec put_custom(registry(), atom() | String.t(), String.t()) :: registry()
+  def put_custom(custom, name, rendered) when is_binary(rendered) do
+    Map.put(custom || %{}, normalize_name(name), rendered)
+  end
+
+  @doc "Renders an emoji token using built-ins plus optional custom overrides."
+  @spec render(String.t() | atom(), keyword()) :: String.t()
+  def render(value, opts \\ [])
+
+  def render(value, opts) when is_binary(value) do
+    if value != "" and not named_emoji?(value) do
+      value
+    else
+      lookup_emoji(value, opts)
+    end
+  end
+
+  def render(value, opts) do
+    lookup_emoji(value, opts)
+  end
+
+  defp lookup_emoji(value, opts) do
+    custom =
+      opts[:custom]
+      |> normalize_custom()
+
+    name = normalize_name(value)
+    Map.get(custom, name) || Map.get(@defaults, name) || fallback_token(value)
+  end
+
+  defp normalize_custom(nil), do: %{}
+
+  defp normalize_custom(custom) when is_map(custom) do
+    custom
+    |> Enum.map(fn {key, value} -> {normalize_name(key), value} end)
+    |> Map.new()
+  end
+
+  defp normalize_name(value) when is_atom(value), do: value
+
+  defp normalize_name(value) when is_binary(value) do
+    value
+    |> String.trim()
+    |> String.trim_leading(":")
+    |> String.trim_trailing(":")
+    |> String.replace("-", "_")
+    |> String.to_atom()
+  end
+
+  defp fallback_token(value) when is_binary(value), do: value
+  defp fallback_token(value) when is_atom(value), do: ":" <> Atom.to_string(value) <> ":"
+
+  defp named_emoji?(value) when is_binary(value) do
+    String.starts_with?(value, ":") and String.ends_with?(value, ":")
+  end
+end

--- a/lib/jido/chat/ephemeral_message.ex
+++ b/lib/jido/chat/ephemeral_message.ex
@@ -3,13 +3,18 @@ defmodule Jido.Chat.EphemeralMessage do
   Canonical result of an ephemeral send attempt.
   """
 
+  alias Jido.Chat.Attachment
+
   @schema Zoi.struct(
             __MODULE__,
             %{
               id: Zoi.string(),
               thread_id: Zoi.string(),
+              text: Zoi.string() |> Zoi.nullish(),
+              formatted: Zoi.string() |> Zoi.nullish(),
               used_fallback: Zoi.boolean() |> Zoi.default(false),
               raw: Zoi.any() |> Zoi.nullish(),
+              attachments: Zoi.array(Zoi.struct(Attachment)) |> Zoi.default([]),
               metadata: Zoi.map() |> Zoi.default(%{})
             },
             coerce: true
@@ -24,5 +29,23 @@ defmodule Jido.Chat.EphemeralMessage do
   def schema, do: @schema
 
   @doc "Creates an ephemeral message result struct."
-  def new(attrs) when is_map(attrs), do: Jido.Chat.Schema.parse!(__MODULE__, @schema, attrs)
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_attachments()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  defp normalize_attachments(attrs) do
+    attachments = attrs[:attachments] || attrs["attachments"] || []
+
+    normalized =
+      Enum.map(attachments, fn
+        %Attachment{} = attachment -> attachment
+        attachment -> Attachment.normalize(attachment)
+      end)
+
+    attrs
+    |> Map.delete("attachments")
+    |> Map.put(:attachments, normalized)
+  end
 end

--- a/lib/jido/chat/event_envelope.ex
+++ b/lib/jido/chat/event_envelope.ex
@@ -3,7 +3,17 @@ defmodule Jido.Chat.EventEnvelope do
   Canonical normalized event envelope used by webhook and gateway ingestion.
   """
 
-  alias Jido.Chat.Wire
+  alias Jido.Chat.{
+    ActionEvent,
+    AssistantContextChangedEvent,
+    AssistantThreadStartedEvent,
+    Incoming,
+    ModalCloseEvent,
+    ModalSubmitEvent,
+    ReactionEvent,
+    SlashCommandEvent,
+    Wire
+  }
 
   @event_types [
     :message,
@@ -64,13 +74,22 @@ defmodule Jido.Chat.EventEnvelope do
   def to_map(%__MODULE__{} = envelope) do
     envelope
     |> Map.from_struct()
+    |> Map.update!(:payload, &serialize_payload/1)
     |> Wire.to_plain()
     |> Map.put("__type__", "event_envelope")
   end
 
   @doc "Builds event envelope from serialized data."
   @spec from_map(map()) :: t()
-  def from_map(map) when is_map(map), do: new(map)
+  def from_map(map) when is_map(map) do
+    payload = map[:payload] || map["payload"]
+
+    map
+    |> Map.drop(["__type__", :__type__])
+    |> Map.delete("payload")
+    |> Map.put(:payload, deserialize_payload(payload))
+    |> new()
+  end
 
   defp maybe_normalize_event_type(attrs) do
     case attrs[:event_type] || attrs["event_type"] do
@@ -86,4 +105,44 @@ defmodule Jido.Chat.EventEnvelope do
   rescue
     ArgumentError -> attrs
   end
+
+  defp serialize_payload(%Incoming{} = payload), do: Incoming.to_map(payload)
+  defp serialize_payload(%ReactionEvent{} = payload), do: ReactionEvent.to_map(payload)
+  defp serialize_payload(%ActionEvent{} = payload), do: ActionEvent.to_map(payload)
+  defp serialize_payload(%ModalSubmitEvent{} = payload), do: ModalSubmitEvent.to_map(payload)
+  defp serialize_payload(%ModalCloseEvent{} = payload), do: ModalCloseEvent.to_map(payload)
+  defp serialize_payload(%SlashCommandEvent{} = payload), do: SlashCommandEvent.to_map(payload)
+
+  defp serialize_payload(%AssistantThreadStartedEvent{} = payload),
+    do: AssistantThreadStartedEvent.to_map(payload)
+
+  defp serialize_payload(%AssistantContextChangedEvent{} = payload),
+    do: AssistantContextChangedEvent.to_map(payload)
+
+  defp serialize_payload(payload), do: Wire.to_plain(payload)
+
+  defp deserialize_payload(%{"__type__" => "incoming"} = payload), do: Incoming.from_map(payload)
+
+  defp deserialize_payload(%{"__type__" => "reaction_event"} = payload),
+    do: ReactionEvent.from_map(payload)
+
+  defp deserialize_payload(%{"__type__" => "action_event"} = payload),
+    do: ActionEvent.from_map(payload)
+
+  defp deserialize_payload(%{"__type__" => "modal_submit_event"} = payload),
+    do: ModalSubmitEvent.from_map(payload)
+
+  defp deserialize_payload(%{"__type__" => "modal_close_event"} = payload),
+    do: ModalCloseEvent.from_map(payload)
+
+  defp deserialize_payload(%{"__type__" => "slash_command_event"} = payload),
+    do: SlashCommandEvent.from_map(payload)
+
+  defp deserialize_payload(%{"__type__" => "assistant_thread_started_event"} = payload),
+    do: AssistantThreadStartedEvent.from_map(payload)
+
+  defp deserialize_payload(%{"__type__" => "assistant_context_changed_event"} = payload),
+    do: AssistantContextChangedEvent.from_map(payload)
+
+  defp deserialize_payload(payload), do: payload
 end

--- a/lib/jido/chat/event_normalizer.ex
+++ b/lib/jido/chat/event_normalizer.ex
@@ -192,11 +192,24 @@ defmodule Jido.Chat.EventNormalizer do
 
   defp infer_event_type(payload) when is_map(payload) do
     cond do
-      Map.has_key?(payload, :emoji) or Map.has_key?(payload, "emoji") -> :reaction
-      Map.has_key?(payload, :action_id) or Map.has_key?(payload, "action_id") -> :action
-      Map.has_key?(payload, :callback_id) or Map.has_key?(payload, "callback_id") -> :modal_submit
-      Map.has_key?(payload, :command) or Map.has_key?(payload, "command") -> :slash_command
-      true -> :message
+      Map.has_key?(payload, :emoji) or Map.has_key?(payload, "emoji") ->
+        :reaction
+
+      Map.has_key?(payload, :action_id) or Map.has_key?(payload, "action_id") ->
+        :action
+
+      Map.get(payload, :event_type) == :modal_close or
+          Map.get(payload, "event_type") == "modal_close" ->
+        :modal_close
+
+      Map.has_key?(payload, :callback_id) or Map.has_key?(payload, "callback_id") ->
+        :modal_submit
+
+      Map.has_key?(payload, :command) or Map.has_key?(payload, "command") ->
+        :slash_command
+
+      true ->
+        :message
     end
   end
 
@@ -212,9 +225,9 @@ defmodule Jido.Chat.EventNormalizer do
 
   defp payload_thread_id(_adapter_name, %ReactionEvent{} = payload), do: payload.thread_id
   defp payload_thread_id(_adapter_name, %ActionEvent{} = payload), do: payload.thread_id
-  defp payload_thread_id(_adapter_name, %ModalSubmitEvent{}), do: nil
-  defp payload_thread_id(_adapter_name, %ModalCloseEvent{}), do: nil
-  defp payload_thread_id(_adapter_name, %SlashCommandEvent{}), do: nil
+  defp payload_thread_id(_adapter_name, %ModalSubmitEvent{} = payload), do: payload.thread_id
+  defp payload_thread_id(_adapter_name, %ModalCloseEvent{} = payload), do: payload.thread_id
+  defp payload_thread_id(_adapter_name, %SlashCommandEvent{} = payload), do: payload.thread_id
 
   defp payload_thread_id(_adapter_name, %AssistantThreadStartedEvent{} = payload),
     do: payload.thread_id
@@ -225,12 +238,23 @@ defmodule Jido.Chat.EventNormalizer do
   defp payload_thread_id(_adapter_name, _), do: nil
 
   defp payload_channel_id(%Incoming{} = incoming), do: stringify(incoming.external_room_id)
+  defp payload_channel_id(%ReactionEvent{} = payload), do: payload.channel_id
+  defp payload_channel_id(%ActionEvent{} = payload), do: payload.channel_id
+  defp payload_channel_id(%ModalSubmitEvent{} = payload), do: payload.channel_id
+  defp payload_channel_id(%ModalCloseEvent{} = payload), do: payload.channel_id
   defp payload_channel_id(%SlashCommandEvent{} = payload), do: payload.channel_id
+  defp payload_channel_id(%AssistantThreadStartedEvent{} = payload), do: payload.channel_id
+  defp payload_channel_id(%AssistantContextChangedEvent{} = payload), do: payload.channel_id
   defp payload_channel_id(_), do: nil
 
   defp payload_message_id(%Incoming{} = incoming), do: stringify(incoming.external_message_id)
   defp payload_message_id(%ReactionEvent{} = payload), do: payload.message_id
   defp payload_message_id(%ActionEvent{} = payload), do: payload.message_id
+  defp payload_message_id(%ModalSubmitEvent{} = payload), do: payload.message_id
+  defp payload_message_id(%ModalCloseEvent{} = payload), do: payload.message_id
+  defp payload_message_id(%SlashCommandEvent{} = payload), do: payload.message_id
+  defp payload_message_id(%AssistantThreadStartedEvent{} = payload), do: payload.message_id
+  defp payload_message_id(%AssistantContextChangedEvent{} = payload), do: payload.message_id
   defp payload_message_id(_), do: nil
 
   defp stringify(nil), do: nil

--- a/lib/jido/chat/file_upload.ex
+++ b/lib/jido/chat/file_upload.ex
@@ -1,0 +1,80 @@
+defmodule Jido.Chat.FileUpload do
+  @moduledoc """
+  Canonical outbound file upload request used by posting and upload helpers.
+  """
+
+  alias Jido.Chat.{Attachment, Wire}
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              kind: Zoi.enum([:image, :audio, :video, :file]) |> Zoi.default(:file),
+              url: Zoi.string() |> Zoi.nullish(),
+              path: Zoi.string() |> Zoi.nullish(),
+              data: Zoi.string() |> Zoi.nullish(),
+              media_type: Zoi.string() |> Zoi.nullish(),
+              filename: Zoi.string() |> Zoi.nullish(),
+              size_bytes: Zoi.integer() |> Zoi.nullish(),
+              width: Zoi.integer() |> Zoi.nullish(),
+              height: Zoi.integer() |> Zoi.nullish(),
+              duration: Zoi.integer() |> Zoi.nullish(),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+  @type input :: t() | Attachment.input()
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the Zoi schema for FileUpload."
+  def schema, do: @schema
+
+  @doc "Creates a file upload request from normalized map input."
+  def new(%__MODULE__{} = file_upload), do: file_upload
+
+  def new(attrs) when is_map(attrs),
+    do: attrs |> normalize_map() |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+
+  @doc "Normalizes supported upload inputs into a canonical file upload struct."
+  @spec normalize(input()) :: t()
+  def normalize(%__MODULE__{} = file_upload), do: file_upload
+
+  def normalize(%Attachment{} = attachment), do: from_attachment(attachment)
+  def normalize(input), do: input |> Attachment.normalize() |> from_attachment()
+
+  @doc "Normalizes a list of file upload inputs."
+  @spec normalize_many([input()]) :: [t()]
+  def normalize_many(files) when is_list(files), do: Enum.map(files, &normalize/1)
+
+  @doc "Serializes a file upload into a plain map with type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = file_upload) do
+    file_upload
+    |> Map.from_struct()
+    |> Wire.to_plain()
+    |> Map.put("__type__", "file_upload")
+  end
+
+  @doc "Builds a file upload from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp from_attachment(%Attachment{} = attachment) do
+    attachment
+    |> Map.from_struct()
+    |> new()
+  end
+
+  defp normalize_map(attrs) do
+    attrs
+    |> Map.drop(["__type__", :__type__])
+    |> Enum.into(%{}, fn
+      {:type, value} -> {:kind, value}
+      {"type", value} -> {:kind, value}
+      pair -> pair
+    end)
+  end
+end

--- a/lib/jido/chat/handler_dispatch.ex
+++ b/lib/jido/chat/handler_dispatch.ex
@@ -39,52 +39,12 @@ defmodule Jido.Chat.HandlerDispatch do
   defp duplicate?(_chat, nil), do: false
 
   defp duplicate?(chat, key) do
-    chat
-    |> Map.get(:dedupe, MapSet.new())
-    |> MapSet.member?(key)
+    Jido.Chat.duplicate?(chat, key)
   end
 
   defp mark_dedupe(chat, nil), do: chat
 
-  defp mark_dedupe(chat, key) do
-    dedupe = Map.get(chat, :dedupe, MapSet.new()) |> MapSet.put(key)
-    dedupe_order = Map.get(chat, :dedupe_order, []) ++ [key]
-    dedupe_limit = dedupe_limit(chat)
-
-    {trimmed_dedupe_order, overflow_keys} = trim_dedupe_order(dedupe_order, dedupe_limit)
-
-    trimmed_dedupe =
-      Enum.reduce(overflow_keys, dedupe, fn overflow_key, acc ->
-        MapSet.delete(acc, overflow_key)
-      end)
-
-    chat
-    |> Map.put(:dedupe, trimmed_dedupe)
-    |> Map.put(:dedupe_order, trimmed_dedupe_order)
-  end
-
-  defp dedupe_limit(chat) do
-    metadata = Map.get(chat, :metadata, %{})
-
-    value =
-      case metadata do
-        %{} -> metadata[:dedupe_limit] || metadata["dedupe_limit"]
-        _ -> nil
-      end
-
-    if is_integer(value) and value > 0, do: value, else: 1_000
-  end
-
-  defp trim_dedupe_order(dedupe_order, dedupe_limit) do
-    overflow_count = max(length(dedupe_order) - dedupe_limit, 0)
-
-    if overflow_count == 0 do
-      {dedupe_order, []}
-    else
-      {overflow_keys, remaining_keys} = Enum.split(dedupe_order, overflow_count)
-      {remaining_keys, overflow_keys}
-    end
-  end
+  defp mark_dedupe(chat, key), do: Jido.Chat.mark_dedupe(chat, key)
 
   defp route_handlers(chat, %Thread{} = thread, %Incoming{} = incoming) do
     cond do
@@ -160,8 +120,6 @@ defmodule Jido.Chat.HandlerDispatch do
   defp mentioned?(_chat, _incoming), do: false
 
   defp subscribed?(chat, thread_id) do
-    chat
-    |> Map.get(:subscriptions, MapSet.new())
-    |> MapSet.member?(thread_id)
+    Jido.Chat.subscribed?(chat, thread_id)
   end
 end

--- a/lib/jido/chat/handler_dispatch.ex
+++ b/lib/jido/chat/handler_dispatch.ex
@@ -1,7 +1,16 @@
 defmodule Jido.Chat.HandlerDispatch do
   @moduledoc false
 
-  alias Jido.Chat.{EventNormalizer, Incoming, Thread}
+  alias Jido.Chat.{
+    ActionEvent,
+    EventNormalizer,
+    Incoming,
+    ModalCloseEvent,
+    ModalSubmitEvent,
+    ReactionEvent,
+    SlashCommandEvent,
+    Thread
+  }
 
   @spec process_message(map(), atom(), String.t(), Incoming.t() | map(), (map(),
                                                                           Incoming.t(),
@@ -27,7 +36,9 @@ defmodule Jido.Chat.HandlerDispatch do
 
   @spec run_event_handlers(map(), list(), term()) :: map()
   def run_event_handlers(chat, handlers, event) when is_map(chat) and is_list(handlers) do
-    Enum.reduce(handlers, chat, fn handler, acc -> run_event_handler(acc, handler, event) end)
+    handlers
+    |> ordered_handlers()
+    |> Enum.reduce(chat, fn handler, acc -> run_event_handler(acc, handler, event) end)
   end
 
   defp dedupe_key(_adapter_name, %Incoming{external_message_id: nil}), do: nil
@@ -85,12 +96,56 @@ defmodule Jido.Chat.HandlerDispatch do
     end
   end
 
+  defp run_event_handler(chat, {selector, handler}, event) do
+    if selector_matches?(selector, event) do
+      run_event_handler(chat, handler, event)
+    else
+      chat
+    end
+  end
+
   defp run_event_handler(chat, handler, event) do
     case :erlang.fun_info(handler, :arity) do
       {:arity, 2} -> coerce_handler_result(chat, handler.(chat, event))
       _ -> coerce_handler_result(chat, handler.(event))
     end
   end
+
+  defp ordered_handlers(handlers) do
+    {specific, catch_all} = Enum.split_with(handlers, &match?({_selector, _handler}, &1))
+    specific ++ catch_all
+  end
+
+  defp selector_matches?(:all, _event), do: true
+
+  defp selector_matches?(selectors, event) when is_list(selectors) do
+    Enum.any?(selectors, &selector_matches?(&1, event))
+  end
+
+  defp selector_matches?(%Regex{} = pattern, event) do
+    case selector_value(event) do
+      value when is_binary(value) -> Regex.match?(pattern, value)
+      _ -> false
+    end
+  end
+
+  defp selector_matches?(selector, event) when is_function(selector, 1), do: selector.(event)
+
+  defp selector_matches?(selector, event) when is_atom(selector) do
+    selector == selector_value(event) || Atom.to_string(selector) == selector_value(event)
+  end
+
+  defp selector_matches?(selector, event) when is_binary(selector),
+    do: selector == selector_value(event)
+
+  defp selector_matches?(_selector, _event), do: false
+
+  defp selector_value(%ReactionEvent{emoji: emoji}), do: emoji
+  defp selector_value(%ActionEvent{action_id: action_id}), do: action_id
+  defp selector_value(%ModalSubmitEvent{callback_id: callback_id}), do: callback_id
+  defp selector_value(%ModalCloseEvent{callback_id: callback_id}), do: callback_id
+  defp selector_value(%SlashCommandEvent{command: command}), do: command
+  defp selector_value(_event), do: nil
 
   defp coerce_handler_result(current_chat, next_chat) when is_map(next_chat) do
     if Map.get(next_chat, :__struct__) == Jido.Chat do

--- a/lib/jido/chat/incoming.ex
+++ b/lib/jido/chat/incoming.ex
@@ -4,6 +4,7 @@ defmodule Jido.Chat.Incoming do
   """
 
   alias Jido.Chat.{Author, ChannelMeta, Media, Mention}
+  alias Jido.Chat.Wire
 
   @schema Zoi.struct(
             __MODULE__,
@@ -49,6 +50,19 @@ defmodule Jido.Chat.Incoming do
     |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
   end
 
+  @doc "Serializes the incoming payload into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = incoming) do
+    incoming
+    |> Map.from_struct()
+    |> Wire.to_plain()
+    |> Map.put("__type__", "incoming")
+  end
+
+  @doc "Builds an incoming payload from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
   defp maybe_attach_author(%{author: %Author{}} = attrs), do: attrs
 
   defp maybe_attach_author(%{author: author} = attrs) when is_map(author),
@@ -62,11 +76,16 @@ defmodule Jido.Chat.Incoming do
     if is_nil(user_id) do
       attrs
     else
-      Map.put_new(attrs, :author, %Author{
-        user_id: to_string(user_id),
-        user_name: username || to_string(user_id),
-        full_name: display_name || username
-      })
+      attrs
+      |> Map.delete("author")
+      |> Map.put_new(
+        :author,
+        %Author{
+          user_id: to_string(user_id),
+          user_name: username || to_string(user_id),
+          full_name: display_name || username
+        }
+      )
     end
   end
 
@@ -78,7 +97,9 @@ defmodule Jido.Chat.Incoming do
         attrs
 
       list when is_list(list) ->
-        Map.put(attrs, :mentions, Enum.map(list, &normalize_mention/1))
+        attrs
+        |> Map.delete("mentions")
+        |> Map.put(:mentions, Enum.map(list, &normalize_mention/1))
 
       _other ->
         attrs
@@ -93,7 +114,9 @@ defmodule Jido.Chat.Incoming do
         attrs
 
       list when is_list(list) ->
-        Map.put(attrs, :media, Enum.map(list, &normalize_media/1))
+        attrs
+        |> Map.delete("media")
+        |> Map.put(:media, Enum.map(list, &normalize_media/1))
 
       _other ->
         attrs
@@ -119,7 +142,9 @@ defmodule Jido.Chat.Incoming do
         attrs
 
       map when is_map(map) ->
-        Map.put(attrs, :channel_meta, ChannelMeta.new(map))
+        attrs
+        |> Map.delete("channel_meta")
+        |> Map.put(:channel_meta, ChannelMeta.new(map))
 
       _other ->
         attrs

--- a/lib/jido/chat/markdown.ex
+++ b/lib/jido/chat/markdown.ex
@@ -1,0 +1,582 @@
+defmodule Jido.Chat.Markdown do
+  @moduledoc """
+  Canonical Markdown AST and formatting helpers.
+  """
+
+  alias Jido.Chat.Markdown.Node
+  alias Jido.Chat.Wire
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              root: Zoi.struct(Node),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+  @type markdown_node :: Node.t()
+  @type node_input :: markdown_node() | map() | String.t()
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the schema for Markdown documents."
+  def schema, do: @schema
+
+  @doc "Creates a canonical Markdown document."
+  @spec new(t() | map() | String.t() | [node_input()]) :: t()
+  def new(%__MODULE__{} = markdown), do: markdown
+
+  def new(value) when is_binary(value), do: parse(value)
+  def new(value) when is_list(value), do: root(value)
+
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_root()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Builds a Markdown document with a root node."
+  @spec root([node_input()], keyword() | map()) :: t()
+  def root(children, opts \\ []) when is_list(children) do
+    opts = normalize_opts(opts)
+
+    new(%{
+      root: Node.new(%{type: :root, children: children}),
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a paragraph node."
+  @spec paragraph([node_input()] | String.t()) :: markdown_node()
+  def paragraph(value), do: Node.new(%{type: :paragraph, children: normalize_children(value)})
+
+  @doc "Builds a text node."
+  @spec text(String.t()) :: markdown_node()
+  def text(value) when is_binary(value), do: Node.new(%{type: :text, text: value})
+
+  @doc "Builds a strong node."
+  @spec strong([node_input()] | String.t()) :: markdown_node()
+  def strong(value), do: Node.new(%{type: :strong, children: normalize_children(value)})
+
+  @doc "Builds an emphasis node."
+  @spec emphasis([node_input()] | String.t()) :: markdown_node()
+  def emphasis(value), do: Node.new(%{type: :emphasis, children: normalize_children(value)})
+
+  @doc "Builds a link node."
+  @spec link([node_input()] | String.t(), String.t(), keyword() | map()) :: markdown_node()
+  def link(label, url, opts \\ []) when is_binary(url) do
+    opts = normalize_opts(opts)
+
+    Node.new(%{
+      type: :link,
+      url: url,
+      children: normalize_children(label),
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds an inline code node."
+  @spec code(String.t()) :: markdown_node()
+  def code(value) when is_binary(value), do: Node.new(%{type: :code, text: value})
+
+  @doc "Builds a fenced code block node."
+  @spec code_block(String.t(), String.t() | nil, keyword() | map()) :: markdown_node()
+  def code_block(value, language \\ nil, opts \\ []) when is_binary(value) do
+    opts = normalize_opts(opts)
+
+    Node.new(%{
+      type: :code_block,
+      text: value,
+      language: language,
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a heading node."
+  @spec heading(pos_integer(), [node_input()] | String.t()) :: markdown_node()
+  def heading(level, value) when is_integer(level) and level >= 1 and level <= 6 do
+    Node.new(%{type: :heading, level: level, children: normalize_children(value)})
+  end
+
+  @doc "Builds a list node."
+  @spec list([node_input()], keyword() | map()) :: markdown_node()
+  def list(items, opts \\ []) when is_list(items) do
+    opts = normalize_opts(opts)
+
+    children =
+      Enum.map(items, fn
+        %Node{type: :list_item} = item -> item
+        item -> list_item(item)
+      end)
+
+    Node.new(%{
+      type: :list,
+      ordered: opts[:ordered] || opts["ordered"] || false,
+      start: opts[:start] || opts["start"],
+      children: children,
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a list item node."
+  @spec list_item([node_input()] | String.t()) :: markdown_node()
+  def list_item(value), do: Node.new(%{type: :list_item, children: normalize_children(value)})
+
+  @doc "Builds a blockquote node."
+  @spec blockquote([node_input()] | String.t()) :: markdown_node()
+  def blockquote(value), do: Node.new(%{type: :blockquote, children: normalize_children(value)})
+
+  @doc "Builds a table node."
+  @spec table([node_input()], keyword() | map()) :: markdown_node()
+  def table(rows, opts \\ []) when is_list(rows) do
+    opts = normalize_opts(opts)
+
+    Node.new(%{
+      type: :table,
+      children: Enum.map(rows, &normalize_row/1),
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a table row node."
+  @spec row([node_input()]) :: markdown_node()
+  def row(cells) when is_list(cells) do
+    Node.new(%{type: :table_row, children: Enum.map(cells, &normalize_cell/1)})
+  end
+
+  @doc "Builds a table cell node."
+  @spec cell([node_input()] | String.t()) :: markdown_node()
+  def cell(value), do: Node.new(%{type: :table_cell, children: normalize_children(value)})
+
+  @doc "Builds a divider node."
+  @spec divider() :: markdown_node()
+  def divider, do: Node.new(%{type: :divider})
+
+  @doc "Parses plain Markdown text into a canonical AST."
+  @spec parse(String.t()) :: t()
+  def parse(markdown) when is_binary(markdown) do
+    markdown
+    |> String.split("\n", trim: false)
+    |> parse_lines([])
+    |> Enum.reverse()
+    |> root(metadata: %{source: :parse})
+  end
+
+  @doc "Stringifies a Markdown document or node back to Markdown text."
+  @spec stringify(t() | markdown_node() | [node_input()] | String.t() | nil) :: String.t()
+  def stringify(nil), do: ""
+  def stringify(value) when is_binary(value), do: value
+  def stringify(%__MODULE__{root: root}), do: render_children(root.children, "\n\n")
+  def stringify(%Node{} = node), do: render_node(node)
+
+  def stringify(nodes) when is_list(nodes),
+    do: nodes |> Enum.map_join("\n\n", &(&1 |> normalize_node() |> render_node()))
+
+  @doc "Extracts plain text from a Markdown document or node."
+  @spec plain_text(t() | markdown_node() | [node_input()] | String.t() | nil) :: String.t()
+  def plain_text(nil), do: ""
+  def plain_text(value) when is_binary(value), do: value
+  def plain_text(%__MODULE__{root: root}), do: render_plain_children(root.children, "\n\n")
+  def plain_text(%Node{} = node), do: render_plain_node(node)
+
+  def plain_text(nodes) when is_list(nodes) do
+    nodes
+    |> Enum.map_join("\n\n", &(&1 |> normalize_node() |> render_plain_node()))
+  end
+
+  @doc "Walks and transforms every node in the Markdown AST."
+  @spec walk(t() | markdown_node(), (markdown_node() -> markdown_node())) ::
+          t() | markdown_node()
+  def walk(%__MODULE__{root: root} = markdown, fun) when is_function(fun, 1) do
+    %{markdown | root: walk_node(root, fun)}
+  end
+
+  def walk(%Node{} = node, fun) when is_function(fun, 1), do: walk_node(node, fun)
+
+  @doc "Renders the first table in a Markdown document, or a given table node, as ASCII."
+  @spec table_to_ascii(t() | markdown_node()) :: String.t()
+  def table_to_ascii(%__MODULE__{root: root}), do: root |> first_table() |> table_to_ascii()
+  def table_to_ascii(nil), do: ""
+
+  def table_to_ascii(%Node{type: :table, children: rows}) do
+    rows =
+      Enum.map(rows, fn %Node{children: cells} ->
+        Enum.map(cells, &(&1 |> render_plain_node() |> String.trim()))
+      end)
+
+    widths =
+      rows
+      |> Enum.zip_with(fn column ->
+        column
+        |> Enum.map(&String.length/1)
+        |> Enum.max(fn -> 0 end)
+      end)
+
+    case rows do
+      [] ->
+        ""
+
+      [header | body] ->
+        divider =
+          widths
+          |> Enum.map_join("-+-", &String.duplicate("-", max(&1, 1)))
+
+        [
+          render_ascii_row(header, widths),
+          divider
+          | Enum.map(body, &render_ascii_row(&1, widths))
+        ]
+        |> Enum.join("\n")
+    end
+  end
+
+  def table_to_ascii(%Node{} = node), do: node |> first_table() |> table_to_ascii()
+
+  @doc "Serializes Markdown into a plain map with type markers."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = markdown) do
+    markdown
+    |> Map.from_struct()
+    |> Map.update!(:root, &Node.to_map/1)
+    |> Wire.to_plain()
+    |> Map.put("__type__", "markdown")
+  end
+
+  @doc "Builds Markdown from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_root(attrs) do
+    root =
+      case attrs[:root] || attrs["root"] do
+        %Node{} = root ->
+          root
+
+        %{} = root ->
+          Node.new(root)
+
+        nil ->
+          children = attrs[:nodes] || attrs["nodes"] || []
+          Node.new(%{type: :root, children: children})
+      end
+
+    attrs
+    |> Map.delete("root")
+    |> Map.put(:root, root)
+  end
+
+  defp parse_lines([], acc), do: acc
+
+  defp parse_lines(["" | rest], acc), do: parse_lines(rest, acc)
+
+  defp parse_lines([line | rest], acc) do
+    cond do
+      String.starts_with?(line, "```") ->
+        {node, remainder} = parse_code_block(rest, String.trim_leading(line, "```"))
+        parse_lines(remainder, [node | acc])
+
+      heading_line?(line) ->
+        {level, text} = parse_heading(line)
+        parse_lines(rest, [heading(level, text) | acc])
+
+      table_header?(line, rest) ->
+        {node, remainder} = parse_table([line | rest])
+        parse_lines(remainder, [node | acc])
+
+      list_line?(line) ->
+        {node, remainder} = parse_list([line | rest])
+        parse_lines(remainder, [node | acc])
+
+      String.starts_with?(String.trim_leading(line), "> ") ->
+        {node, remainder} = parse_blockquote([line | rest])
+        parse_lines(remainder, [node | acc])
+
+      String.trim(line) == "---" ->
+        parse_lines(rest, [divider() | acc])
+
+      true ->
+        {node, remainder} = parse_paragraph([line | rest])
+        parse_lines(remainder, [node | acc])
+    end
+  end
+
+  defp parse_code_block(lines, language) do
+    {body, remainder} = Enum.split_while(lines, &(not String.starts_with?(&1, "```")))
+    remainder = if remainder == [], do: [], else: tl(remainder)
+    {code_block(Enum.join(body, "\n"), blank_to_nil(String.trim(language))), remainder}
+  end
+
+  defp parse_heading(line) do
+    trimmed = String.trim_leading(line)
+    marks = trimmed |> String.graphemes() |> Enum.take_while(&(&1 == "#")) |> length()
+    {marks, trimmed |> String.trim_leading("#") |> String.trim()}
+  end
+
+  defp parse_table([header, _separator | rest]) do
+    {rows, remainder} =
+      rest
+      |> Enum.split_while(fn line -> String.contains?(line, "|") and String.trim(line) != "" end)
+
+    header_row = header |> split_table_row() |> row()
+    body_rows = Enum.map(rows, &(&1 |> split_table_row() |> row()))
+    {table([header_row | body_rows]), remainder}
+  end
+
+  defp parse_list(lines) do
+    {items, remainder} = Enum.split_while(lines, &list_line?/1)
+
+    ordered? =
+      case items do
+        [first | _] -> Regex.match?(~r/^\s*\d+\.\s+/, first)
+        _ -> false
+      end
+
+    items =
+      Enum.map(items, fn line ->
+        line
+        |> String.trim()
+        |> String.replace(~r/^([-*]|\d+\.)\s+/, "")
+        |> list_item()
+      end)
+
+    {list(items, ordered: ordered?), remainder}
+  end
+
+  defp parse_blockquote(lines) do
+    {quoted, remainder} =
+      Enum.split_while(lines, fn line ->
+        trimmed = String.trim_leading(line)
+        String.starts_with?(trimmed, "> ")
+      end)
+
+    text =
+      quoted
+      |> Enum.map(fn line -> line |> String.trim_leading() |> String.trim_leading("> ") end)
+      |> Enum.join("\n")
+
+    {blockquote([paragraph(text)]), remainder}
+  end
+
+  defp parse_paragraph(lines) do
+    {paragraph_lines, remainder} =
+      Enum.split_while(lines, fn line ->
+        trimmed = String.trim(line)
+
+        trimmed != "" and not heading_line?(line) and not list_line?(line) and
+          not String.starts_with?(trimmed, "> ") and not String.starts_with?(trimmed, "```") and
+          not table_header?(line, remainder_preview(lines, line))
+      end)
+
+    text =
+      paragraph_lines
+      |> Enum.map(&String.trim/1)
+      |> Enum.join(" ")
+
+    {paragraph(text), remainder}
+  end
+
+  defp render_node(%Node{type: :root, children: children}), do: render_children(children, "\n\n")
+
+  defp render_node(%Node{type: :paragraph, children: children}), do: render_children(children, "")
+
+  defp render_node(%Node{type: :text, text: text}), do: text || ""
+
+  defp render_node(%Node{type: :strong, children: children}),
+    do: "**#{render_children(children, "")}**"
+
+  defp render_node(%Node{type: :emphasis, children: children}),
+    do: "_#{render_children(children, "")}_"
+
+  defp render_node(%Node{type: :link, url: url, children: children}),
+    do: "[#{render_children(children, "")}](#{url})"
+
+  defp render_node(%Node{type: :code, text: text}), do: "`#{text || ""}`"
+
+  defp render_node(%Node{type: :code_block, text: text, language: language}) do
+    "```#{language || ""}\n#{text || ""}\n```"
+  end
+
+  defp render_node(%Node{type: :heading, level: level, children: children}) do
+    "#{String.duplicate("#", level || 1)} #{render_children(children, "")}"
+  end
+
+  defp render_node(%Node{type: :list, ordered: ordered?, start: start, children: children}) do
+    start = start || 1
+
+    children
+    |> Enum.with_index(start)
+    |> Enum.map_join("\n", fn {%Node{} = child, index} ->
+      marker = if ordered?, do: "#{index}. ", else: "- "
+      marker <> render_list_item(child)
+    end)
+  end
+
+  defp render_node(%Node{type: :list_item} = node), do: render_list_item(node)
+
+  defp render_node(%Node{type: :blockquote, children: children}) do
+    children
+    |> render_children("\n")
+    |> String.split("\n")
+    |> Enum.map_join("\n", &("> " <> &1))
+  end
+
+  defp render_node(%Node{type: :table} = node), do: render_markdown_table(node)
+
+  defp render_node(%Node{type: :table_row, children: children}) do
+    children
+    |> Enum.map_join(" | ", &render_plain_node/1)
+  end
+
+  defp render_node(%Node{type: :table_cell, children: children}),
+    do: render_children(children, "")
+
+  defp render_node(%Node{type: :divider}), do: "---"
+
+  defp render_plain_node(%Node{type: :root, children: children}),
+    do: render_plain_children(children, "\n\n")
+
+  defp render_plain_node(%Node{type: :paragraph, children: children}),
+    do: render_plain_children(children, "")
+
+  defp render_plain_node(%Node{type: :text, text: text}), do: text || ""
+
+  defp render_plain_node(%Node{type: :strong, children: children}),
+    do: render_plain_children(children, "")
+
+  defp render_plain_node(%Node{type: :emphasis, children: children}),
+    do: render_plain_children(children, "")
+
+  defp render_plain_node(%Node{type: :link, children: children}),
+    do: render_plain_children(children, "")
+
+  defp render_plain_node(%Node{type: :code, text: text}), do: text || ""
+  defp render_plain_node(%Node{type: :code_block, text: text}), do: text || ""
+
+  defp render_plain_node(%Node{type: :heading, children: children}),
+    do: render_plain_children(children, "")
+
+  defp render_plain_node(%Node{type: :list, children: children}) do
+    children
+    |> Enum.map_join("\n", &render_plain_node/1)
+  end
+
+  defp render_plain_node(%Node{type: :list_item, children: children}),
+    do: render_plain_children(children, " ")
+
+  defp render_plain_node(%Node{type: :blockquote, children: children}),
+    do: render_plain_children(children, "\n")
+
+  defp render_plain_node(%Node{type: :table} = node), do: table_to_ascii(node)
+
+  defp render_plain_node(%Node{type: :table_row, children: children}) do
+    children
+    |> Enum.map_join(" | ", &render_plain_node/1)
+  end
+
+  defp render_plain_node(%Node{type: :table_cell, children: children}),
+    do: render_plain_children(children, "")
+
+  defp render_plain_node(%Node{type: :divider}), do: "---"
+
+  defp render_children(children, separator),
+    do: children |> Enum.map_join(separator, &(&1 |> normalize_node() |> render_node()))
+
+  defp render_plain_children(children, separator) do
+    children
+    |> Enum.map_join(separator, &(&1 |> normalize_node() |> render_plain_node()))
+    |> String.trim()
+  end
+
+  defp render_list_item(%Node{children: children}) do
+    children
+    |> Enum.map_join(" ", fn child -> child |> normalize_node() |> render_node() end)
+    |> String.replace("\n", "\n  ")
+  end
+
+  defp render_markdown_table(%Node{children: []}), do: ""
+
+  defp render_markdown_table(%Node{children: [%Node{} = header | body]}) do
+    header_cells = Enum.map(header.children, &render_plain_node/1)
+    divider = Enum.map_join(header_cells, " | ", fn _ -> "---" end)
+
+    body_rows =
+      Enum.map_join(body, "\n", fn %Node{children: cells} ->
+        "| " <> Enum.map_join(cells, " | ", &render_plain_node/1) <> " |"
+      end)
+
+    [
+      "| " <> Enum.join(header_cells, " | ") <> " |",
+      "| " <> divider <> " |",
+      body_rows
+    ]
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n")
+  end
+
+  defp walk_node(%Node{} = node, fun) do
+    children = Enum.map(node.children, &walk_node(normalize_node(&1), fun))
+    node |> Map.put(:children, children) |> fun.()
+  end
+
+  defp first_table(%Node{type: :table} = node), do: node
+
+  defp first_table(%Node{children: children}) do
+    Enum.find_value(children, &first_table(normalize_node(&1)))
+  end
+
+  defp normalize_node(%Node{} = node), do: node
+  defp normalize_node(node), do: Node.normalize(node)
+
+  defp normalize_children(value) when is_binary(value), do: [text(value)]
+  defp normalize_children(value) when is_list(value), do: Enum.map(value, &normalize_node/1)
+  defp normalize_children(value), do: [normalize_node(value)]
+
+  defp normalize_row(%Node{type: :table_row} = row), do: row
+  defp normalize_row(values) when is_list(values), do: row(values)
+  defp normalize_row(value), do: row([value])
+
+  defp normalize_cell(%Node{type: :table_cell} = cell), do: cell
+  defp normalize_cell(value), do: cell(value)
+
+  defp split_table_row(line) do
+    line
+    |> String.trim()
+    |> String.trim("|")
+    |> String.split("|")
+    |> Enum.map(&String.trim/1)
+  end
+
+  defp render_ascii_row(values, widths) do
+    values
+    |> Enum.zip(widths)
+    |> Enum.map_join(" | ", fn {value, width} -> String.pad_trailing(value, width) end)
+  end
+
+  defp heading_line?(line), do: Regex.match?(~r/^\s{0,3}\#{1,6}\s+.+$/, line)
+
+  defp list_line?(line) do
+    Regex.match?(~r/^\s*([-*]|\d+\.)\s+.+$/, line)
+  end
+
+  defp table_header?(line, [separator | _rest]) do
+    String.contains?(line, "|") and Regex.match?(~r/^\s*\|?[\s:-|]+\|?\s*$/, separator)
+  end
+
+  defp table_header?(_line, _rest), do: false
+
+  defp remainder_preview(lines, current) do
+    case Enum.drop_while(lines, &(&1 != current)) do
+      [_current | rest] -> rest
+      _ -> []
+    end
+  end
+
+  defp blank_to_nil(""), do: nil
+  defp blank_to_nil(value), do: value
+
+  defp normalize_opts(opts) when is_list(opts), do: Map.new(opts)
+  defp normalize_opts(opts) when is_map(opts), do: opts
+end

--- a/lib/jido/chat/markdown/node.ex
+++ b/lib/jido/chat/markdown/node.ex
@@ -1,0 +1,109 @@
+defmodule Jido.Chat.Markdown.Node do
+  @moduledoc """
+  Canonical Markdown AST node used by `Jido.Chat.Markdown`.
+  """
+
+  alias Jido.Chat.Wire
+
+  @node_types [
+    :root,
+    :paragraph,
+    :text,
+    :strong,
+    :emphasis,
+    :link,
+    :code,
+    :code_block,
+    :heading,
+    :list,
+    :list_item,
+    :blockquote,
+    :table,
+    :table_row,
+    :table_cell,
+    :divider
+  ]
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              type: Zoi.enum(@node_types),
+              text: Zoi.string() |> Zoi.nullish(),
+              url: Zoi.string() |> Zoi.nullish(),
+              language: Zoi.string() |> Zoi.nullish(),
+              level: Zoi.integer() |> Zoi.nullish(),
+              ordered: Zoi.boolean() |> Zoi.nullish(),
+              start: Zoi.integer() |> Zoi.nullish(),
+              align: Zoi.string() |> Zoi.nullish(),
+              children: Zoi.list() |> Zoi.default([]),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type node_type ::
+          :root
+          | :paragraph
+          | :text
+          | :strong
+          | :emphasis
+          | :link
+          | :code
+          | :code_block
+          | :heading
+          | :list
+          | :list_item
+          | :blockquote
+          | :table
+          | :table_row
+          | :table_cell
+          | :divider
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the schema for a Markdown node."
+  def schema, do: @schema
+
+  @doc "Creates a canonical Markdown node."
+  @spec new(t() | map()) :: t()
+  def new(%__MODULE__{} = node), do: node
+
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_children()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Serializes a Markdown node into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = node) do
+    node
+    |> Map.from_struct()
+    |> Map.update!(:children, &Enum.map(&1, fn child -> child |> normalize() |> to_map() end))
+    |> Wire.to_plain()
+    |> Map.put("__type__", "markdown_node")
+  end
+
+  @doc "Builds a Markdown node from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  @doc "Normalizes a Markdown node input."
+  @spec normalize(t() | map() | String.t() | nil) :: t() | nil
+  def normalize(nil), do: nil
+  def normalize(%__MODULE__{} = node), do: node
+  def normalize(value) when is_binary(value), do: new(%{type: :text, text: value})
+  def normalize(value) when is_map(value), do: new(value)
+
+  defp normalize_children(attrs) do
+    children =
+      attrs[:children] || attrs["children"] || []
+
+    attrs
+    |> Map.delete("children")
+    |> Map.put(:children, Enum.map(children, &normalize/1))
+  end
+end

--- a/lib/jido/chat/modal.ex
+++ b/lib/jido/chat/modal.ex
@@ -1,0 +1,160 @@
+defmodule Jido.Chat.Modal do
+  @moduledoc """
+  Canonical modal open payload and builder helpers.
+  """
+
+  alias Jido.Chat.Modal.Element
+  alias Jido.Chat.Wire
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              id: Zoi.string() |> Zoi.nullish(),
+              callback_id: Zoi.string() |> Zoi.nullish(),
+              title: Zoi.string(),
+              submit_label: Zoi.string() |> Zoi.default("Submit"),
+              close_label: Zoi.string() |> Zoi.default("Cancel"),
+              notify_on_close: Zoi.boolean() |> Zoi.default(false),
+              private_metadata: Zoi.string() |> Zoi.nullish(),
+              elements: Zoi.list() |> Zoi.default([]),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the schema for modals."
+  def schema, do: @schema
+
+  @doc "Creates a canonical modal."
+  @spec new(t() | map()) :: t()
+  def new(%__MODULE__{} = modal), do: modal
+
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> Map.put_new(
+      :callback_id,
+      attrs[:id] || attrs["id"] || attrs[:callback_id] || attrs["callback_id"]
+    )
+    |> normalize_elements()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Builds a text input element."
+  @spec text_input(String.t(), String.t(), keyword() | map()) :: Element.t()
+  def text_input(id, label, opts \\ []) when is_binary(id) and is_binary(label) do
+    opts = normalize_opts(opts)
+
+    Element.new(%{
+      kind: :text_input,
+      id: id,
+      label: label,
+      value: opts[:value] || opts["value"],
+      placeholder: opts[:placeholder] || opts["placeholder"],
+      help_text: opts[:help_text] || opts["help_text"],
+      required: opts[:required] || opts["required"] || false,
+      multiline: opts[:multiline] || opts["multiline"] || false,
+      min_length: opts[:min_length] || opts["min_length"],
+      max_length: opts[:max_length] || opts["max_length"],
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a select option element."
+  @spec select_option(String.t(), String.t(), keyword() | map()) :: Element.t()
+  def select_option(label, value, opts \\ []) when is_binary(label) and is_binary(value) do
+    opts = normalize_opts(opts)
+
+    Element.new(%{
+      kind: :select_option,
+      id: value,
+      label: label,
+      value: value,
+      help_text: opts[:help_text] || opts["help_text"],
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a select element."
+  @spec select(String.t(), String.t(), [Element.t() | map()], keyword() | map()) :: Element.t()
+  def select(id, label, options, opts \\ [])
+      when is_binary(id) and is_binary(label) and is_list(options) do
+    opts = normalize_opts(opts)
+
+    Element.new(%{
+      kind: :select,
+      id: id,
+      label: label,
+      value: opts[:value] || opts["value"],
+      placeholder: opts[:placeholder] || opts["placeholder"],
+      help_text: opts[:help_text] || opts["help_text"],
+      required: opts[:required] || opts["required"] || false,
+      options: options,
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a radio select element."
+  @spec radio_select(String.t(), String.t(), [Element.t() | map()], keyword() | map()) ::
+          Element.t()
+  def radio_select(id, label, options, opts \\ [])
+      when is_binary(id) and is_binary(label) and is_list(options) do
+    opts = normalize_opts(opts)
+
+    Element.new(%{
+      kind: :radio_select,
+      id: id,
+      label: label,
+      value: opts[:value] || opts["value"],
+      help_text: opts[:help_text] || opts["help_text"],
+      required: opts[:required] || opts["required"] || false,
+      options: options,
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Returns a plain map suitable for adapter-specific modal rendering."
+  @spec to_adapter_payload(t()) :: map()
+  def to_adapter_payload(%__MODULE__{} = modal) do
+    modal
+    |> Map.from_struct()
+    |> Map.update!(:elements, fn elements -> Enum.map(elements, &element_to_plain/1) end)
+    |> Wire.to_plain()
+  end
+
+  @doc "Serializes the modal into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = modal) do
+    modal
+    |> Map.from_struct()
+    |> Map.update!(:elements, &Enum.map(&1, fn element -> Element.to_map(element) end))
+    |> Wire.to_plain()
+    |> Map.put("__type__", "modal")
+  end
+
+  @doc "Builds a modal from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_elements(attrs) do
+    elements = attrs[:elements] || attrs["elements"] || []
+
+    attrs
+    |> Map.delete("elements")
+    |> Map.put(:elements, Enum.map(elements, &Element.normalize/1))
+  end
+
+  defp normalize_opts(opts) when is_list(opts), do: Map.new(opts)
+  defp normalize_opts(opts) when is_map(opts), do: opts
+
+  defp element_to_plain(%Element{} = element) do
+    element
+    |> Map.from_struct()
+    |> Map.update!(:options, fn options -> Enum.map(options, &element_to_plain/1) end)
+    |> Wire.to_plain()
+  end
+end

--- a/lib/jido/chat/modal/element.ex
+++ b/lib/jido/chat/modal/element.ex
@@ -1,0 +1,71 @@
+defmodule Jido.Chat.Modal.Element do
+  @moduledoc """
+  Canonical modal element used by `Jido.Chat.Modal`.
+  """
+
+  alias Jido.Chat.Wire
+
+  @kinds [:text_input, :select, :radio_select, :select_option]
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              kind: Zoi.enum(@kinds),
+              id: Zoi.string(),
+              label: Zoi.string() |> Zoi.nullish(),
+              value: Zoi.string() |> Zoi.nullish(),
+              placeholder: Zoi.string() |> Zoi.nullish(),
+              help_text: Zoi.string() |> Zoi.nullish(),
+              required: Zoi.boolean() |> Zoi.default(false),
+              multiline: Zoi.boolean() |> Zoi.default(false),
+              min_length: Zoi.integer() |> Zoi.nullish(),
+              max_length: Zoi.integer() |> Zoi.nullish(),
+              options: Zoi.list() |> Zoi.default([]),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+  @type input :: t() | map()
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the schema for modal elements."
+  def schema, do: @schema
+
+  @doc "Creates a canonical modal element."
+  @spec new(t() | map()) :: t()
+  def new(%__MODULE__{} = element), do: element
+
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_options()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Normalizes modal element input."
+  @spec normalize(input()) :: t()
+  def normalize(%__MODULE__{} = element), do: element
+  def normalize(map) when is_map(map), do: new(map)
+
+  @doc "Serializes the modal element into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = element) do
+    element
+    |> Map.from_struct()
+    |> Map.update!(:options, &Enum.map(&1, fn option -> option |> normalize() |> to_map() end))
+    |> Wire.to_plain()
+    |> Map.put("__type__", "modal_element")
+  end
+
+  @doc "Builds a modal element from serialized data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_options(attrs) do
+    options = attrs[:options] || attrs["options"] || []
+    attrs |> Map.delete("options") |> Map.put(:options, Enum.map(options, &normalize/1))
+  end
+end

--- a/lib/jido/chat/modal_close_event.ex
+++ b/lib/jido/chat/modal_close_event.ex
@@ -3,15 +3,27 @@ defmodule Jido.Chat.ModalCloseEvent do
   Normalized modal close event payload placeholder for Phase 2.
   """
 
-  alias Jido.Chat.Author
+  alias Jido.Chat.{Author, ChannelRef, Message, ModalResponse, Thread, Wire}
 
   @schema Zoi.struct(
             __MODULE__,
             %{
+              adapter: Zoi.any() |> Zoi.nullish(),
               adapter_name: Zoi.atom() |> Zoi.nullish(),
+              thread_id: Zoi.string() |> Zoi.nullish(),
+              channel_id: Zoi.string() |> Zoi.nullish(),
+              message_id: Zoi.string() |> Zoi.nullish(),
               callback_id: Zoi.string() |> Zoi.nullish(),
               view_id: Zoi.string() |> Zoi.nullish(),
+              trigger_id: Zoi.string() |> Zoi.nullish(),
+              private_metadata: Zoi.string() |> Zoi.nullish(),
               user: Zoi.struct(Author) |> Zoi.nullish(),
+              thread: Zoi.struct(Thread) |> Zoi.nullish(),
+              channel: Zoi.struct(ChannelRef) |> Zoi.nullish(),
+              message: Zoi.struct(Message) |> Zoi.nullish(),
+              related_thread: Zoi.struct(Thread) |> Zoi.nullish(),
+              related_channel: Zoi.struct(ChannelRef) |> Zoi.nullish(),
+              related_message: Zoi.struct(Message) |> Zoi.nullish(),
               raw: Zoi.map() |> Zoi.default(%{}),
               metadata: Zoi.map() |> Zoi.default(%{})
             },
@@ -27,5 +39,75 @@ defmodule Jido.Chat.ModalCloseEvent do
   def schema, do: @schema
 
   @doc "Creates a normalized modal close event payload."
-  def new(attrs) when is_map(attrs), do: Jido.Chat.Schema.parse!(__MODULE__, @schema, attrs)
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_author()
+    |> normalize_handles()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Builds a close response for modal handlers."
+  @spec close(keyword() | map()) :: ModalResponse.t()
+  def close(opts \\ []), do: ModalResponse.close(opts)
+
+  @doc "Serializes the modal close event into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = event) do
+    event
+    |> Map.from_struct()
+    |> serialize_handles()
+    |> Wire.to_plain()
+    |> Map.put("__type__", "modal_close_event")
+  end
+
+  @doc "Builds a modal close event from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_author(%{user: %Author{}} = attrs), do: attrs
+  defp normalize_author(%{"user" => %Author{}} = attrs), do: attrs
+
+  defp normalize_author(attrs) do
+    case attrs[:user] || attrs["user"] do
+      %{} = user -> Map.delete(attrs, "user") |> Map.put(:user, Author.new(user))
+      _ -> attrs
+    end
+  end
+
+  defp normalize_handles(attrs) do
+    attrs
+    |> normalize_handle(:thread, Thread)
+    |> normalize_handle(:channel, ChannelRef)
+    |> normalize_handle(:message, Message)
+    |> normalize_handle(:related_thread, Thread)
+    |> normalize_handle(:related_channel, ChannelRef)
+    |> normalize_handle(:related_message, Message)
+  end
+
+  defp normalize_handle(attrs, key, mod) do
+    case attrs[key] || attrs[Atom.to_string(key)] do
+      %{__struct__: ^mod} = value ->
+        attrs |> Map.delete(Atom.to_string(key)) |> Map.put(key, value)
+
+      %{} = value ->
+        attrs |> Map.delete(Atom.to_string(key)) |> Map.put(key, mod.new(value))
+
+      _ ->
+        attrs
+    end
+  end
+
+  defp serialize_handles(map) do
+    map
+    |> Map.update!(:adapter, &Wire.encode_module/1)
+    |> Map.update!(:thread, fn value -> serialize_handle(value, &Thread.to_map/1) end)
+    |> Map.update!(:channel, fn value -> serialize_handle(value, &ChannelRef.to_map/1) end)
+    |> Map.update!(:message, fn value -> serialize_handle(value, &Message.to_map/1) end)
+    |> Map.update!(:related_thread, fn value -> serialize_handle(value, &Thread.to_map/1) end)
+    |> Map.update!(:related_channel, fn value -> serialize_handle(value, &ChannelRef.to_map/1) end)
+    |> Map.update!(:related_message, fn value -> serialize_handle(value, &Message.to_map/1) end)
+  end
+
+  defp serialize_handle(nil, _fun), do: nil
+  defp serialize_handle(value, fun), do: fun.(value)
 end

--- a/lib/jido/chat/modal_response.ex
+++ b/lib/jido/chat/modal_response.ex
@@ -1,0 +1,101 @@
+defmodule Jido.Chat.ModalResponse do
+  @moduledoc """
+  Canonical modal lifecycle response used by submit and close handlers.
+  """
+
+  alias Jido.Chat.Modal
+  alias Jido.Chat.Wire
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              action: Zoi.enum([:close, :errors, :update, :push]),
+              modal: Zoi.any() |> Zoi.nullish(),
+              errors: Zoi.map() |> Zoi.default(%{}),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the schema for modal responses."
+  def schema, do: @schema
+
+  @doc "Creates a canonical modal response."
+  @spec new(t() | map()) :: t()
+  def new(%__MODULE__{} = response), do: response
+
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_modal()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Builds a close response."
+  @spec close(keyword() | map()) :: t()
+  def close(opts \\ []), do: new(Map.merge(normalize_opts(opts), %{action: :close}))
+
+  @doc "Builds a validation-error response."
+  @spec errors(map(), keyword() | map()) :: t()
+  def errors(errors, opts \\ []) when is_map(errors) do
+    new(Map.merge(normalize_opts(opts), %{action: :errors, errors: errors}))
+  end
+
+  @doc "Builds an update response with a replacement modal."
+  @spec update(Modal.t() | map(), keyword() | map()) :: t()
+  def update(modal, opts \\ []) do
+    new(Map.merge(normalize_opts(opts), %{action: :update, modal: modal}))
+  end
+
+  @doc "Builds a push response with a new modal."
+  @spec push(Modal.t() | map(), keyword() | map()) :: t()
+  def push(modal, opts \\ []) do
+    new(Map.merge(normalize_opts(opts), %{action: :push, modal: modal}))
+  end
+
+  @doc "Returns a plain adapter-facing response map."
+  @spec to_adapter_payload(t()) :: map()
+  def to_adapter_payload(%__MODULE__{} = response), do: to_map(response)
+
+  @doc "Serializes the response into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = response) do
+    response
+    |> Map.from_struct()
+    |> Map.update!(:modal, fn
+      nil -> nil
+      %Modal{} = modal -> Modal.to_map(modal)
+      other -> other
+    end)
+    |> Wire.to_plain()
+    |> Map.put("__type__", "modal_response")
+  end
+
+  @doc "Builds a modal response from serialized data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_modal(attrs) do
+    case attrs[:modal] || attrs["modal"] do
+      nil ->
+        attrs
+
+      %Modal{} = modal ->
+        attrs
+        |> Map.delete("modal")
+        |> Map.put(:modal, modal)
+
+      %{} = modal ->
+        attrs
+        |> Map.delete("modal")
+        |> Map.put(:modal, Modal.new(modal))
+    end
+  end
+
+  defp normalize_opts(opts) when is_list(opts), do: Map.new(opts)
+  defp normalize_opts(opts) when is_map(opts), do: opts
+end

--- a/lib/jido/chat/modal_submit_event.ex
+++ b/lib/jido/chat/modal_submit_event.ex
@@ -3,16 +3,28 @@ defmodule Jido.Chat.ModalSubmitEvent do
   Normalized modal submit event payload placeholder for Phase 2.
   """
 
-  alias Jido.Chat.Author
+  alias Jido.Chat.{Author, ChannelRef, Message, Modal, ModalResponse, Thread, Wire}
 
   @schema Zoi.struct(
             __MODULE__,
             %{
+              adapter: Zoi.any() |> Zoi.nullish(),
               adapter_name: Zoi.atom() |> Zoi.nullish(),
+              thread_id: Zoi.string() |> Zoi.nullish(),
+              channel_id: Zoi.string() |> Zoi.nullish(),
+              message_id: Zoi.string() |> Zoi.nullish(),
               callback_id: Zoi.string() |> Zoi.nullish(),
               view_id: Zoi.string() |> Zoi.nullish(),
+              trigger_id: Zoi.string() |> Zoi.nullish(),
+              private_metadata: Zoi.string() |> Zoi.nullish(),
               values: Zoi.map() |> Zoi.default(%{}),
               user: Zoi.struct(Author) |> Zoi.nullish(),
+              thread: Zoi.struct(Thread) |> Zoi.nullish(),
+              channel: Zoi.struct(ChannelRef) |> Zoi.nullish(),
+              message: Zoi.struct(Message) |> Zoi.nullish(),
+              related_thread: Zoi.struct(Thread) |> Zoi.nullish(),
+              related_channel: Zoi.struct(ChannelRef) |> Zoi.nullish(),
+              related_message: Zoi.struct(Message) |> Zoi.nullish(),
               raw: Zoi.map() |> Zoi.default(%{}),
               metadata: Zoi.map() |> Zoi.default(%{})
             },
@@ -28,5 +40,87 @@ defmodule Jido.Chat.ModalSubmitEvent do
   def schema, do: @schema
 
   @doc "Creates a normalized modal submit event payload."
-  def new(attrs) when is_map(attrs), do: Jido.Chat.Schema.parse!(__MODULE__, @schema, attrs)
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_author()
+    |> normalize_handles()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Builds a close response for modal handlers."
+  @spec close(keyword() | map()) :: ModalResponse.t()
+  def close(opts \\ []), do: ModalResponse.close(opts)
+
+  @doc "Builds a validation error response for modal handlers."
+  @spec errors(map(), keyword() | map()) :: ModalResponse.t()
+  def errors(errors, opts \\ []), do: ModalResponse.errors(errors, opts)
+
+  @doc "Builds an update response for modal handlers."
+  @spec update(Modal.t() | map(), keyword() | map()) :: ModalResponse.t()
+  def update(modal, opts \\ []), do: ModalResponse.update(modal, opts)
+
+  @doc "Builds a push response for modal handlers."
+  @spec push(Modal.t() | map(), keyword() | map()) :: ModalResponse.t()
+  def push(modal, opts \\ []), do: ModalResponse.push(modal, opts)
+
+  @doc "Serializes the modal submit event into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = event) do
+    event
+    |> Map.from_struct()
+    |> serialize_handles()
+    |> Wire.to_plain()
+    |> Map.put("__type__", "modal_submit_event")
+  end
+
+  @doc "Builds a modal submit event from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_author(%{user: %Author{}} = attrs), do: attrs
+  defp normalize_author(%{"user" => %Author{}} = attrs), do: attrs
+
+  defp normalize_author(attrs) do
+    case attrs[:user] || attrs["user"] do
+      %{} = user -> Map.delete(attrs, "user") |> Map.put(:user, Author.new(user))
+      _ -> attrs
+    end
+  end
+
+  defp normalize_handles(attrs) do
+    attrs
+    |> normalize_handle(:thread, Thread)
+    |> normalize_handle(:channel, ChannelRef)
+    |> normalize_handle(:message, Message)
+    |> normalize_handle(:related_thread, Thread)
+    |> normalize_handle(:related_channel, ChannelRef)
+    |> normalize_handle(:related_message, Message)
+  end
+
+  defp normalize_handle(attrs, key, mod) do
+    case attrs[key] || attrs[Atom.to_string(key)] do
+      %{__struct__: ^mod} = value ->
+        attrs |> Map.delete(Atom.to_string(key)) |> Map.put(key, value)
+
+      %{} = value ->
+        attrs |> Map.delete(Atom.to_string(key)) |> Map.put(key, mod.new(value))
+
+      _ ->
+        attrs
+    end
+  end
+
+  defp serialize_handles(map) do
+    map
+    |> Map.update!(:adapter, &Wire.encode_module/1)
+    |> Map.update!(:thread, fn value -> serialize_handle(value, &Thread.to_map/1) end)
+    |> Map.update!(:channel, fn value -> serialize_handle(value, &ChannelRef.to_map/1) end)
+    |> Map.update!(:message, fn value -> serialize_handle(value, &Message.to_map/1) end)
+    |> Map.update!(:related_thread, fn value -> serialize_handle(value, &Thread.to_map/1) end)
+    |> Map.update!(:related_channel, fn value -> serialize_handle(value, &ChannelRef.to_map/1) end)
+    |> Map.update!(:related_message, fn value -> serialize_handle(value, &Message.to_map/1) end)
+  end
+
+  defp serialize_handle(nil, _fun), do: nil
+  defp serialize_handle(value, fun), do: fun.(value)
 end

--- a/lib/jido/chat/post_payload.ex
+++ b/lib/jido/chat/post_payload.ex
@@ -3,7 +3,7 @@ defmodule Jido.Chat.PostPayload do
   Typed normalized outbound payload used by thread/channel posting helpers.
   """
 
-  alias Jido.Chat.{Attachment, FileUpload, StreamChunk, Wire}
+  alias Jido.Chat.{Attachment, Card, FileUpload, Markdown, StreamChunk, Wire}
 
   @schema Zoi.struct(
             __MODULE__,
@@ -93,6 +93,8 @@ defmodule Jido.Chat.PostPayload do
   def to_map(%__MODULE__{} = payload) do
     payload
     |> Map.from_struct()
+    |> Map.update!(:ast, &serialize_ast/1)
+    |> Map.update!(:card, &serialize_card/1)
     |> Map.update!(:stream, &serialize_stream/1)
     |> Wire.to_plain()
     |> Map.put("__type__", "post_payload")
@@ -122,7 +124,13 @@ defmodule Jido.Chat.PostPayload do
   end
 
   defp normalize_content(%{kind: :markdown} = attrs) do
-    markdown = attrs[:markdown] || attrs["markdown"] || attrs[:text] || attrs["text"]
+    markdown =
+      case attrs[:markdown] || attrs["markdown"] || attrs[:text] || attrs["text"] do
+        %Markdown{} = markdown -> Markdown.stringify(markdown)
+        %{} = markdown -> markdown |> Markdown.new() |> Markdown.stringify()
+        value -> value
+      end
+
     text = attrs[:text] || attrs["text"] || markdown
     formatted = attrs[:formatted] || attrs["formatted"] || text
 
@@ -147,8 +155,9 @@ defmodule Jido.Chat.PostPayload do
     ast = attrs[:ast] || attrs["ast"] || attrs[:raw] || attrs["raw"]
     raw = attrs[:raw] || attrs["raw"] || ast
     fallback_text = attrs[:fallback_text] || attrs["fallback_text"]
-    text = attrs[:text] || attrs["text"] || fallback_text || to_text_value(ast)
-    formatted = attrs[:formatted] || attrs["formatted"] || text
+    {ast, formatted, ast_text} = normalize_ast(ast)
+    text = attrs[:text] || attrs["text"] || fallback_text || ast_text
+    formatted = attrs[:formatted] || attrs["formatted"] || formatted || text
 
     attrs
     |> Map.put(:ast, ast)
@@ -160,11 +169,11 @@ defmodule Jido.Chat.PostPayload do
 
   defp normalize_content(%{kind: :card} = attrs) do
     card = attrs[:card] || attrs["card"] || attrs[:raw] || attrs["raw"]
-    raw = attrs[:raw] || attrs["raw"] || card
+    {card, raw, card_text} = normalize_card(card)
 
     fallback_text =
       attrs[:fallback_text] || attrs["fallback_text"] || attrs[:text] || attrs["text"] ||
-        to_text_value(card)
+        card_text
 
     text = attrs[:text] || attrs["text"] || fallback_text
     formatted = attrs[:formatted] || attrs["formatted"] || text
@@ -181,7 +190,8 @@ defmodule Jido.Chat.PostPayload do
     stream = attrs[:stream] || attrs["stream"] || attrs[:raw] || attrs["raw"]
 
     fallback_text =
-      attrs[:fallback_text] || attrs["fallback_text"] || attrs[:text] || attrs["text"]
+      attrs[:fallback_text] || attrs["fallback_text"] || attrs[:text] || attrs["text"] ||
+        stream_fallback_text(stream)
 
     formatted = attrs[:formatted] || attrs["formatted"] || fallback_text
 
@@ -274,6 +284,51 @@ defmodule Jido.Chat.PostPayload do
   defp normalize_stream_item(chunk) when is_map(chunk), do: StreamChunk.new(chunk)
   defp normalize_stream_item(chunk), do: chunk
 
+  defp normalize_ast(%Markdown{} = markdown) do
+    {markdown, Markdown.stringify(markdown), Markdown.plain_text(markdown)}
+  end
+
+  defp normalize_ast(%{} = ast) do
+    markdown = Markdown.new(ast)
+    {markdown, Markdown.stringify(markdown), Markdown.plain_text(markdown)}
+  rescue
+    _ -> {ast, to_text_value(ast), to_text_value(ast)}
+  end
+
+  defp normalize_ast(ast), do: {ast, to_text_value(ast), to_text_value(ast)}
+
+  defp normalize_card(%Card{} = card) do
+    fallback = Card.fallback_text(card)
+    {card, card, fallback}
+  end
+
+  defp normalize_card(%{} = card) do
+    normalized = Card.new(card)
+    fallback = Card.fallback_text(normalized)
+    {normalized, normalized, fallback}
+  rescue
+    _ -> {card, card, to_text_value(card)}
+  end
+
+  defp normalize_card(card), do: {card, card, to_text_value(card)}
+
+  defp stream_fallback_text(chunks) when is_list(chunks) do
+    chunks
+    |> Enum.map(fn
+      %StreamChunk{} = chunk -> StreamChunk.fallback_text(chunk)
+      value when is_binary(value) -> value
+      value when is_map(value) -> value |> StreamChunk.new() |> StreamChunk.fallback_text()
+      value -> to_string(value)
+    end)
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join("")
+    |> blank_to_nil()
+  rescue
+    _ -> nil
+  end
+
+  defp stream_fallback_text(_), do: nil
+
   defp serialize_stream(nil), do: nil
 
   defp serialize_stream(chunks) when is_list(chunks) do
@@ -285,6 +340,12 @@ defmodule Jido.Chat.PostPayload do
 
   defp serialize_stream(_other), do: nil
 
+  defp serialize_ast(%Markdown{} = markdown), do: Markdown.to_map(markdown)
+  defp serialize_ast(other), do: Wire.to_plain(other)
+
+  defp serialize_card(%Card{} = card), do: Card.to_map(card)
+  defp serialize_card(other), do: Wire.to_plain(other)
+
   defp to_text_value(nil), do: nil
   defp to_text_value(value) when is_binary(value), do: value
 
@@ -294,6 +355,9 @@ defmodule Jido.Chat.PostPayload do
       {:error, _reason} -> inspect(value)
     end
   end
+
+  defp blank_to_nil(""), do: nil
+  defp blank_to_nil(value), do: value
 
   defp present?(nil), do: false
   defp present?(""), do: false

--- a/lib/jido/chat/post_payload.ex
+++ b/lib/jido/chat/post_payload.ex
@@ -3,7 +3,7 @@ defmodule Jido.Chat.PostPayload do
   Typed normalized outbound payload used by thread/channel posting helpers.
   """
 
-  alias Jido.Chat.{Attachment, Wire}
+  alias Jido.Chat.{Attachment, FileUpload, StreamChunk, Wire}
 
   @schema Zoi.struct(
             __MODULE__,
@@ -12,9 +12,15 @@ defmodule Jido.Chat.PostPayload do
                 Zoi.enum([:text, :markdown, :raw, :ast, :card, :stream])
                 |> Zoi.default(:text),
               text: Zoi.string() |> Zoi.nullish(),
+              markdown: Zoi.string() |> Zoi.nullish(),
               formatted: Zoi.string() |> Zoi.nullish(),
               raw: Zoi.any() |> Zoi.nullish(),
+              ast: Zoi.any() |> Zoi.nullish(),
+              card: Zoi.any() |> Zoi.nullish(),
+              stream: Zoi.any() |> Zoi.nullish(),
+              fallback_text: Zoi.string() |> Zoi.nullish(),
               attachments: Zoi.array(Zoi.struct(Attachment)) |> Zoi.default([]),
+              files: Zoi.array(Zoi.struct(FileUpload)) |> Zoi.default([]),
               metadata: Zoi.map() |> Zoi.default(%{})
             },
             coerce: true
@@ -29,33 +35,178 @@ defmodule Jido.Chat.PostPayload do
   def schema, do: @schema
 
   @doc "Creates a normalized post payload."
-  @spec new(map()) :: t()
+  @spec new(map() | t()) :: t()
+  def new(%__MODULE__{} = payload), do: payload
+
   def new(attrs) when is_map(attrs) do
     attrs
+    |> normalize_kind()
+    |> normalize_content()
+    |> normalize_metadata()
     |> normalize_attachments()
+    |> normalize_files()
+    |> normalize_stream()
     |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
   end
 
   @doc "Builds a text payload."
-  @spec text(String.t()) :: t()
-  def text(value) when is_binary(value), do: new(%{kind: :text, text: value, formatted: value})
+  @spec text(String.t(), keyword() | map()) :: t()
+  def text(value, opts \\ []) when is_binary(value) do
+    opts = normalize_opts(opts)
+    new(Map.merge(opts, %{kind: :text, text: value, formatted: value}))
+  end
 
   @doc "Builds a stream payload marker."
   @spec stream() :: t()
   def stream, do: new(%{kind: :stream})
+
+  @doc "Builds a stream payload from chunk input."
+  @spec stream(term(), keyword() | map()) :: t()
+  def stream(chunks, opts) do
+    opts = normalize_opts(opts)
+    new(Map.merge(opts, %{kind: :stream, stream: chunks}))
+  end
+
+  @doc "Returns the best text fallback for the payload."
+  @spec display_text(t()) :: String.t() | nil
+  def display_text(%__MODULE__{} = payload), do: payload.text || payload.fallback_text
+
+  @doc "Returns upload candidates preserving canonical file inputs where present."
+  @spec upload_candidates(t()) :: [Attachment.t() | FileUpload.t()]
+  def upload_candidates(%__MODULE__{} = payload) do
+    (payload.attachments || []) ++ (payload.files || [])
+  end
+
+  @doc "Returns outbound attachments including normalized file uploads."
+  @spec outbound_attachments(t()) :: [Attachment.t()]
+  def outbound_attachments(%__MODULE__{} = payload) do
+    attachment_uploads =
+      payload.files
+      |> Kernel.||([])
+      |> Enum.map(&Attachment.normalize/1)
+
+    (payload.attachments || []) ++ attachment_uploads
+  end
 
   @doc "Serializes post payload into plain map with type marker."
   @spec to_map(t()) :: map()
   def to_map(%__MODULE__{} = payload) do
     payload
     |> Map.from_struct()
+    |> Map.update!(:stream, &serialize_stream/1)
     |> Wire.to_plain()
     |> Map.put("__type__", "post_payload")
   end
 
   @doc "Builds post payload from serialized data."
   @spec from_map(map()) :: t()
-  def from_map(map) when is_map(map), do: new(map)
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_kind(attrs) do
+    kind =
+      attrs
+      |> Map.get(:kind, Map.get(attrs, "kind"))
+      |> normalize_kind_value()
+      |> Kernel.||(infer_kind(attrs))
+
+    Map.put(attrs, :kind, kind)
+  end
+
+  defp normalize_content(%{kind: :text} = attrs) do
+    text = attrs[:text] || attrs["text"]
+    formatted = attrs[:formatted] || attrs["formatted"] || text
+
+    attrs
+    |> Map.put(:text, text)
+    |> Map.put(:formatted, formatted)
+  end
+
+  defp normalize_content(%{kind: :markdown} = attrs) do
+    markdown = attrs[:markdown] || attrs["markdown"] || attrs[:text] || attrs["text"]
+    text = attrs[:text] || attrs["text"] || markdown
+    formatted = attrs[:formatted] || attrs["formatted"] || text
+
+    attrs
+    |> Map.put(:markdown, markdown)
+    |> Map.put(:text, text)
+    |> Map.put(:formatted, formatted)
+  end
+
+  defp normalize_content(%{kind: :raw} = attrs) do
+    raw = attrs[:raw] || attrs["raw"]
+    text = attrs[:text] || attrs["text"] || to_text_value(raw)
+    formatted = attrs[:formatted] || attrs["formatted"] || text
+
+    attrs
+    |> Map.put(:raw, raw)
+    |> Map.put(:text, text)
+    |> Map.put(:formatted, formatted)
+  end
+
+  defp normalize_content(%{kind: :ast} = attrs) do
+    ast = attrs[:ast] || attrs["ast"] || attrs[:raw] || attrs["raw"]
+    raw = attrs[:raw] || attrs["raw"] || ast
+    fallback_text = attrs[:fallback_text] || attrs["fallback_text"]
+    text = attrs[:text] || attrs["text"] || fallback_text || to_text_value(ast)
+    formatted = attrs[:formatted] || attrs["formatted"] || text
+
+    attrs
+    |> Map.put(:ast, ast)
+    |> Map.put(:raw, raw)
+    |> Map.put(:fallback_text, fallback_text)
+    |> Map.put(:text, text)
+    |> Map.put(:formatted, formatted)
+  end
+
+  defp normalize_content(%{kind: :card} = attrs) do
+    card = attrs[:card] || attrs["card"] || attrs[:raw] || attrs["raw"]
+    raw = attrs[:raw] || attrs["raw"] || card
+
+    fallback_text =
+      attrs[:fallback_text] || attrs["fallback_text"] || attrs[:text] || attrs["text"] ||
+        to_text_value(card)
+
+    text = attrs[:text] || attrs["text"] || fallback_text
+    formatted = attrs[:formatted] || attrs["formatted"] || text
+
+    attrs
+    |> Map.put(:card, card)
+    |> Map.put(:raw, raw)
+    |> Map.put(:fallback_text, fallback_text)
+    |> Map.put(:text, text)
+    |> Map.put(:formatted, formatted)
+  end
+
+  defp normalize_content(%{kind: :stream} = attrs) do
+    stream = attrs[:stream] || attrs["stream"] || attrs[:raw] || attrs["raw"]
+
+    fallback_text =
+      attrs[:fallback_text] || attrs["fallback_text"] || attrs[:text] || attrs["text"]
+
+    formatted = attrs[:formatted] || attrs["formatted"] || fallback_text
+
+    attrs
+    |> Map.put(:stream, stream)
+    |> Map.put(:fallback_text, fallback_text)
+    |> Map.put(:text, attrs[:text] || attrs["text"])
+    |> Map.put(:formatted, formatted)
+  end
+
+  defp normalize_metadata(attrs) do
+    metadata = attrs[:metadata] || attrs["metadata"] || %{}
+
+    metadata =
+      case attrs[:kind] do
+        :markdown -> Map.put_new(metadata, :format, :markdown)
+        :ast -> Map.put_new(metadata, :format, :ast)
+        :card -> Map.put_new(metadata, :format, :card)
+        _other -> metadata
+      end
+
+    attrs
+    |> Map.delete("metadata")
+    |> Map.put(:metadata, metadata)
+  end
 
   defp normalize_attachments(attrs) do
     attachments = attrs[:attachments] || attrs["attachments"] || []
@@ -64,4 +215,87 @@ defmodule Jido.Chat.PostPayload do
     |> Map.delete("attachments")
     |> Map.put(:attachments, Attachment.normalize_many(attachments))
   end
+
+  defp normalize_files(attrs) do
+    files = attrs[:files] || attrs["files"] || []
+
+    attrs
+    |> Map.delete("files")
+    |> Map.put(:files, FileUpload.normalize_many(files))
+  end
+
+  defp normalize_stream(attrs) do
+    stream = attrs[:stream] || attrs["stream"]
+
+    normalized =
+      case stream do
+        chunks when is_list(chunks) -> Enum.map(chunks, &normalize_stream_item/1)
+        other -> other
+      end
+
+    attrs
+    |> Map.delete("stream")
+    |> Map.put(:stream, normalized)
+  end
+
+  defp infer_kind(attrs) do
+    cond do
+      present?(attrs[:stream] || attrs["stream"]) -> :stream
+      present?(attrs[:card] || attrs["card"]) -> :card
+      present?(attrs[:ast] || attrs["ast"]) -> :ast
+      present?(attrs[:raw] || attrs["raw"]) -> :raw
+      present?(attrs[:markdown] || attrs["markdown"]) -> :markdown
+      true -> :text
+    end
+  end
+
+  defp normalize_kind_value(kind)
+       when kind in [:text, :markdown, :raw, :ast, :card, :stream],
+       do: kind
+
+  defp normalize_kind_value(kind) when is_binary(kind) do
+    case kind do
+      "text" -> :text
+      "markdown" -> :markdown
+      "raw" -> :raw
+      "ast" -> :ast
+      "card" -> :card
+      "stream" -> :stream
+      _ -> nil
+    end
+  end
+
+  defp normalize_kind_value(_kind), do: nil
+
+  defp normalize_opts(opts) when is_list(opts), do: Map.new(opts)
+  defp normalize_opts(opts) when is_map(opts), do: opts
+
+  defp normalize_stream_item(%StreamChunk{} = chunk), do: chunk
+  defp normalize_stream_item(chunk) when is_map(chunk), do: StreamChunk.new(chunk)
+  defp normalize_stream_item(chunk), do: chunk
+
+  defp serialize_stream(nil), do: nil
+
+  defp serialize_stream(chunks) when is_list(chunks) do
+    Enum.map(chunks, fn
+      %StreamChunk{} = chunk -> StreamChunk.to_map(chunk)
+      other -> Wire.to_plain(other)
+    end)
+  end
+
+  defp serialize_stream(_other), do: nil
+
+  defp to_text_value(nil), do: nil
+  defp to_text_value(value) when is_binary(value), do: value
+
+  defp to_text_value(value) do
+    case Jason.encode(value) do
+      {:ok, encoded} -> encoded
+      {:error, _reason} -> inspect(value)
+    end
+  end
+
+  defp present?(nil), do: false
+  defp present?(""), do: false
+  defp present?(_value), do: true
 end

--- a/lib/jido/chat/postable.ex
+++ b/lib/jido/chat/postable.ex
@@ -3,17 +3,23 @@ defmodule Jido.Chat.Postable do
   Typed post payload accepted by thread/channel post helpers.
   """
 
-  alias Jido.Chat.{Attachment, PostPayload}
+  alias Jido.Chat.{Attachment, FileUpload, PostPayload}
 
   @schema Zoi.struct(
             __MODULE__,
             %{
-              kind: Zoi.enum([:raw, :markdown, :ast, :card, :text]) |> Zoi.default(:text),
+              kind:
+                Zoi.enum([:raw, :markdown, :ast, :card, :text, :stream])
+                |> Zoi.default(:text),
               text: Zoi.string() |> Zoi.nullish(),
+              markdown: Zoi.string() |> Zoi.nullish(),
               raw: Zoi.any() |> Zoi.nullish(),
               ast: Zoi.any() |> Zoi.nullish(),
               card: Zoi.any() |> Zoi.nullish(),
+              stream: Zoi.any() |> Zoi.nullish(),
+              fallback_text: Zoi.string() |> Zoi.nullish(),
               attachments: Zoi.array(Zoi.struct(Attachment)) |> Zoi.default([]),
+              files: Zoi.array(Zoi.struct(FileUpload)) |> Zoi.default([]),
               metadata: Zoi.map() |> Zoi.default(%{})
             },
             coerce: true
@@ -32,111 +38,57 @@ defmodule Jido.Chat.Postable do
 
   def new(attrs) when is_map(attrs) do
     attrs
-    |> normalize_attachments()
+    |> PostPayload.new()
+    |> Map.from_struct()
+    |> Map.take([
+      :kind,
+      :text,
+      :markdown,
+      :raw,
+      :ast,
+      :card,
+      :stream,
+      :fallback_text,
+      :attachments,
+      :files,
+      :metadata
+    ])
     |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
   end
 
   @doc "Builds a text post payload."
-  def text(value) when is_binary(value), do: new(%{kind: :text, text: value})
+  def text(value, opts \\ []) when is_binary(value),
+    do: new(Map.merge(normalize_opts(opts), %{kind: :text, text: value}))
 
   @doc "Builds a markdown post payload."
-  def markdown(value) when is_binary(value), do: new(%{kind: :markdown, text: value})
+  def markdown(value, opts \\ []) when is_binary(value),
+    do: new(Map.merge(normalize_opts(opts), %{kind: :markdown, markdown: value, text: value}))
 
   @doc "Builds a raw payload wrapper."
-  def raw(value), do: new(%{kind: :raw, raw: value})
+  def raw(value, opts \\ []), do: new(Map.merge(normalize_opts(opts), %{kind: :raw, raw: value}))
 
   @doc "Builds an AST payload wrapper."
-  def ast(value), do: new(%{kind: :ast, ast: value})
+  def ast(value, opts \\ []), do: new(Map.merge(normalize_opts(opts), %{kind: :ast, ast: value}))
 
   @doc "Builds a card payload wrapper."
-  def card(value), do: new(%{kind: :card, card: value})
+  def card(value, opts \\ []),
+    do: new(Map.merge(normalize_opts(opts), %{kind: :card, card: value}))
+
+  @doc "Builds a stream payload wrapper."
+  def stream(chunks, opts \\ []),
+    do: new(Map.merge(normalize_opts(opts), %{kind: :stream, stream: chunks}))
 
   @doc "Builds a normalized outbound payload preserving post intent."
   @spec to_payload(t()) :: PostPayload.t()
-  def to_payload(%__MODULE__{} = postable) do
-    attachments = postable.attachments || []
-    metadata = postable.metadata || %{}
-
-    case postable.kind do
-      :text ->
-        PostPayload.new(%{
-          kind: :text,
-          text: postable.text,
-          formatted: postable.text,
-          attachments: attachments,
-          metadata: metadata
-        })
-
-      :markdown ->
-        text = postable.text || ""
-
-        PostPayload.new(%{
-          kind: :markdown,
-          text: text,
-          formatted: text,
-          attachments: attachments,
-          metadata: Map.put(metadata, :format, :markdown)
-        })
-
-      :raw ->
-        text = to_text_value(postable.raw)
-
-        PostPayload.new(%{
-          kind: :raw,
-          text: text,
-          formatted: text,
-          raw: postable.raw,
-          attachments: attachments,
-          metadata: metadata
-        })
-
-      :ast ->
-        text = to_text_value(postable.ast)
-
-        PostPayload.new(%{
-          kind: :ast,
-          text: text,
-          formatted: text,
-          raw: postable.ast,
-          attachments: attachments,
-          metadata: Map.put(metadata, :format, :ast)
-        })
-
-      :card ->
-        text = to_text_value(postable.card)
-
-        PostPayload.new(%{
-          kind: :card,
-          text: text,
-          formatted: text,
-          raw: postable.card,
-          attachments: attachments,
-          metadata: Map.put(metadata, :format, :card)
-        })
-    end
-  end
+  def to_payload(%__MODULE__{} = postable), do: postable |> Map.from_struct() |> PostPayload.new()
 
   @doc "Flattens postable payload into adapter-safe text."
   @spec to_text(t()) :: String.t()
   def to_text(%__MODULE__{} = postable) do
     payload = to_payload(postable)
-    payload.text || ""
+    PostPayload.display_text(payload) || ""
   end
 
-  defp to_text_value(value) when is_binary(value), do: value
-
-  defp to_text_value(value) do
-    case Jason.encode(value) do
-      {:ok, encoded} -> encoded
-      {:error, _reason} -> inspect(value)
-    end
-  end
-
-  defp normalize_attachments(attrs) do
-    attachments = attrs[:attachments] || attrs["attachments"] || []
-
-    attrs
-    |> Map.delete("attachments")
-    |> Map.put(:attachments, Attachment.normalize_many(attachments))
-  end
+  defp normalize_opts(opts) when is_list(opts), do: Map.new(opts)
+  defp normalize_opts(opts) when is_map(opts), do: opts
 end

--- a/lib/jido/chat/postable.ex
+++ b/lib/jido/chat/postable.ex
@@ -3,7 +3,7 @@ defmodule Jido.Chat.Postable do
   Typed post payload accepted by thread/channel post helpers.
   """
 
-  alias Jido.Chat.{Attachment, FileUpload, PostPayload}
+  alias Jido.Chat.{Attachment, Card, FileUpload, Markdown, PostPayload}
 
   @schema Zoi.struct(
             __MODULE__,
@@ -61,8 +61,20 @@ defmodule Jido.Chat.Postable do
     do: new(Map.merge(normalize_opts(opts), %{kind: :text, text: value}))
 
   @doc "Builds a markdown post payload."
-  def markdown(value, opts \\ []) when is_binary(value),
+  def markdown(value, opts \\ [])
+
+  def markdown(value, opts) when is_binary(value),
     do: new(Map.merge(normalize_opts(opts), %{kind: :markdown, markdown: value, text: value}))
+
+  def markdown(%Markdown{} = value, opts) do
+    new(
+      Map.merge(normalize_opts(opts), %{
+        kind: :markdown,
+        markdown: Markdown.stringify(value),
+        text: Markdown.plain_text(value)
+      })
+    )
+  end
 
   @doc "Builds a raw payload wrapper."
   def raw(value, opts \\ []), do: new(Map.merge(normalize_opts(opts), %{kind: :raw, raw: value}))
@@ -71,7 +83,12 @@ defmodule Jido.Chat.Postable do
   def ast(value, opts \\ []), do: new(Map.merge(normalize_opts(opts), %{kind: :ast, ast: value}))
 
   @doc "Builds a card payload wrapper."
-  def card(value, opts \\ []),
+  def card(value, opts \\ [])
+
+  def card(%Card{} = value, opts),
+    do: new(Map.merge(normalize_opts(opts), %{kind: :card, card: value}))
+
+  def card(value, opts),
     do: new(Map.merge(normalize_opts(opts), %{kind: :card, card: value}))
 
   @doc "Builds a stream payload wrapper."

--- a/lib/jido/chat/reaction_event.ex
+++ b/lib/jido/chat/reaction_event.ex
@@ -3,17 +3,26 @@ defmodule Jido.Chat.ReactionEvent do
   Normalized reaction event payload placeholder for Phase 2.
   """
 
-  alias Jido.Chat.Author
+  alias Jido.Chat.{Author, ChannelRef, Message, Thread, Wire}
 
   @schema Zoi.struct(
             __MODULE__,
             %{
+              adapter: Zoi.any() |> Zoi.nullish(),
               adapter_name: Zoi.atom() |> Zoi.nullish(),
               thread_id: Zoi.string() |> Zoi.nullish(),
+              channel_id: Zoi.string() |> Zoi.nullish(),
               message_id: Zoi.string() |> Zoi.nullish(),
               emoji: Zoi.string() |> Zoi.nullish(),
               added: Zoi.boolean() |> Zoi.default(true),
+              trigger_id: Zoi.string() |> Zoi.nullish(),
               user: Zoi.struct(Author) |> Zoi.nullish(),
+              thread: Zoi.struct(Thread) |> Zoi.nullish(),
+              channel: Zoi.struct(ChannelRef) |> Zoi.nullish(),
+              message: Zoi.struct(Message) |> Zoi.nullish(),
+              related_thread: Zoi.struct(Thread) |> Zoi.nullish(),
+              related_channel: Zoi.struct(ChannelRef) |> Zoi.nullish(),
+              related_message: Zoi.struct(Message) |> Zoi.nullish(),
               raw: Zoi.map() |> Zoi.default(%{}),
               metadata: Zoi.map() |> Zoi.default(%{})
             },
@@ -29,5 +38,71 @@ defmodule Jido.Chat.ReactionEvent do
   def schema, do: @schema
 
   @doc "Creates a normalized reaction event payload."
-  def new(attrs) when is_map(attrs), do: Jido.Chat.Schema.parse!(__MODULE__, @schema, attrs)
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_author()
+    |> normalize_handles()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Serializes the reaction event into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = event) do
+    event
+    |> Map.from_struct()
+    |> serialize_handles()
+    |> Wire.to_plain()
+    |> Map.put("__type__", "reaction_event")
+  end
+
+  @doc "Builds a reaction event from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_author(%{user: %Author{}} = attrs), do: attrs
+  defp normalize_author(%{"user" => %Author{}} = attrs), do: attrs
+
+  defp normalize_author(attrs) do
+    case attrs[:user] || attrs["user"] do
+      %{} = user -> Map.delete(attrs, "user") |> Map.put(:user, Author.new(user))
+      _ -> attrs
+    end
+  end
+
+  defp normalize_handles(attrs) do
+    attrs
+    |> normalize_handle(:thread, Thread)
+    |> normalize_handle(:channel, ChannelRef)
+    |> normalize_handle(:message, Message)
+    |> normalize_handle(:related_thread, Thread)
+    |> normalize_handle(:related_channel, ChannelRef)
+    |> normalize_handle(:related_message, Message)
+  end
+
+  defp normalize_handle(attrs, key, mod) do
+    case attrs[key] || attrs[Atom.to_string(key)] do
+      %{__struct__: ^mod} = value ->
+        attrs |> Map.delete(Atom.to_string(key)) |> Map.put(key, value)
+
+      %{} = value ->
+        attrs |> Map.delete(Atom.to_string(key)) |> Map.put(key, mod.new(value))
+
+      _ ->
+        attrs
+    end
+  end
+
+  defp serialize_handles(map) do
+    map
+    |> Map.update!(:adapter, &Wire.encode_module/1)
+    |> Map.update!(:thread, fn value -> serialize_handle(value, &Thread.to_map/1) end)
+    |> Map.update!(:channel, fn value -> serialize_handle(value, &ChannelRef.to_map/1) end)
+    |> Map.update!(:message, fn value -> serialize_handle(value, &Message.to_map/1) end)
+    |> Map.update!(:related_thread, fn value -> serialize_handle(value, &Thread.to_map/1) end)
+    |> Map.update!(:related_channel, fn value -> serialize_handle(value, &ChannelRef.to_map/1) end)
+    |> Map.update!(:related_message, fn value -> serialize_handle(value, &Message.to_map/1) end)
+  end
+
+  defp serialize_handle(nil, _fun), do: nil
+  defp serialize_handle(value, fun), do: fun.(value)
 end

--- a/lib/jido/chat/sent_message.ex
+++ b/lib/jido/chat/sent_message.ex
@@ -3,7 +3,7 @@ defmodule Jido.Chat.SentMessage do
   Canonical sent-message handle with follow-up lifecycle operations.
   """
 
-  alias Jido.Chat.{Adapter, Attachment, Author, PostPayload, Postable, Response, Wire}
+  alias Jido.Chat.{Adapter, Attachment, Author, Emoji, PostPayload, Postable, Response, Wire}
 
   @schema Zoi.struct(
             __MODULE__,
@@ -75,8 +75,10 @@ defmodule Jido.Chat.SentMessage do
   end
 
   @doc "Adds a reaction to the message when supported by the adapter."
-  @spec add_reaction(t(), String.t(), keyword()) :: :ok | {:error, term()}
-  def add_reaction(%__MODULE__{} = sent, emoji, opts \\ []) when is_binary(emoji) do
+  @spec add_reaction(t(), String.t() | atom(), keyword()) :: :ok | {:error, term()}
+  def add_reaction(%__MODULE__{} = sent, emoji, opts \\ []) do
+    emoji = Emoji.render(emoji, custom: opts[:custom_emoji])
+
     Adapter.add_reaction(
       sent.adapter,
       sent.external_room_id,
@@ -87,8 +89,10 @@ defmodule Jido.Chat.SentMessage do
   end
 
   @doc "Removes a reaction from the message when supported by the adapter."
-  @spec remove_reaction(t(), String.t(), keyword()) :: :ok | {:error, term()}
-  def remove_reaction(%__MODULE__{} = sent, emoji, opts \\ []) when is_binary(emoji) do
+  @spec remove_reaction(t(), String.t() | atom(), keyword()) :: :ok | {:error, term()}
+  def remove_reaction(%__MODULE__{} = sent, emoji, opts \\ []) do
+    emoji = Emoji.render(emoji, custom: opts[:custom_emoji])
+
     Adapter.remove_reaction(
       sent.adapter,
       sent.external_room_id,

--- a/lib/jido/chat/sent_message.ex
+++ b/lib/jido/chat/sent_message.ex
@@ -3,7 +3,7 @@ defmodule Jido.Chat.SentMessage do
   Canonical sent-message handle with follow-up lifecycle operations.
   """
 
-  alias Jido.Chat.{Adapter, Attachment, Author, Response, Wire}
+  alias Jido.Chat.{Adapter, Attachment, Author, PostPayload, Postable, Response, Wire}
 
   @schema Zoi.struct(
             __MODULE__,
@@ -43,28 +43,29 @@ defmodule Jido.Chat.SentMessage do
     |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
   end
 
-  @doc "Edits the message text and returns an updated sent-message handle."
-  @spec edit(t(), String.t(), keyword()) :: {:ok, t()} | {:error, term()}
-  def edit(%__MODULE__{} = sent, text, opts \\ []) when is_binary(text) do
-    with {:ok, response} <-
-           Adapter.edit_message(
-             sent.adapter,
-             sent.external_room_id,
-             sent.id,
-             text,
-             merge_opts(sent, opts)
-           ) do
-      {:ok,
-       %{
-         sent
-         | id: response.external_message_id || sent.id,
-           external_room_id: response.external_room_id || sent.external_room_id,
-           response: response,
-           text: text,
-           formatted: text,
-           raw: response.raw
-       }}
-    end
+  @doc "Edits the message using the canonical outbound payload contract."
+  @spec edit(t(), String.t() | Postable.t() | map(), keyword()) :: {:ok, t()} | {:error, term()}
+  def edit(message, input, opts \\ [])
+
+  def edit(%__MODULE__{} = sent, text, opts) when is_binary(text) do
+    text
+    |> PostPayload.text()
+    |> then(&edit_payload(sent, &1, opts))
+  end
+
+  def edit(%__MODULE__{} = sent, %Postable{} = postable, opts) do
+    postable
+    |> Postable.to_payload()
+    |> then(&edit_payload(sent, &1, opts))
+  end
+
+  def edit(%__MODULE__{} = sent, postable_map, opts) when is_map(postable_map) do
+    postable_map
+    |> Postable.new()
+    |> Postable.to_payload()
+    |> then(&edit_payload(sent, &1, opts))
+  rescue
+    _ -> {:error, :invalid_postable}
   end
 
   @doc "Deletes the message when supported by the adapter."
@@ -186,4 +187,39 @@ defmodule Jido.Chat.SentMessage do
        do: Keyword.merge(defaults, opts)
 
   defp merge_opts(_sent, opts), do: opts
+
+  defp edit_payload(%__MODULE__{} = sent, %PostPayload{} = payload, opts) do
+    upload_candidates = PostPayload.upload_candidates(payload)
+    text = PostPayload.display_text(payload)
+
+    cond do
+      payload.kind == :stream ->
+        {:error, :edit_stream_unsupported}
+
+      upload_candidates != [] ->
+        {:error, :edit_attachments_unsupported}
+
+      true ->
+        with {:ok, response} <-
+               Adapter.edit_message(
+                 sent.adapter,
+                 sent.external_room_id,
+                 sent.id,
+                 text || "",
+                 merge_opts(sent, opts)
+               ) do
+          {:ok,
+           %{
+             sent
+             | id: response.external_message_id || sent.id,
+               external_room_id: response.external_room_id || sent.external_room_id,
+               response: response,
+               text: text,
+               formatted: payload.formatted || text,
+               raw: payload.raw || response.raw,
+               metadata: Map.merge(sent.metadata || %{}, payload.metadata || %{})
+           }}
+        end
+    end
+  end
 end

--- a/lib/jido/chat/serialization.ex
+++ b/lib/jido/chat/serialization.ex
@@ -5,10 +5,13 @@ defmodule Jido.Chat.Serialization do
     CapabilityMatrix,
     ChannelRef,
     EventEnvelope,
+    FileUpload,
     IngressResult,
     Message,
     ModalResult,
+    PostPayload,
     SentMessage,
+    StreamChunk,
     Thread,
     WebhookRequest,
     WebhookResponse,
@@ -66,7 +69,10 @@ defmodule Jido.Chat.Serialization do
   def revive(%{"__type__" => "thread"} = map), do: Thread.from_map(map)
   def revive(%{"__type__" => "channel"} = map), do: ChannelRef.from_map(map)
   def revive(%{"__type__" => "message"} = map), do: Message.from_map(map)
+  def revive(%{"__type__" => "file_upload"} = map), do: FileUpload.from_map(map)
+  def revive(%{"__type__" => "post_payload"} = map), do: PostPayload.from_map(map)
   def revive(%{"__type__" => "sent_message"} = map), do: SentMessage.from_map(map)
+  def revive(%{"__type__" => "stream_chunk"} = map), do: StreamChunk.from_map(map)
   def revive(%{"__type__" => "event_envelope"} = map), do: EventEnvelope.from_map(map)
   def revive(%{"__type__" => "ingress_result"} = map), do: IngressResult.from_map(map)
   def revive(%{"__type__" => "modal_result"} = map), do: ModalResult.from_map(map)

--- a/lib/jido/chat/serialization.ex
+++ b/lib/jido/chat/serialization.ex
@@ -32,6 +32,8 @@ defmodule Jido.Chat.Serialization do
 
   @spec to_map(map()) :: map()
   def to_map(chat) when is_map(chat) do
+    snapshot = Jido.Chat.StateAdapter.snapshot(chat.state_adapter, chat.state)
+
     %{
       id: chat.id,
       user_name: chat.user_name,
@@ -44,6 +46,8 @@ defmodule Jido.Chat.Serialization do
       metadata: Wire.to_plain(chat.metadata),
       thread_state: Wire.to_plain(chat.thread_state),
       channel_state: Wire.to_plain(chat.channel_state),
+      locks: Wire.to_plain(snapshot.locks),
+      pending_locks: Wire.to_plain(snapshot.pending_locks),
       initialized: chat.initialized
     }
     |> Wire.to_plain()
@@ -63,7 +67,9 @@ defmodule Jido.Chat.Serialization do
         dedupe: map[:dedupe] || map["dedupe"] || [],
         dedupe_order: map[:dedupe_order] || map["dedupe_order"] || [],
         thread_state: map[:thread_state] || map["thread_state"] || %{},
-        channel_state: map[:channel_state] || map["channel_state"] || %{}
+        channel_state: map[:channel_state] || map["channel_state"] || %{},
+        locks: map[:locks] || map["locks"] || %{},
+        pending_locks: map[:pending_locks] || map["pending_locks"] || %{}
       })
 
     %{

--- a/lib/jido/chat/serialization.ex
+++ b/lib/jido/chat/serialization.ex
@@ -2,19 +2,27 @@ defmodule Jido.Chat.Serialization do
   @moduledoc false
 
   alias Jido.Chat.{
+    ActionEvent,
+    AssistantContextChangedEvent,
+    AssistantThreadStartedEvent,
     Card,
     CapabilityMatrix,
     ChannelRef,
     EventEnvelope,
     FileUpload,
+    Incoming,
     IngressResult,
     Markdown,
     Message,
     Modal,
+    ModalCloseEvent,
     ModalResult,
+    ModalSubmitEvent,
     ModalResponse,
     PostPayload,
+    ReactionEvent,
     SentMessage,
+    SlashCommandEvent,
     StreamChunk,
     Thread,
     WebhookRequest,
@@ -72,6 +80,19 @@ defmodule Jido.Chat.Serialization do
   def revive(%{"__type__" => "chat"} = map), do: from_map(map)
   def revive(%{"__type__" => "thread"} = map), do: Thread.from_map(map)
   def revive(%{"__type__" => "channel"} = map), do: ChannelRef.from_map(map)
+  def revive(%{"__type__" => "incoming"} = map), do: Incoming.from_map(map)
+  def revive(%{"__type__" => "reaction_event"} = map), do: ReactionEvent.from_map(map)
+  def revive(%{"__type__" => "action_event"} = map), do: ActionEvent.from_map(map)
+  def revive(%{"__type__" => "modal_submit_event"} = map), do: ModalSubmitEvent.from_map(map)
+  def revive(%{"__type__" => "modal_close_event"} = map), do: ModalCloseEvent.from_map(map)
+  def revive(%{"__type__" => "slash_command_event"} = map), do: SlashCommandEvent.from_map(map)
+
+  def revive(%{"__type__" => "assistant_thread_started_event"} = map),
+    do: AssistantThreadStartedEvent.from_map(map)
+
+  def revive(%{"__type__" => "assistant_context_changed_event"} = map),
+    do: AssistantContextChangedEvent.from_map(map)
+
   def revive(%{"__type__" => "markdown"} = map), do: Markdown.from_map(map)
   def revive(%{"__type__" => "markdown_node"} = map), do: Jido.Chat.Markdown.Node.from_map(map)
   def revive(%{"__type__" => "card"} = map), do: Card.from_map(map)

--- a/lib/jido/chat/serialization.ex
+++ b/lib/jido/chat/serialization.ex
@@ -21,6 +21,7 @@ defmodule Jido.Chat.Serialization do
       id: chat.id,
       user_name: chat.user_name,
       adapters: serialize_adapters(chat.adapters),
+      state_adapter: Wire.encode_module(chat.state_adapter),
       subscriptions: chat.subscriptions |> MapSet.to_list() |> Enum.sort(),
       dedupe: serialize_dedupe(chat.dedupe),
       dedupe_order: serialize_dedupe_order(chat.dedupe_order || []),
@@ -41,24 +42,19 @@ defmodule Jido.Chat.Serialization do
         id: map[:id] || map["id"],
         user_name: map[:user_name] || map["user_name"],
         adapters: deserialize_adapters(map[:adapters] || map["adapters"] || %{}),
+        state_adapter: map[:state_adapter] || map["state_adapter"],
         metadata: map[:metadata] || map["metadata"] || %{},
+        subscriptions: map[:subscriptions] || map["subscriptions"] || [],
+        dedupe: map[:dedupe] || map["dedupe"] || [],
+        dedupe_order: map[:dedupe_order] || map["dedupe_order"] || [],
         thread_state: map[:thread_state] || map["thread_state"] || %{},
         channel_state: map[:channel_state] || map["channel_state"] || %{}
       })
 
-    subscriptions = map[:subscriptions] || map["subscriptions"] || []
-    dedupe = map[:dedupe] || map["dedupe"] || []
-    dedupe_order = map[:dedupe_order] || map["dedupe_order"] || dedupe
-
     %{
       chat
       | initialized: map[:initialized] || map["initialized"] || false,
-        dedupe: deserialize_dedupe(dedupe),
-        dedupe_order: deserialize_dedupe_order(dedupe_order),
-        subscriptions: deserialize_subscriptions(subscriptions),
-        handlers: deserialize_handlers(map[:handlers] || map["handlers"] || %{}, chat.handlers),
-        thread_state: map[:thread_state] || map["thread_state"] || %{},
-        channel_state: map[:channel_state] || map["channel_state"] || %{}
+        handlers: deserialize_handlers(map[:handlers] || map["handlers"] || %{}, chat.handlers)
     }
   end
 
@@ -115,23 +111,6 @@ defmodule Jido.Chat.Serialization do
 
   defp deserialize_adapters(_), do: %{}
 
-  defp deserialize_dedupe(dedupe) when is_list(dedupe) do
-    dedupe
-    |> Enum.reduce(MapSet.new(), fn
-      [adapter_name, message_id], acc ->
-        MapSet.put(acc, {normalize_key_atom(adapter_name), to_string(message_id)})
-
-      {adapter_name, message_id}, acc ->
-        MapSet.put(acc, {normalize_key_atom(adapter_name), to_string(message_id)})
-
-      _other, acc ->
-        acc
-    end)
-  end
-
-  defp deserialize_dedupe(%MapSet{} = dedupe), do: dedupe
-  defp deserialize_dedupe(_), do: MapSet.new()
-
   defp serialize_dedupe_order(dedupe_order) when is_list(dedupe_order) do
     dedupe_order
     |> Enum.map(fn
@@ -143,32 +122,6 @@ defmodule Jido.Chat.Serialization do
   end
 
   defp serialize_dedupe_order(_), do: []
-
-  defp deserialize_dedupe_order(dedupe_order) when is_list(dedupe_order) do
-    dedupe_order
-    |> Enum.reduce([], fn
-      [adapter_name, message_id], acc ->
-        [{normalize_key_atom(adapter_name), to_string(message_id)} | acc]
-
-      {adapter_name, message_id}, acc ->
-        [{normalize_key_atom(adapter_name), to_string(message_id)} | acc]
-
-      _other, acc ->
-        acc
-    end)
-    |> Enum.reverse()
-  end
-
-  defp deserialize_dedupe_order(_), do: []
-
-  defp deserialize_subscriptions(subscriptions) when is_list(subscriptions) do
-    subscriptions
-    |> Enum.map(&to_string/1)
-    |> MapSet.new()
-  end
-
-  defp deserialize_subscriptions(%MapSet{} = subscriptions), do: subscriptions
-  defp deserialize_subscriptions(_), do: MapSet.new()
 
   defp deserialize_handlers(handlers, defaults) when is_map(handlers) and is_map(defaults) do
     serializable? = handlers[:serializable] || handlers["serializable"] || false

--- a/lib/jido/chat/serialization.ex
+++ b/lib/jido/chat/serialization.ex
@@ -2,13 +2,17 @@ defmodule Jido.Chat.Serialization do
   @moduledoc false
 
   alias Jido.Chat.{
+    Card,
     CapabilityMatrix,
     ChannelRef,
     EventEnvelope,
     FileUpload,
     IngressResult,
+    Markdown,
     Message,
+    Modal,
     ModalResult,
+    ModalResponse,
     PostPayload,
     SentMessage,
     StreamChunk,
@@ -68,6 +72,12 @@ defmodule Jido.Chat.Serialization do
   def revive(%{"__type__" => "chat"} = map), do: from_map(map)
   def revive(%{"__type__" => "thread"} = map), do: Thread.from_map(map)
   def revive(%{"__type__" => "channel"} = map), do: ChannelRef.from_map(map)
+  def revive(%{"__type__" => "markdown"} = map), do: Markdown.from_map(map)
+  def revive(%{"__type__" => "markdown_node"} = map), do: Jido.Chat.Markdown.Node.from_map(map)
+  def revive(%{"__type__" => "card"} = map), do: Card.from_map(map)
+  def revive(%{"__type__" => "card_component"} = map), do: Jido.Chat.Card.Component.from_map(map)
+  def revive(%{"__type__" => "modal"} = map), do: Modal.from_map(map)
+  def revive(%{"__type__" => "modal_element"} = map), do: Jido.Chat.Modal.Element.from_map(map)
   def revive(%{"__type__" => "message"} = map), do: Message.from_map(map)
   def revive(%{"__type__" => "file_upload"} = map), do: FileUpload.from_map(map)
   def revive(%{"__type__" => "post_payload"} = map), do: PostPayload.from_map(map)
@@ -76,6 +86,7 @@ defmodule Jido.Chat.Serialization do
   def revive(%{"__type__" => "event_envelope"} = map), do: EventEnvelope.from_map(map)
   def revive(%{"__type__" => "ingress_result"} = map), do: IngressResult.from_map(map)
   def revive(%{"__type__" => "modal_result"} = map), do: ModalResult.from_map(map)
+  def revive(%{"__type__" => "modal_response"} = map), do: ModalResponse.from_map(map)
   def revive(%{"__type__" => "capability_matrix"} = map), do: CapabilityMatrix.from_map(map)
   def revive(%{"__type__" => "webhook_request"} = map), do: WebhookRequest.from_map(map)
   def revive(%{"__type__" => "webhook_response"} = map), do: WebhookResponse.from_map(map)

--- a/lib/jido/chat/slash_command_event.ex
+++ b/lib/jido/chat/slash_command_event.ex
@@ -3,17 +3,26 @@ defmodule Jido.Chat.SlashCommandEvent do
   Normalized slash-command event payload placeholder for Phase 2.
   """
 
-  alias Jido.Chat.Author
+  alias Jido.Chat.{Author, ChannelRef, Message, Modal, ModalResult, Thread, Wire}
 
   @schema Zoi.struct(
             __MODULE__,
             %{
+              adapter: Zoi.any() |> Zoi.nullish(),
               adapter_name: Zoi.atom() |> Zoi.nullish(),
+              thread_id: Zoi.string() |> Zoi.nullish(),
               channel_id: Zoi.string() |> Zoi.nullish(),
+              message_id: Zoi.string() |> Zoi.nullish(),
               command: Zoi.string() |> Zoi.nullish(),
               text: Zoi.string() |> Zoi.nullish(),
               trigger_id: Zoi.string() |> Zoi.nullish(),
               user: Zoi.struct(Author) |> Zoi.nullish(),
+              thread: Zoi.struct(Thread) |> Zoi.nullish(),
+              channel: Zoi.struct(ChannelRef) |> Zoi.nullish(),
+              message: Zoi.struct(Message) |> Zoi.nullish(),
+              related_thread: Zoi.struct(Thread) |> Zoi.nullish(),
+              related_channel: Zoi.struct(ChannelRef) |> Zoi.nullish(),
+              related_message: Zoi.struct(Message) |> Zoi.nullish(),
               raw: Zoi.map() |> Zoi.default(%{}),
               metadata: Zoi.map() |> Zoi.default(%{})
             },
@@ -29,5 +38,85 @@ defmodule Jido.Chat.SlashCommandEvent do
   def schema, do: @schema
 
   @doc "Creates a normalized slash-command event payload."
-  def new(attrs) when is_map(attrs), do: Jido.Chat.Schema.parse!(__MODULE__, @schema, attrs)
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_author()
+    |> normalize_handles()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Opens a modal using the slash command event context."
+  def open_modal(event, payload, opts \\ [])
+
+  @spec open_modal(t(), Modal.t() | map(), keyword()) :: {:ok, ModalResult.t()} | {:error, term()}
+  def open_modal(%__MODULE__{thread: %Thread{} = thread}, payload, opts) do
+    Thread.open_modal(thread, payload, opts)
+  end
+
+  def open_modal(%__MODULE__{channel: %ChannelRef{} = channel}, payload, opts) do
+    ChannelRef.open_modal(channel, payload, opts)
+  end
+
+  def open_modal(%__MODULE__{}, _payload, _opts), do: {:error, :missing_modal_target}
+
+  @doc "Serializes the slash command event into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = event) do
+    event
+    |> Map.from_struct()
+    |> serialize_handles()
+    |> Wire.to_plain()
+    |> Map.put("__type__", "slash_command_event")
+  end
+
+  @doc "Builds a slash command event from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_author(%{user: %Author{}} = attrs), do: attrs
+  defp normalize_author(%{"user" => %Author{}} = attrs), do: attrs
+
+  defp normalize_author(attrs) do
+    case attrs[:user] || attrs["user"] do
+      %{} = user -> Map.delete(attrs, "user") |> Map.put(:user, Author.new(user))
+      _ -> attrs
+    end
+  end
+
+  defp normalize_handles(attrs) do
+    attrs
+    |> normalize_handle(:thread, Thread)
+    |> normalize_handle(:channel, ChannelRef)
+    |> normalize_handle(:message, Message)
+    |> normalize_handle(:related_thread, Thread)
+    |> normalize_handle(:related_channel, ChannelRef)
+    |> normalize_handle(:related_message, Message)
+  end
+
+  defp normalize_handle(attrs, key, mod) do
+    case attrs[key] || attrs[Atom.to_string(key)] do
+      %{__struct__: ^mod} = value ->
+        attrs |> Map.delete(Atom.to_string(key)) |> Map.put(key, value)
+
+      %{} = value ->
+        attrs |> Map.delete(Atom.to_string(key)) |> Map.put(key, mod.new(value))
+
+      _ ->
+        attrs
+    end
+  end
+
+  defp serialize_handles(map) do
+    map
+    |> Map.update!(:adapter, &Wire.encode_module/1)
+    |> Map.update!(:thread, fn value -> serialize_handle(value, &Thread.to_map/1) end)
+    |> Map.update!(:channel, fn value -> serialize_handle(value, &ChannelRef.to_map/1) end)
+    |> Map.update!(:message, fn value -> serialize_handle(value, &Message.to_map/1) end)
+    |> Map.update!(:related_thread, fn value -> serialize_handle(value, &Thread.to_map/1) end)
+    |> Map.update!(:related_channel, fn value -> serialize_handle(value, &ChannelRef.to_map/1) end)
+    |> Map.update!(:related_message, fn value -> serialize_handle(value, &Message.to_map/1) end)
+  end
+
+  defp serialize_handle(nil, _fun), do: nil
+  defp serialize_handle(value, fun), do: fun.(value)
 end

--- a/lib/jido/chat/state_adapter.ex
+++ b/lib/jido/chat/state_adapter.ex
@@ -1,0 +1,234 @@
+defmodule Jido.Chat.StateAdapter do
+  @moduledoc """
+  Behavior and helpers for pluggable chat state storage.
+
+  State adapters own subscriptions, dedupe windows, and per-thread / per-channel
+  state maps. The default adapter keeps everything in memory, but adapters may
+  persist state elsewhere as long as they can expose a normalized snapshot.
+  """
+
+  @type dedupe_key :: {atom(), String.t()}
+
+  @type snapshot :: %{
+          subscriptions: MapSet.t(String.t()),
+          dedupe: MapSet.t(dedupe_key()),
+          dedupe_order: [dedupe_key()],
+          thread_state: %{optional(String.t()) => map()},
+          channel_state: %{optional(String.t()) => map()}
+        }
+
+  @type state :: term()
+
+  @callback init(snapshot(), keyword()) :: state()
+  @callback snapshot(state()) :: snapshot() | map()
+  @callback subscribed?(state(), String.t()) :: boolean()
+  @callback subscribe(state(), String.t()) :: state()
+  @callback unsubscribe(state(), String.t()) :: state()
+  @callback thread_state(state(), String.t()) :: map()
+  @callback put_thread_state(state(), String.t(), map()) :: state()
+  @callback channel_state(state(), String.t()) :: map()
+  @callback put_channel_state(state(), String.t(), map()) :: state()
+  @callback duplicate?(state(), dedupe_key()) :: boolean()
+  @callback mark_dedupe(state(), dedupe_key(), pos_integer()) :: state()
+
+  @doc "Initializes adapter state from a normalized snapshot."
+  @spec init(module(), map(), keyword()) :: state()
+  def init(adapter_module, snapshot, opts \\ []) when is_atom(adapter_module) do
+    adapter_module.init(normalize_snapshot(snapshot), opts)
+  end
+
+  @doc "Returns a normalized snapshot for adapter-managed state."
+  @spec snapshot(module(), state()) :: snapshot()
+  def snapshot(adapter_module, state) when is_atom(adapter_module) do
+    adapter_module.snapshot(state)
+    |> normalize_snapshot()
+  end
+
+  @doc "Returns true when the thread is subscribed in adapter-managed state."
+  @spec subscribed?(module(), state(), String.t()) :: boolean()
+  def subscribed?(adapter_module, state, thread_id)
+      when is_atom(adapter_module) and is_binary(thread_id) do
+    adapter_module.subscribed?(state, thread_id)
+  end
+
+  @doc "Adds a subscribed thread id to adapter-managed state."
+  @spec subscribe(module(), state(), String.t()) :: state()
+  def subscribe(adapter_module, state, thread_id)
+      when is_atom(adapter_module) and is_binary(thread_id) do
+    adapter_module.subscribe(state, thread_id)
+  end
+
+  @doc "Removes a subscribed thread id from adapter-managed state."
+  @spec unsubscribe(module(), state(), String.t()) :: state()
+  def unsubscribe(adapter_module, state, thread_id)
+      when is_atom(adapter_module) and is_binary(thread_id) do
+    adapter_module.unsubscribe(state, thread_id)
+  end
+
+  @doc "Returns thread state map from adapter-managed state."
+  @spec thread_state(module(), state(), String.t()) :: map()
+  def thread_state(adapter_module, state, thread_id)
+      when is_atom(adapter_module) and is_binary(thread_id) do
+    adapter_module.thread_state(state, thread_id)
+  end
+
+  @doc "Writes thread state map into adapter-managed state."
+  @spec put_thread_state(module(), state(), String.t(), map()) :: state()
+  def put_thread_state(adapter_module, state, thread_id, value)
+      when is_atom(adapter_module) and is_binary(thread_id) and is_map(value) do
+    adapter_module.put_thread_state(state, thread_id, value)
+  end
+
+  @doc "Returns channel state map from adapter-managed state."
+  @spec channel_state(module(), state(), String.t()) :: map()
+  def channel_state(adapter_module, state, channel_id)
+      when is_atom(adapter_module) and is_binary(channel_id) do
+    adapter_module.channel_state(state, channel_id)
+  end
+
+  @doc "Writes channel state map into adapter-managed state."
+  @spec put_channel_state(module(), state(), String.t(), map()) :: state()
+  def put_channel_state(adapter_module, state, channel_id, value)
+      when is_atom(adapter_module) and is_binary(channel_id) and is_map(value) do
+    adapter_module.put_channel_state(state, channel_id, value)
+  end
+
+  @doc "Returns true when a message dedupe key has already been seen."
+  @spec duplicate?(module(), state(), dedupe_key()) :: boolean()
+  def duplicate?(adapter_module, state, key)
+      when is_atom(adapter_module) and is_tuple(key) do
+    adapter_module.duplicate?(state, key)
+  end
+
+  @doc "Records a new dedupe key and trims state to the requested limit."
+  @spec mark_dedupe(module(), state(), dedupe_key(), pos_integer()) :: state()
+  def mark_dedupe(adapter_module, state, key, limit)
+      when is_atom(adapter_module) and is_tuple(key) and is_integer(limit) and limit > 0 do
+    adapter_module.mark_dedupe(state, key, limit)
+  end
+
+  @doc "Returns the canonical empty snapshot."
+  @spec default_snapshot() :: snapshot()
+  def default_snapshot do
+    %{
+      subscriptions: MapSet.new(),
+      dedupe: MapSet.new(),
+      dedupe_order: [],
+      thread_state: %{},
+      channel_state: %{}
+    }
+  end
+
+  @doc "Normalizes maps, lists, and map-sets into the canonical state snapshot shape."
+  @spec normalize_snapshot(map()) :: snapshot()
+  def normalize_snapshot(snapshot) when is_map(snapshot) do
+    defaults = default_snapshot()
+
+    %{
+      subscriptions:
+        snapshot[:subscriptions] || snapshot["subscriptions"] || defaults.subscriptions,
+      dedupe: snapshot[:dedupe] || snapshot["dedupe"] || defaults.dedupe,
+      dedupe_order: snapshot[:dedupe_order] || snapshot["dedupe_order"] || defaults.dedupe_order,
+      thread_state: snapshot[:thread_state] || snapshot["thread_state"] || defaults.thread_state,
+      channel_state:
+        snapshot[:channel_state] || snapshot["channel_state"] || defaults.channel_state
+    }
+    |> normalize_subscriptions()
+    |> normalize_dedupe()
+    |> normalize_dedupe_order()
+    |> normalize_thread_state()
+    |> normalize_channel_state()
+  end
+
+  def normalize_snapshot(_snapshot), do: default_snapshot()
+
+  defp normalize_subscriptions(snapshot) do
+    subscriptions =
+      case snapshot.subscriptions do
+        %MapSet{} = subscriptions ->
+          subscriptions
+
+        subscriptions when is_list(subscriptions) ->
+          subscriptions
+          |> Enum.map(&to_string/1)
+          |> MapSet.new()
+
+        _ ->
+          MapSet.new()
+      end
+
+    %{snapshot | subscriptions: subscriptions}
+  end
+
+  defp normalize_dedupe(snapshot) do
+    dedupe =
+      case snapshot.dedupe do
+        %MapSet{} = dedupe ->
+          dedupe
+
+        dedupe when is_list(dedupe) ->
+          Enum.reduce(dedupe, MapSet.new(), fn
+            [adapter_name, message_id], acc ->
+              MapSet.put(acc, {normalize_key_atom(adapter_name), to_string(message_id)})
+
+            {adapter_name, message_id}, acc ->
+              MapSet.put(acc, {normalize_key_atom(adapter_name), to_string(message_id)})
+
+            _other, acc ->
+              acc
+          end)
+
+        _ ->
+          MapSet.new()
+      end
+
+    %{snapshot | dedupe: dedupe}
+  end
+
+  defp normalize_dedupe_order(snapshot) do
+    dedupe_order =
+      case snapshot.dedupe_order do
+        dedupe_order when is_list(dedupe_order) ->
+          Enum.reduce(dedupe_order, [], fn
+            [adapter_name, message_id], acc ->
+              [{normalize_key_atom(adapter_name), to_string(message_id)} | acc]
+
+            {adapter_name, message_id}, acc ->
+              [{normalize_key_atom(adapter_name), to_string(message_id)} | acc]
+
+            _other, acc ->
+              acc
+          end)
+          |> Enum.reverse()
+
+        _ ->
+          []
+      end
+
+    %{snapshot | dedupe_order: dedupe_order}
+  end
+
+  defp normalize_thread_state(snapshot) do
+    thread_state =
+      case snapshot.thread_state do
+        thread_state when is_map(thread_state) -> thread_state
+        _ -> %{}
+      end
+
+    %{snapshot | thread_state: thread_state}
+  end
+
+  defp normalize_channel_state(snapshot) do
+    channel_state =
+      case snapshot.channel_state do
+        channel_state when is_map(channel_state) -> channel_state
+        _ -> %{}
+      end
+
+    %{snapshot | channel_state: channel_state}
+  end
+
+  defp normalize_key_atom(key) when is_atom(key), do: key
+  defp normalize_key_atom(key) when is_binary(key), do: String.to_atom(key)
+  defp normalize_key_atom(key), do: key
+end

--- a/lib/jido/chat/state_adapter.ex
+++ b/lib/jido/chat/state_adapter.ex
@@ -14,10 +14,14 @@ defmodule Jido.Chat.StateAdapter do
           dedupe: MapSet.t(dedupe_key()),
           dedupe_order: [dedupe_key()],
           thread_state: %{optional(String.t()) => map()},
-          channel_state: %{optional(String.t()) => map()}
+          channel_state: %{optional(String.t()) => map()},
+          locks: %{optional(String.t()) => map()},
+          pending_locks: %{optional(String.t()) => [map()]}
         }
 
   @type state :: term()
+  @type lock_result :: :acquired | :queued | :debounced | :busy
+  @type release_result :: {:released, [map()]} | {:error, :not_owner}
 
   @callback init(snapshot(), keyword()) :: state()
   @callback snapshot(state()) :: snapshot() | map()
@@ -30,6 +34,9 @@ defmodule Jido.Chat.StateAdapter do
   @callback put_channel_state(state(), String.t(), map()) :: state()
   @callback duplicate?(state(), dedupe_key()) :: boolean()
   @callback mark_dedupe(state(), dedupe_key(), pos_integer()) :: state()
+  @callback lock(state(), String.t(), String.t(), atom(), map()) :: {lock_result(), state()}
+  @callback release_lock(state(), String.t(), String.t()) :: {release_result(), state()}
+  @callback force_release_lock(state(), String.t()) :: {{:released, [map()]}, state()}
 
   @doc "Initializes adapter state from a normalized snapshot."
   @spec init(module(), map(), keyword()) :: state()
@@ -107,6 +114,28 @@ defmodule Jido.Chat.StateAdapter do
     adapter_module.mark_dedupe(state, key, limit)
   end
 
+  @doc "Attempts to acquire a concurrency lock for the given key and owner."
+  @spec lock(module(), state(), String.t(), String.t(), atom(), map()) :: {lock_result(), state()}
+  def lock(adapter_module, state, key, owner, strategy, metadata \\ %{})
+      when is_atom(adapter_module) and is_binary(key) and is_binary(owner) and is_atom(strategy) and
+             is_map(metadata) do
+    adapter_module.lock(state, key, owner, strategy, metadata)
+  end
+
+  @doc "Releases a held lock and returns any queued/debounced pending entries."
+  @spec release_lock(module(), state(), String.t(), String.t()) :: {release_result(), state()}
+  def release_lock(adapter_module, state, key, owner)
+      when is_atom(adapter_module) and is_binary(key) and is_binary(owner) do
+    adapter_module.release_lock(state, key, owner)
+  end
+
+  @doc "Force-releases a lock regardless of owner and returns pending entries."
+  @spec force_release_lock(module(), state(), String.t()) :: {{:released, [map()]}, state()}
+  def force_release_lock(adapter_module, state, key)
+      when is_atom(adapter_module) and is_binary(key) do
+    adapter_module.force_release_lock(state, key)
+  end
+
   @doc "Returns the canonical empty snapshot."
   @spec default_snapshot() :: snapshot()
   def default_snapshot do
@@ -115,7 +144,9 @@ defmodule Jido.Chat.StateAdapter do
       dedupe: MapSet.new(),
       dedupe_order: [],
       thread_state: %{},
-      channel_state: %{}
+      channel_state: %{},
+      locks: %{},
+      pending_locks: %{}
     }
   end
 
@@ -131,13 +162,18 @@ defmodule Jido.Chat.StateAdapter do
       dedupe_order: snapshot[:dedupe_order] || snapshot["dedupe_order"] || defaults.dedupe_order,
       thread_state: snapshot[:thread_state] || snapshot["thread_state"] || defaults.thread_state,
       channel_state:
-        snapshot[:channel_state] || snapshot["channel_state"] || defaults.channel_state
+        snapshot[:channel_state] || snapshot["channel_state"] || defaults.channel_state,
+      locks: snapshot[:locks] || snapshot["locks"] || defaults.locks,
+      pending_locks:
+        snapshot[:pending_locks] || snapshot["pending_locks"] || defaults.pending_locks
     }
     |> normalize_subscriptions()
     |> normalize_dedupe()
     |> normalize_dedupe_order()
     |> normalize_thread_state()
     |> normalize_channel_state()
+    |> normalize_locks()
+    |> normalize_pending_locks()
   end
 
   def normalize_snapshot(_snapshot), do: default_snapshot()
@@ -226,6 +262,40 @@ defmodule Jido.Chat.StateAdapter do
       end
 
     %{snapshot | channel_state: channel_state}
+  end
+
+  defp normalize_locks(snapshot) do
+    locks =
+      case snapshot.locks do
+        locks when is_map(locks) -> locks
+        _ -> %{}
+      end
+
+    %{snapshot | locks: locks}
+  end
+
+  defp normalize_pending_locks(snapshot) do
+    pending_locks =
+      case snapshot.pending_locks do
+        pending when is_map(pending) ->
+          pending
+          |> Enum.map(fn {key, entries} ->
+            normalized_entries =
+              if is_list(entries) do
+                Enum.filter(entries, &is_map/1)
+              else
+                []
+              end
+
+            {to_string(key), normalized_entries}
+          end)
+          |> Map.new()
+
+        _ ->
+          %{}
+      end
+
+    %{snapshot | pending_locks: pending_locks}
   end
 
   defp normalize_key_atom(key) when is_atom(key), do: key

--- a/lib/jido/chat/state_adapters/memory.ex
+++ b/lib/jido/chat/state_adapters/memory.ex
@@ -1,0 +1,113 @@
+defmodule Jido.Chat.StateAdapters.Memory do
+  @moduledoc """
+  Default in-memory state adapter.
+
+  This preserves the current pure-struct semantics while routing all state access
+  through the `Jido.Chat.StateAdapter` contract.
+  """
+
+  @behaviour Jido.Chat.StateAdapter
+
+  alias Jido.Chat.StateAdapter
+
+  @enforce_keys [:subscriptions, :dedupe, :dedupe_order, :thread_state, :channel_state]
+  defstruct subscriptions: MapSet.new(),
+            dedupe: MapSet.new(),
+            dedupe_order: [],
+            thread_state: %{},
+            channel_state: %{}
+
+  @type t :: %__MODULE__{
+          subscriptions: MapSet.t(String.t()),
+          dedupe: MapSet.t(StateAdapter.dedupe_key()),
+          dedupe_order: [StateAdapter.dedupe_key()],
+          thread_state: %{optional(String.t()) => map()},
+          channel_state: %{optional(String.t()) => map()}
+        }
+
+  @impl true
+  def init(snapshot, _opts \\ []) do
+    snapshot = StateAdapter.normalize_snapshot(snapshot)
+
+    %__MODULE__{
+      subscriptions: snapshot.subscriptions,
+      dedupe: snapshot.dedupe,
+      dedupe_order: snapshot.dedupe_order,
+      thread_state: snapshot.thread_state,
+      channel_state: snapshot.channel_state
+    }
+  end
+
+  @impl true
+  def snapshot(%__MODULE__{} = state) do
+    %{
+      subscriptions: state.subscriptions,
+      dedupe: state.dedupe,
+      dedupe_order: state.dedupe_order,
+      thread_state: state.thread_state,
+      channel_state: state.channel_state
+    }
+  end
+
+  @impl true
+  def subscribed?(%__MODULE__{} = state, thread_id),
+    do: MapSet.member?(state.subscriptions, thread_id)
+
+  @impl true
+  def subscribe(%__MODULE__{} = state, thread_id) do
+    %{state | subscriptions: MapSet.put(state.subscriptions, thread_id)}
+  end
+
+  @impl true
+  def unsubscribe(%__MODULE__{} = state, thread_id) do
+    %{state | subscriptions: MapSet.delete(state.subscriptions, thread_id)}
+  end
+
+  @impl true
+  def thread_state(%__MODULE__{} = state, thread_id),
+    do: Map.get(state.thread_state, thread_id, %{})
+
+  @impl true
+  def put_thread_state(%__MODULE__{} = state, thread_id, value) when is_map(value) do
+    %{state | thread_state: Map.put(state.thread_state, thread_id, value)}
+  end
+
+  @impl true
+  def channel_state(%__MODULE__{} = state, channel_id),
+    do: Map.get(state.channel_state, channel_id, %{})
+
+  @impl true
+  def put_channel_state(%__MODULE__{} = state, channel_id, value) when is_map(value) do
+    %{state | channel_state: Map.put(state.channel_state, channel_id, value)}
+  end
+
+  @impl true
+  def duplicate?(%__MODULE__{} = state, key), do: MapSet.member?(state.dedupe, key)
+
+  @impl true
+  def mark_dedupe(%__MODULE__{} = state, key, dedupe_limit)
+      when is_tuple(key) and is_integer(dedupe_limit) and dedupe_limit > 0 do
+    dedupe = MapSet.put(state.dedupe, key)
+    dedupe_order = state.dedupe_order ++ [key]
+
+    {trimmed_dedupe_order, overflow_keys} = trim_dedupe_order(dedupe_order, dedupe_limit)
+
+    trimmed_dedupe =
+      Enum.reduce(overflow_keys, dedupe, fn overflow_key, acc ->
+        MapSet.delete(acc, overflow_key)
+      end)
+
+    %{state | dedupe: trimmed_dedupe, dedupe_order: trimmed_dedupe_order}
+  end
+
+  defp trim_dedupe_order(dedupe_order, dedupe_limit) do
+    overflow_count = max(length(dedupe_order) - dedupe_limit, 0)
+
+    if overflow_count == 0 do
+      {dedupe_order, []}
+    else
+      {overflow_keys, remaining_keys} = Enum.split(dedupe_order, overflow_count)
+      {remaining_keys, overflow_keys}
+    end
+  end
+end

--- a/lib/jido/chat/state_adapters/memory.ex
+++ b/lib/jido/chat/state_adapters/memory.ex
@@ -15,14 +15,18 @@ defmodule Jido.Chat.StateAdapters.Memory do
             dedupe: MapSet.new(),
             dedupe_order: [],
             thread_state: %{},
-            channel_state: %{}
+            channel_state: %{},
+            locks: %{},
+            pending_locks: %{}
 
   @type t :: %__MODULE__{
           subscriptions: MapSet.t(String.t()),
           dedupe: MapSet.t(StateAdapter.dedupe_key()),
           dedupe_order: [StateAdapter.dedupe_key()],
           thread_state: %{optional(String.t()) => map()},
-          channel_state: %{optional(String.t()) => map()}
+          channel_state: %{optional(String.t()) => map()},
+          locks: %{optional(String.t()) => map()},
+          pending_locks: %{optional(String.t()) => [map()]}
         }
 
   @impl true
@@ -34,7 +38,9 @@ defmodule Jido.Chat.StateAdapters.Memory do
       dedupe: snapshot.dedupe,
       dedupe_order: snapshot.dedupe_order,
       thread_state: snapshot.thread_state,
-      channel_state: snapshot.channel_state
+      channel_state: snapshot.channel_state,
+      locks: snapshot.locks,
+      pending_locks: snapshot.pending_locks
     }
   end
 
@@ -45,7 +51,9 @@ defmodule Jido.Chat.StateAdapters.Memory do
       dedupe: state.dedupe,
       dedupe_order: state.dedupe_order,
       thread_state: state.thread_state,
-      channel_state: state.channel_state
+      channel_state: state.channel_state,
+      locks: state.locks,
+      pending_locks: state.pending_locks
     }
   end
 
@@ -100,6 +108,62 @@ defmodule Jido.Chat.StateAdapters.Memory do
     %{state | dedupe: trimmed_dedupe, dedupe_order: trimmed_dedupe_order}
   end
 
+  @impl true
+  def lock(%__MODULE__{} = state, _key, _owner, :concurrent, _metadata) do
+    {:acquired, state}
+  end
+
+  def lock(%__MODULE__{} = state, key, owner, strategy, metadata)
+      when strategy in [:reject, :queue, :debounce] do
+    case Map.get(state.locks, key) do
+      nil ->
+        next_state = put_lock(state, key, owner, strategy, metadata)
+        {:acquired, next_state}
+
+      _lock when strategy == :reject ->
+        {:busy, state}
+
+      _lock when strategy == :queue ->
+        pending = Map.get(state.pending_locks, key, [])
+        entry = pending_entry(owner, strategy, metadata)
+        {:queued, %{state | pending_locks: Map.put(state.pending_locks, key, pending ++ [entry])}}
+
+      _lock when strategy == :debounce ->
+        entry = pending_entry(owner, strategy, metadata)
+        {:debounced, %{state | pending_locks: Map.put(state.pending_locks, key, [entry])}}
+    end
+  end
+
+  @impl true
+  def release_lock(%__MODULE__{} = state, key, owner) do
+    case Map.get(state.locks, key) do
+      %{owner: ^owner} ->
+        pending = Map.get(state.pending_locks, key, [])
+
+        next_state =
+          state
+          |> delete_lock(key)
+          |> delete_pending(key)
+
+        {{:released, pending}, next_state}
+
+      _other ->
+        {{:error, :not_owner}, state}
+    end
+  end
+
+  @impl true
+  def force_release_lock(%__MODULE__{} = state, key) do
+    pending = Map.get(state.pending_locks, key, [])
+
+    next_state =
+      state
+      |> delete_lock(key)
+      |> delete_pending(key)
+
+    {{:released, pending}, next_state}
+  end
+
   defp trim_dedupe_order(dedupe_order, dedupe_limit) do
     overflow_count = max(length(dedupe_order) - dedupe_limit, 0)
 
@@ -109,5 +173,19 @@ defmodule Jido.Chat.StateAdapters.Memory do
       {overflow_keys, remaining_keys} = Enum.split(dedupe_order, overflow_count)
       {remaining_keys, overflow_keys}
     end
+  end
+
+  defp put_lock(%__MODULE__{} = state, key, owner, strategy, metadata) do
+    lock = %{owner: owner, strategy: strategy, metadata: metadata}
+    %{state | locks: Map.put(state.locks, key, lock)}
+  end
+
+  defp delete_lock(%__MODULE__{} = state, key), do: %{state | locks: Map.delete(state.locks, key)}
+
+  defp delete_pending(%__MODULE__{} = state, key),
+    do: %{state | pending_locks: Map.delete(state.pending_locks, key)}
+
+  defp pending_entry(owner, strategy, metadata) do
+    %{owner: owner, strategy: strategy, metadata: metadata}
   end
 end

--- a/lib/jido/chat/stream_chunk.ex
+++ b/lib/jido/chat/stream_chunk.ex
@@ -9,7 +9,7 @@ defmodule Jido.Chat.StreamChunk do
             __MODULE__,
             %{
               kind:
-                Zoi.enum([:text, :markdown, :status, :plan, :data])
+                Zoi.enum([:text, :markdown, :status, :plan, :data, :step_start, :step_finish])
                 |> Zoi.default(:text),
               text: Zoi.string() |> Zoi.nullish(),
               payload: Zoi.any() |> Zoi.nullish(),
@@ -48,6 +48,29 @@ defmodule Jido.Chat.StreamChunk do
   @spec normalize_many([input()]) :: [t() | String.t()]
   def normalize_many(chunks) when is_list(chunks), do: Enum.map(chunks, &normalize/1)
 
+  @doc "Returns the best text fallback for the chunk."
+  @spec fallback_text(t() | String.t()) :: String.t()
+  def fallback_text(value) when is_binary(value), do: value
+
+  def fallback_text(%__MODULE__{kind: kind, text: text, payload: payload}) do
+    cond do
+      is_binary(text) and text != "" ->
+        text
+
+      kind in [:step_start, :step_finish] ->
+        payload_label(payload)
+
+      kind == :plan ->
+        payload_lines(payload)
+
+      kind == :status ->
+        payload_label(payload)
+
+      true ->
+        payload_label(payload) || ""
+    end
+  end
+
   @doc "Serializes a stream chunk into a plain map with type marker."
   @spec to_map(t()) :: map()
   def to_map(%__MODULE__{} = chunk) do
@@ -60,6 +83,21 @@ defmodule Jido.Chat.StreamChunk do
   @doc "Builds a stream chunk from serialized map data."
   @spec from_map(map()) :: t()
   def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp payload_label(%{label: label}) when is_binary(label), do: label
+  defp payload_label(%{"label" => label}) when is_binary(label), do: label
+  defp payload_label(%{title: title}) when is_binary(title), do: title
+  defp payload_label(%{"title" => title}) when is_binary(title), do: title
+  defp payload_label(payload) when is_binary(payload), do: payload
+  defp payload_label(_payload), do: nil
+
+  defp payload_lines(payload) when is_list(payload) do
+    payload
+    |> Enum.map(&to_string/1)
+    |> Enum.join("\n")
+  end
+
+  defp payload_lines(payload), do: payload_label(payload) || ""
 
   defp normalize_opts(opts) when is_list(opts), do: Map.new(opts)
   defp normalize_opts(opts) when is_map(opts), do: opts

--- a/lib/jido/chat/stream_chunk.ex
+++ b/lib/jido/chat/stream_chunk.ex
@@ -1,0 +1,66 @@
+defmodule Jido.Chat.StreamChunk do
+  @moduledoc """
+  Typed stream input chunk used by outbound stream payloads.
+  """
+
+  alias Jido.Chat.Wire
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              kind:
+                Zoi.enum([:text, :markdown, :status, :plan, :data])
+                |> Zoi.default(:text),
+              text: Zoi.string() |> Zoi.nullish(),
+              payload: Zoi.any() |> Zoi.nullish(),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+  @type input :: t() | String.t() | map()
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the Zoi schema for StreamChunk."
+  def schema, do: @schema
+
+  @doc "Creates a stream chunk from normalized map input."
+  def new(%__MODULE__{} = chunk), do: chunk
+  def new(attrs) when is_map(attrs), do: Jido.Chat.Schema.parse!(__MODULE__, @schema, attrs)
+
+  @doc "Builds a text chunk."
+  @spec text(String.t(), keyword() | map()) :: t()
+  def text(value, opts \\ []) when is_binary(value) do
+    opts = normalize_opts(opts)
+    new(Map.merge(opts, %{kind: :text, text: value}))
+  end
+
+  @doc "Normalizes supported stream chunk inputs."
+  @spec normalize(input()) :: t() | String.t()
+  def normalize(%__MODULE__{} = chunk), do: chunk
+  def normalize(value) when is_binary(value), do: value
+  def normalize(attrs) when is_map(attrs), do: new(attrs)
+
+  @doc "Normalizes a list of stream chunk inputs."
+  @spec normalize_many([input()]) :: [t() | String.t()]
+  def normalize_many(chunks) when is_list(chunks), do: Enum.map(chunks, &normalize/1)
+
+  @doc "Serializes a stream chunk into a plain map with type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = chunk) do
+    chunk
+    |> Map.from_struct()
+    |> Wire.to_plain()
+    |> Map.put("__type__", "stream_chunk")
+  end
+
+  @doc "Builds a stream chunk from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_opts(opts) when is_list(opts), do: Map.new(opts)
+  defp normalize_opts(opts) when is_map(opts), do: opts
+end

--- a/lib/jido/chat/thread.ex
+++ b/lib/jido/chat/thread.ex
@@ -174,17 +174,39 @@ defmodule Jido.Chat.Thread do
   end
 
   @doc "Posts an ephemeral message to a user with optional DM fallback policy."
-  @spec post_ephemeral(t(), String.t() | integer() | Author.t() | map(), String.t(), keyword()) ::
+  @spec post_ephemeral(
+          t(),
+          String.t() | integer() | Author.t() | map(),
+          String.t() | Postable.t() | map(),
+          keyword()
+        ) ::
           {:ok, Jido.Chat.EphemeralMessage.t()} | {:error, term()}
-  def post_ephemeral(%__MODULE__{} = thread, user, text, opts \\ []) when is_binary(text) do
+  def post_ephemeral(thread, user, input, opts \\ [])
+
+  def post_ephemeral(%__MODULE__{} = thread, user, text, opts) when is_binary(text) do
+    do_post_ephemeral(thread, user, PostPayload.text(text), opts)
+  end
+
+  def post_ephemeral(%__MODULE__{} = thread, user, %Postable{} = postable, opts) do
+    do_post_ephemeral(thread, user, Postable.to_payload(postable), opts)
+  end
+
+  def post_ephemeral(%__MODULE__{} = thread, user, postable_map, opts)
+      when is_map(postable_map) do
+    do_post_ephemeral(thread, user, postable_map |> Postable.new() |> Postable.to_payload(), opts)
+  rescue
+    _ -> {:error, :invalid_postable}
+  end
+
+  defp do_post_ephemeral(%__MODULE__{} = thread, user, %PostPayload{} = payload, opts) do
     with {:ok, external_user_id} <- external_user_id(user) do
       opts = with_thread_opts(thread, opts)
 
-      Adapter.post_ephemeral(
+      Adapter.post_ephemeral_message(
         thread.adapter,
         thread.external_room_id,
         external_user_id,
-        text,
+        payload,
         opts
       )
     end

--- a/lib/jido/chat/thread.ex
+++ b/lib/jido/chat/thread.ex
@@ -11,6 +11,7 @@ defmodule Jido.Chat.Thread do
     FileUpload,
     Message,
     MessagePage,
+    Modal,
     ModalResult,
     PostPayload,
     Postable,
@@ -110,8 +111,9 @@ defmodule Jido.Chat.Thread do
   end
 
   @doc "Opens a modal in the thread when supported by the adapter."
-  @spec open_modal(t(), map(), keyword()) :: {:ok, ModalResult.t()} | {:error, term()}
-  def open_modal(%__MODULE__{} = thread, payload, opts \\ []) when is_map(payload) do
+  @spec open_modal(t(), Modal.t() | map(), keyword()) :: {:ok, ModalResult.t()} | {:error, term()}
+  def open_modal(%__MODULE__{} = thread, payload, opts \\ [])
+      when is_map(payload) or is_struct(payload, Modal) do
     opts = with_thread_opts(thread, opts)
     Adapter.open_modal(thread.adapter, thread.external_room_id, payload, opts)
   end

--- a/lib/jido/chat/thread.ex
+++ b/lib/jido/chat/thread.ex
@@ -278,19 +278,19 @@ defmodule Jido.Chat.Thread do
   @doc "Subscribes this thread in a pure `Jido.Chat` state struct."
   @spec subscribe(Jido.Chat.t(), t()) :: Jido.Chat.t()
   def subscribe(%Jido.Chat{} = chat, %__MODULE__{} = thread) do
-    %{chat | subscriptions: MapSet.put(chat.subscriptions, thread.id)}
+    Jido.Chat.subscribe(chat, thread.id)
   end
 
   @doc "Unsubscribes this thread in a pure `Jido.Chat` state struct."
   @spec unsubscribe(Jido.Chat.t(), t()) :: Jido.Chat.t()
   def unsubscribe(%Jido.Chat{} = chat, %__MODULE__{} = thread) do
-    %{chat | subscriptions: MapSet.delete(chat.subscriptions, thread.id)}
+    Jido.Chat.unsubscribe(chat, thread.id)
   end
 
   @doc "Returns true when the thread is subscribed in a pure `Jido.Chat` state struct."
   @spec subscribed?(Jido.Chat.t(), t()) :: boolean()
   def subscribed?(%Jido.Chat{} = chat, %__MODULE__{} = thread) do
-    MapSet.member?(chat.subscriptions, thread.id)
+    Jido.Chat.subscribed?(chat, thread.id)
   end
 
   @doc "Serializes thread into a plain map with type marker."

--- a/lib/jido/chat/thread.ex
+++ b/lib/jido/chat/thread.ex
@@ -8,6 +8,7 @@ defmodule Jido.Chat.Thread do
     Attachment,
     Author,
     ChannelRef,
+    FileUpload,
     Message,
     MessagePage,
     ModalResult,
@@ -58,20 +59,20 @@ defmodule Jido.Chat.Thread do
   def post(%__MODULE__{} = thread, text, opts) when is_binary(text) do
     text
     |> PostPayload.text()
-    |> then(&post_payload(thread, &1, opts))
+    |> then(&dispatch_post_payload(thread, &1, opts))
   end
 
   def post(%__MODULE__{} = thread, %Postable{} = postable, opts) do
     postable
     |> Postable.to_payload()
-    |> then(&post_payload(thread, &1, opts))
+    |> then(&dispatch_post_payload(thread, &1, opts))
   end
 
   def post(%__MODULE__{} = thread, postable_map, opts) when is_map(postable_map) do
     postable_map
     |> Postable.new()
     |> Postable.to_payload()
-    |> then(&post_payload(thread, &1, opts))
+    |> then(&dispatch_post_payload(thread, &1, opts))
   rescue
     _ -> {:error, :invalid_postable}
   end
@@ -85,7 +86,7 @@ defmodule Jido.Chat.Thread do
   end
 
   @doc "Uploads a file to the thread when supported by the adapter."
-  @spec send_file(t(), Attachment.input(), keyword()) :: {:ok, SentMessage.t()} | {:error, term()}
+  @spec send_file(t(), FileUpload.input(), keyword()) :: {:ok, SentMessage.t()} | {:error, term()}
   def send_file(%__MODULE__{} = thread, file, opts \\ []) do
     opts = with_thread_opts(thread, opts)
 
@@ -327,15 +328,24 @@ defmodule Jido.Chat.Thread do
          thread_id: thread.id,
          adapter: thread.adapter,
          external_room_id: thread.external_room_id,
-         text: payload.text,
-         formatted: payload.formatted || payload.text,
+         text: PostPayload.display_text(payload),
+         formatted: payload.formatted || PostPayload.display_text(payload),
          raw: payload.raw,
-         attachments: payload.attachments || [],
+         attachments: PostPayload.outbound_attachments(payload),
          metadata: payload.metadata,
          response: response,
          default_opts: default_opts
        })}
     end
+  end
+
+  defp dispatch_post_payload(%__MODULE__{} = thread, %PostPayload{kind: :stream} = payload, opts)
+       when not is_nil(payload.stream) do
+    post_stream(thread, payload.stream, opts)
+  end
+
+  defp dispatch_post_payload(%__MODULE__{} = thread, %PostPayload{} = payload, opts) do
+    post_payload(thread, payload, opts)
   end
 
   defp post_stream(%__MODULE__{} = thread, enumerable, opts) do
@@ -437,13 +447,19 @@ defmodule Jido.Chat.Thread do
     Keyword.put_new(opts, :thread_id, external_thread_id)
   end
 
-  defp maybe_put_caption(opts, %PostPayload{text: nil}), do: opts
-  defp maybe_put_caption(opts, %PostPayload{text: ""}), do: opts
+  defp maybe_put_caption(opts, %PostPayload{} = payload) do
+    case PostPayload.display_text(payload) do
+      nil ->
+        opts
 
-  defp maybe_put_caption(opts, %PostPayload{text: text}) do
-    opts
-    |> Keyword.put_new(:caption, text)
-    |> Keyword.put_new(:text, text)
+      "" ->
+        opts
+
+      text ->
+        opts
+        |> Keyword.put_new(:caption, text)
+        |> Keyword.put_new(:text, text)
+    end
   end
 
   defp maybe_put_metadata(opts, metadata) when metadata in [%{}, nil], do: opts
@@ -453,14 +469,16 @@ defmodule Jido.Chat.Thread do
   end
 
   defp post_default_opts(adapter, %PostPayload{} = payload, opts, _scope) do
+    upload_candidates = PostPayload.upload_candidates(payload)
+
     cond do
       function_exported?(adapter, :post_message, 3) ->
         {:ok, opts}
 
-      payload.attachments in [nil, []] ->
+      upload_candidates in [nil, []] ->
         {:ok, opts}
 
-      match?([_attachment], payload.attachments) ->
+      match?([_attachment], upload_candidates) ->
         {:ok,
          opts
          |> maybe_put_caption(payload)

--- a/lib/jido_chat.ex
+++ b/lib/jido_chat.ex
@@ -12,6 +12,7 @@ defmodule Jido.Chat do
     Author,
     CapabilityMatrix,
     ChannelRef,
+    Concurrency,
     Emoji,
     EventRouter,
     EventEnvelope,
@@ -760,6 +761,65 @@ defmodule Jido.Chat do
     |> sync_state(chat)
   end
 
+  @doc "Returns normalized overlapping-message concurrency config."
+  @spec concurrency(t()) :: Concurrency.t()
+  def concurrency(%__MODULE__{} = chat) do
+    Concurrency.new(chat.metadata[:concurrency] || chat.metadata["concurrency"] || %{})
+  end
+
+  @doc "Updates chat-level concurrency configuration."
+  @spec configure_concurrency(t(), keyword() | map()) :: t()
+  def configure_concurrency(%__MODULE__{} = chat, opts) when is_list(opts) or is_map(opts) do
+    config = Concurrency.new(opts)
+    metadata = Map.put(chat.metadata || %{}, :concurrency, Map.from_struct(config))
+    %{chat | metadata: metadata}
+  end
+
+  @doc "Returns the current concurrency lock snapshot."
+  @spec lock_snapshot(t()) :: %{locks: map(), pending_locks: map()}
+  def lock_snapshot(%__MODULE__{} = chat) do
+    snapshot = StateAdapter.snapshot(chat.state_adapter, chat.state)
+    %{locks: snapshot.locks, pending_locks: snapshot.pending_locks}
+  end
+
+  @doc "Attempts to acquire a concurrency lock for a message-processing key."
+  @spec acquire_lock(t(), String.t(), String.t(), keyword() | map()) ::
+          {:acquired | :queued | :debounced | :busy, t()}
+  def acquire_lock(%__MODULE__{} = chat, key, owner, opts \\ [])
+      when is_binary(key) and is_binary(owner) do
+    opts = if is_list(opts), do: Map.new(opts), else: opts
+    config = opts[:concurrency] || opts["concurrency"] || concurrency(chat)
+    config = Concurrency.new(config)
+    metadata = opts[:metadata] || opts["metadata"] || %{}
+
+    {result, state} =
+      StateAdapter.lock(
+        chat.state_adapter,
+        chat.state,
+        key,
+        owner,
+        config.strategy,
+        metadata
+      )
+
+    {result, sync_state(state, chat)}
+  end
+
+  @doc "Releases a held concurrency lock and returns queued/debounced entries."
+  @spec release_lock(t(), String.t(), String.t()) ::
+          {{:released, [map()]} | {:error, :not_owner}, t()}
+  def release_lock(%__MODULE__{} = chat, key, owner) when is_binary(key) and is_binary(owner) do
+    {result, state} = StateAdapter.release_lock(chat.state_adapter, chat.state, key, owner)
+    {result, sync_state(state, chat)}
+  end
+
+  @doc "Force-releases a concurrency lock regardless of owner."
+  @spec force_release_lock(t(), String.t()) :: {{:released, [map()]}, t()}
+  def force_release_lock(%__MODULE__{} = chat, key) when is_binary(key) do
+    {result, state} = StateAdapter.force_release_lock(chat.state_adapter, chat.state, key)
+    {result, sync_state(state, chat)}
+  end
+
   @doc "Unsubscribes a thread id."
   @spec unsubscribe(t(), String.t()) :: t()
   def unsubscribe(%__MODULE__{} = chat, thread_id) when is_binary(thread_id) do
@@ -1140,7 +1200,9 @@ defmodule Jido.Chat do
       dedupe: opts[:dedupe] || opts["dedupe"] || MapSet.new(),
       dedupe_order: opts[:dedupe_order] || opts["dedupe_order"] || [],
       thread_state: opts[:thread_state] || opts["thread_state"] || %{},
-      channel_state: opts[:channel_state] || opts["channel_state"] || %{}
+      channel_state: opts[:channel_state] || opts["channel_state"] || %{},
+      locks: opts[:locks] || opts["locks"] || %{},
+      pending_locks: opts[:pending_locks] || opts["pending_locks"] || %{}
     }
     |> StateAdapter.normalize_snapshot()
   end

--- a/lib/jido_chat.ex
+++ b/lib/jido_chat.ex
@@ -24,6 +24,7 @@ defmodule Jido.Chat do
     Room,
     Serialization,
     SlashCommandEvent,
+    StateAdapter,
     Thread,
     WebhookPipeline,
     WebhookRequest,
@@ -102,6 +103,8 @@ defmodule Jido.Chat do
           id: String.t(),
           user_name: String.t(),
           adapters: %{optional(atom()) => module()},
+          state_adapter: module(),
+          state: term(),
           subscriptions: MapSet.t(String.t()),
           dedupe: MapSet.t({atom(), String.t()}),
           dedupe_order: [{atom(), String.t()}],
@@ -131,6 +134,8 @@ defmodule Jido.Chat do
               id: Zoi.string(),
               user_name: Zoi.string() |> Zoi.default("bot"),
               adapters: Zoi.map() |> Zoi.default(%{}),
+              state_adapter: Zoi.any() |> Zoi.default(Jido.Chat.StateAdapters.Memory),
+              state: Zoi.any() |> Zoi.nullish(),
               subscriptions: Zoi.any() |> Zoi.default(MapSet.new()),
               dedupe: Zoi.any() |> Zoi.default(MapSet.new()),
               dedupe_order: Zoi.list() |> Zoi.default([]),
@@ -157,6 +162,9 @@ defmodule Jido.Chat do
     * `:user_name`
     * `:adapters` - map `%{telegram: Jido.Chat.Telegram.Adapter, ...}`
     * `:metadata`
+    * `:state_adapter` - state backend module, defaults to `Jido.Chat.StateAdapters.Memory`
+    * `:state_opts` - adapter-specific initialization options
+    * `:state` - explicit adapter state, overrides legacy snapshot inputs
   """
   @spec new(keyword() | map()) :: t()
   def new(opts \\ [])
@@ -164,13 +172,37 @@ defmodule Jido.Chat do
   def new(opts) when is_list(opts), do: opts |> Map.new() |> new()
 
   def new(opts) when is_map(opts) do
+    state_adapter =
+      opts[:state_adapter] || opts["state_adapter"] || Jido.Chat.StateAdapters.Memory
+
+    state_adapter = Jido.Chat.Wire.decode_module(state_adapter) || Jido.Chat.StateAdapters.Memory
+    state_opts = opts[:state_opts] || opts["state_opts"] || []
+
+    state_snapshot =
+      opts
+      |> initial_state_snapshot()
+      |> maybe_replace_with_explicit_state(state_adapter, opts[:state] || opts["state"])
+
+    state =
+      case opts[:state] || opts["state"] do
+        nil -> StateAdapter.init(state_adapter, state_snapshot, state_opts)
+        explicit_state -> explicit_state
+      end
+
+    normalized_state_snapshot = StateAdapter.snapshot(state_adapter, state)
+
     attrs = %{
       id: opts[:id] || opts["id"] || Jido.Chat.ID.generate!(),
       user_name: opts[:user_name] || opts["user_name"] || "bot",
       adapters: AdapterRegistry.normalize_adapters(opts[:adapters] || opts["adapters"] || %{}),
+      state_adapter: state_adapter,
+      state: state,
       metadata: opts[:metadata] || opts["metadata"] || %{},
-      thread_state: opts[:thread_state] || opts["thread_state"] || %{},
-      channel_state: opts[:channel_state] || opts["channel_state"] || %{}
+      subscriptions: normalized_state_snapshot.subscriptions,
+      dedupe: normalized_state_snapshot.dedupe,
+      dedupe_order: normalized_state_snapshot.dedupe_order,
+      thread_state: normalized_state_snapshot.thread_state,
+      channel_state: normalized_state_snapshot.channel_state
     }
 
     Jido.Chat.Schema.parse!(__MODULE__, @schema, attrs)
@@ -638,39 +670,74 @@ defmodule Jido.Chat do
 
   @doc "Returns true when a thread id is currently subscribed."
   @spec subscribed?(t(), String.t()) :: boolean()
-  def subscribed?(%__MODULE__{} = chat, thread_id),
-    do: MapSet.member?(chat.subscriptions, thread_id)
+  def subscribed?(%__MODULE__{} = chat, thread_id) when is_binary(thread_id) do
+    StateAdapter.subscribed?(chat.state_adapter, chat.state, thread_id)
+  end
 
   @doc "Subscribes a thread id."
   @spec subscribe(t(), String.t()) :: t()
-  def subscribe(%__MODULE__{} = chat, thread_id),
-    do: %{chat | subscriptions: MapSet.put(chat.subscriptions, thread_id)}
+  def subscribe(%__MODULE__{} = chat, thread_id) when is_binary(thread_id) do
+    chat.state_adapter
+    |> StateAdapter.subscribe(chat.state, thread_id)
+    |> sync_state(chat)
+  end
 
   @doc "Unsubscribes a thread id."
   @spec unsubscribe(t(), String.t()) :: t()
-  def unsubscribe(%__MODULE__{} = chat, thread_id),
-    do: %{chat | subscriptions: MapSet.delete(chat.subscriptions, thread_id)}
+  def unsubscribe(%__MODULE__{} = chat, thread_id) when is_binary(thread_id) do
+    chat.state_adapter
+    |> StateAdapter.unsubscribe(chat.state, thread_id)
+    |> sync_state(chat)
+  end
 
   @doc "Gets thread state map by id."
   @spec thread_state(t(), String.t()) :: map()
-  def thread_state(%__MODULE__{} = chat, thread_id),
-    do: Map.get(chat.thread_state, thread_id, %{})
+  def thread_state(%__MODULE__{} = chat, thread_id) when is_binary(thread_id) do
+    StateAdapter.thread_state(chat.state_adapter, chat.state, thread_id)
+  end
 
   @doc "Sets thread state map by id."
   @spec put_thread_state(t(), String.t(), map()) :: t()
   def put_thread_state(%__MODULE__{} = chat, thread_id, state) when is_map(state) do
-    %{chat | thread_state: Map.put(chat.thread_state, thread_id, state)}
+    chat.state_adapter
+    |> StateAdapter.put_thread_state(chat.state, thread_id, state)
+    |> sync_state(chat)
   end
 
   @doc "Gets channel state map by id."
   @spec channel_state(t(), String.t()) :: map()
-  def channel_state(%__MODULE__{} = chat, channel_id),
-    do: Map.get(chat.channel_state, channel_id, %{})
+  def channel_state(%__MODULE__{} = chat, channel_id) when is_binary(channel_id) do
+    StateAdapter.channel_state(chat.state_adapter, chat.state, channel_id)
+  end
 
   @doc "Sets channel state map by id."
   @spec put_channel_state(t(), String.t(), map()) :: t()
   def put_channel_state(%__MODULE__{} = chat, channel_id, state) when is_map(state) do
-    %{chat | channel_state: Map.put(chat.channel_state, channel_id, state)}
+    chat.state_adapter
+    |> StateAdapter.put_channel_state(chat.state, channel_id, state)
+    |> sync_state(chat)
+  end
+
+  @doc false
+  @spec duplicate?(t(), {atom(), String.t()} | nil) :: boolean()
+  def duplicate?(%__MODULE__{}, nil), do: false
+
+  def duplicate?(%__MODULE__{} = chat, {adapter_name, message_id})
+      when is_atom(adapter_name) and is_binary(message_id) do
+    StateAdapter.duplicate?(chat.state_adapter, chat.state, {adapter_name, message_id})
+  end
+
+  @doc false
+  @spec mark_dedupe(t(), {atom(), String.t()} | nil) :: t()
+  def mark_dedupe(%__MODULE__{} = chat, nil), do: chat
+
+  def mark_dedupe(%__MODULE__{} = chat, {adapter_name, message_id})
+      when is_atom(adapter_name) and is_binary(message_id) do
+    dedupe_limit = dedupe_limit(chat)
+
+    chat.state_adapter
+    |> StateAdapter.mark_dedupe(chat.state, {adapter_name, message_id}, dedupe_limit)
+    |> sync_state(chat)
   end
 
   @doc "Creates a normalized Chat SDK-style message."
@@ -701,6 +768,49 @@ defmodule Jido.Chat do
   @doc false
   @spec revive(map()) :: term()
   def revive(map), do: Serialization.revive(map)
+
+  defp sync_state(state, %__MODULE__{} = chat) do
+    snapshot = StateAdapter.snapshot(chat.state_adapter, state)
+
+    %{
+      chat
+      | state: state,
+        subscriptions: snapshot.subscriptions,
+        dedupe: snapshot.dedupe,
+        dedupe_order: snapshot.dedupe_order,
+        thread_state: snapshot.thread_state,
+        channel_state: snapshot.channel_state
+    }
+  end
+
+  defp initial_state_snapshot(opts) do
+    %{
+      subscriptions: opts[:subscriptions] || opts["subscriptions"] || MapSet.new(),
+      dedupe: opts[:dedupe] || opts["dedupe"] || MapSet.new(),
+      dedupe_order: opts[:dedupe_order] || opts["dedupe_order"] || [],
+      thread_state: opts[:thread_state] || opts["thread_state"] || %{},
+      channel_state: opts[:channel_state] || opts["channel_state"] || %{}
+    }
+    |> StateAdapter.normalize_snapshot()
+  end
+
+  defp maybe_replace_with_explicit_state(snapshot, _state_adapter, nil), do: snapshot
+
+  defp maybe_replace_with_explicit_state(_snapshot, state_adapter, explicit_state) do
+    StateAdapter.snapshot(state_adapter, explicit_state)
+  end
+
+  defp dedupe_limit(chat) do
+    metadata = Map.get(chat, :metadata, %{})
+
+    value =
+      case metadata do
+        %{} -> metadata[:dedupe_limit] || metadata["dedupe_limit"]
+        _ -> nil
+      end
+
+    if is_integer(value) and value > 0, do: value, else: 1_000
+  end
 
   defp normalize_ingress_event(%EventEnvelope{} = envelope), do: envelope
   defp normalize_ingress_event(nil), do: nil

--- a/lib/jido_chat.ex
+++ b/lib/jido_chat.ex
@@ -1,6 +1,11 @@
 defmodule Jido.Chat do
   @moduledoc """
-  Core chat SDK facade and event-loop state container.
+  Core adapter-contract facade and lightweight event-loop state container.
+
+  `jido_chat` owns canonical chat types, adapter contracts, typed handles, and
+  deterministic fallback behavior. It does not define the supervised runtime or
+  process tree for production messaging systems; that responsibility belongs in
+  `jido_messaging`.
   """
 
   alias Jido.Chat.{

--- a/lib/jido_chat.ex
+++ b/lib/jido_chat.ex
@@ -9,8 +9,10 @@ defmodule Jido.Chat do
     AdapterRegistry,
     AssistantContextChangedEvent,
     AssistantThreadStartedEvent,
+    Author,
     CapabilityMatrix,
     ChannelRef,
+    Emoji,
     EventRouter,
     EventEnvelope,
     Errors,
@@ -258,10 +260,28 @@ defmodule Jido.Chat do
     update_in(chat.handlers.reaction, &(&1 ++ [handler]))
   end
 
+  @doc "Registers a filtered reaction-event handler."
+  @spec on_reaction(
+          t(),
+          String.t() | atom() | [String.t() | atom()] | Regex.t(),
+          reaction_handler()
+        ) ::
+          t()
+  def on_reaction(%__MODULE__{} = chat, selector, handler) when is_function(handler) do
+    register_filtered_handler(chat, :reaction, selector, handler)
+  end
+
   @doc "Registers an action-event handler."
   @spec on_action(t(), action_handler()) :: t()
   def on_action(%__MODULE__{} = chat, handler) when is_function(handler) do
     update_in(chat.handlers.action, &(&1 ++ [handler]))
+  end
+
+  @doc "Registers a filtered action-event handler."
+  @spec on_action(t(), String.t() | atom() | [String.t() | atom()] | Regex.t(), action_handler()) ::
+          t()
+  def on_action(%__MODULE__{} = chat, selector, handler) when is_function(handler) do
+    register_filtered_handler(chat, :action, selector, handler)
   end
 
   @doc "Registers a modal-submit handler."
@@ -270,16 +290,46 @@ defmodule Jido.Chat do
     update_in(chat.handlers.modal_submit, &(&1 ++ [handler]))
   end
 
+  @doc "Registers a filtered modal-submit handler."
+  @spec on_modal_submit(
+          t(),
+          String.t() | atom() | [String.t() | atom()] | Regex.t(),
+          modal_submit_handler()
+        ) :: t()
+  def on_modal_submit(%__MODULE__{} = chat, selector, handler) when is_function(handler) do
+    register_filtered_handler(chat, :modal_submit, selector, handler)
+  end
+
   @doc "Registers a modal-close handler."
   @spec on_modal_close(t(), modal_close_handler()) :: t()
   def on_modal_close(%__MODULE__{} = chat, handler) when is_function(handler) do
     update_in(chat.handlers.modal_close, &(&1 ++ [handler]))
   end
 
+  @doc "Registers a filtered modal-close handler."
+  @spec on_modal_close(
+          t(),
+          String.t() | atom() | [String.t() | atom()] | Regex.t(),
+          modal_close_handler()
+        ) :: t()
+  def on_modal_close(%__MODULE__{} = chat, selector, handler) when is_function(handler) do
+    register_filtered_handler(chat, :modal_close, selector, handler)
+  end
+
   @doc "Registers a slash-command handler."
   @spec on_slash_command(t(), slash_command_handler()) :: t()
   def on_slash_command(%__MODULE__{} = chat, handler) when is_function(handler) do
     update_in(chat.handlers.slash_command, &(&1 ++ [handler]))
+  end
+
+  @doc "Registers a filtered slash-command handler."
+  @spec on_slash_command(
+          t(),
+          String.t() | atom() | [String.t() | atom()] | Regex.t(),
+          slash_command_handler()
+        ) :: t()
+  def on_slash_command(%__MODULE__{} = chat, selector, handler) when is_function(handler) do
+    register_filtered_handler(chat, :slash_command, selector, handler)
   end
 
   @doc "Registers assistant thread started handlers."
@@ -447,7 +497,11 @@ defmodule Jido.Chat do
   @doc """
   Opens a DM thread with an adapter when supported.
   """
-  @spec open_dm(t(), atom(), String.t() | integer()) :: {:ok, Thread.t()} | {:error, term()}
+  @spec open_dm(
+          t(),
+          atom() | Author.t() | map() | String.t() | integer(),
+          String.t() | integer() | keyword() | map()
+        ) :: {:ok, Thread.t()} | {:error, term()}
   def open_dm(%__MODULE__{} = chat, adapter_name, external_user_id) when is_atom(adapter_name) do
     with {:ok, adapter_module} <- AdapterRegistry.resolve(chat, adapter_name) do
       if function_exported?(adapter_module, :open_dm, 2) do
@@ -461,6 +515,18 @@ defmodule Jido.Chat do
       else
         {:error, :unsupported}
       end
+    end
+  end
+
+  def open_dm(%__MODULE__{} = chat, target, opts) when is_list(opts) or is_map(opts) do
+    with {:ok, adapter_name, external_user_id} <- resolve_dm_target(chat, target, opts) do
+      open_dm(chat, adapter_name, external_user_id)
+    end
+  end
+
+  def open_dm(%__MODULE__{} = chat, target, []) do
+    with {:ok, adapter_name, external_user_id} <- resolve_dm_target(chat, target, []) do
+      open_dm(chat, adapter_name, external_user_id)
     end
   end
 
@@ -544,6 +610,7 @@ defmodule Jido.Chat do
   def process_reaction(%__MODULE__{} = chat, adapter_name, event, opts \\ [])
       when is_atom(adapter_name) and is_list(opts) do
     with {:ok, reaction} <- EventRouter.ensure_reaction_event(event, adapter_name) do
+      reaction = enrich_event_context(chat, adapter_name, reaction)
       {:ok, EventRouter.run_event_handlers(chat, chat.handlers.reaction, reaction), reaction}
     end
   end
@@ -554,6 +621,7 @@ defmodule Jido.Chat do
   def process_action(%__MODULE__{} = chat, adapter_name, event, opts \\ [])
       when is_atom(adapter_name) and is_list(opts) do
     with {:ok, action} <- EventRouter.ensure_action_event(event, adapter_name) do
+      action = enrich_event_context(chat, adapter_name, action)
       {:ok, EventRouter.run_event_handlers(chat, chat.handlers.action, action), action}
     end
   end
@@ -564,6 +632,8 @@ defmodule Jido.Chat do
   def process_modal_submit(%__MODULE__{} = chat, adapter_name, event, opts \\ [])
       when is_atom(adapter_name) and is_list(opts) do
     with {:ok, modal_submit} <- EventRouter.ensure_modal_submit_event(event, adapter_name) do
+      modal_submit = enrich_event_context(chat, adapter_name, modal_submit)
+
       {:ok, EventRouter.run_event_handlers(chat, chat.handlers.modal_submit, modal_submit),
        modal_submit}
     end
@@ -575,6 +645,8 @@ defmodule Jido.Chat do
   def process_modal_close(%__MODULE__{} = chat, adapter_name, event, opts \\ [])
       when is_atom(adapter_name) and is_list(opts) do
     with {:ok, modal_close} <- EventRouter.ensure_modal_close_event(event, adapter_name) do
+      modal_close = enrich_event_context(chat, adapter_name, modal_close)
+
       {:ok, EventRouter.run_event_handlers(chat, chat.handlers.modal_close, modal_close),
        modal_close}
     end
@@ -586,6 +658,8 @@ defmodule Jido.Chat do
   def process_slash_command(%__MODULE__{} = chat, adapter_name, event, opts \\ [])
       when is_atom(adapter_name) and is_list(opts) do
     with {:ok, slash_command} <- EventRouter.ensure_slash_command_event(event, adapter_name) do
+      slash_command = enrich_event_context(chat, adapter_name, slash_command)
+
       {:ok, EventRouter.run_event_handlers(chat, chat.handlers.slash_command, slash_command),
        slash_command}
     end
@@ -627,6 +701,8 @@ defmodule Jido.Chat do
       when is_atom(adapter_name) do
     with {:ok, assistant_event} <-
            EventRouter.ensure_assistant_thread_started_event(event, adapter_name) do
+      assistant_event = enrich_event_context(chat, adapter_name, assistant_event)
+
       {:ok,
        EventRouter.run_event_handlers(
          chat,
@@ -647,6 +723,8 @@ defmodule Jido.Chat do
       when is_atom(adapter_name) do
     with {:ok, assistant_event} <-
            EventRouter.ensure_assistant_context_changed_event(event, adapter_name) do
+      assistant_event = enrich_event_context(chat, adapter_name, assistant_event)
+
       {:ok,
        EventRouter.run_event_handlers(
          chat,
@@ -753,6 +831,10 @@ defmodule Jido.Chat do
   @spec text(String.t()) :: Text.t()
   def text(value), do: Text.new(value)
 
+  @doc "Resolves a cross-platform emoji token into a rendered value."
+  @spec emoji(String.t() | atom(), keyword()) :: String.t()
+  def emoji(value, opts \\ []), do: Emoji.render(value, opts)
+
   @doc "Serializes chat state to a revivable map."
   @spec to_map(t()) :: map()
   def to_map(%__MODULE__{} = chat), do: Serialization.to_map(chat)
@@ -768,6 +850,275 @@ defmodule Jido.Chat do
   @doc false
   @spec revive(map()) :: term()
   def revive(map), do: Serialization.revive(map)
+
+  defp register_filtered_handler(%__MODULE__{} = chat, key, selector, handler) do
+    normalized = normalize_handler_selector(selector)
+    update_in(chat.handlers[key], &(&1 ++ [{normalized, handler}]))
+  end
+
+  defp normalize_handler_selector(selectors) when is_list(selectors),
+    do: Enum.map(selectors, &normalize_handler_selector/1)
+
+  defp normalize_handler_selector(selector) when is_atom(selector) and selector != :all,
+    do: Atom.to_string(selector)
+
+  defp normalize_handler_selector(selector), do: selector
+
+  defp resolve_dm_target(%__MODULE__{} = chat, %Author{} = author, opts) do
+    adapter_name =
+      opts[:adapter_name] ||
+        author.metadata[:adapter_name] ||
+        author.metadata["adapter_name"] ||
+        infer_single_adapter(chat)
+
+    with {:ok, adapter_name} <- normalize_adapter_name(chat, adapter_name) do
+      {:ok, adapter_name, author.user_id}
+    end
+  end
+
+  defp resolve_dm_target(%__MODULE__{} = chat, target, opts) when is_map(target) do
+    resolve_dm_target(chat, Author.new(target), opts)
+  rescue
+    _ -> {:error, :invalid_dm_target}
+  end
+
+  defp resolve_dm_target(%__MODULE__{} = chat, target, opts)
+       when is_binary(target) or is_integer(target) do
+    case parse_adapter_prefixed_target(chat, target) do
+      {:ok, adapter_name, external_user_id} ->
+        {:ok, adapter_name, external_user_id}
+
+      :error ->
+        with {:ok, adapter_name} <-
+               normalize_adapter_name(chat, opts[:adapter_name] || infer_single_adapter(chat)) do
+          {:ok, adapter_name, to_string(target)}
+        end
+    end
+  end
+
+  defp resolve_dm_target(_chat, _target, _opts), do: {:error, :invalid_dm_target}
+
+  defp normalize_adapter_name(_chat, adapter_name) when is_atom(adapter_name),
+    do: {:ok, adapter_name}
+
+  defp normalize_adapter_name(_chat, nil), do: {:error, :ambiguous_adapter}
+
+  defp normalize_adapter_name(chat, adapter_name) when is_binary(adapter_name) do
+    adapter_atom = String.to_existing_atom(adapter_name)
+    normalize_adapter_name(chat, adapter_atom)
+  rescue
+    ArgumentError -> {:error, :ambiguous_adapter}
+  end
+
+  defp infer_single_adapter(%__MODULE__{adapters: adapters}) when map_size(adapters) == 1 do
+    adapters |> Map.keys() |> List.first()
+  end
+
+  defp infer_single_adapter(_chat), do: nil
+
+  defp parse_adapter_prefixed_target(%__MODULE__{adapters: adapters}, target)
+       when is_binary(target) do
+    case String.split(target, ":", parts: 2) do
+      [adapter_name, external_user_id] when external_user_id != "" ->
+        adapter_atom = String.to_atom(adapter_name)
+
+        if Map.has_key?(adapters, adapter_atom) do
+          {:ok, adapter_atom, external_user_id}
+        else
+          :error
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  defp parse_adapter_prefixed_target(_chat, _target), do: :error
+
+  defp enrich_event_context(%__MODULE__{} = chat, adapter_name, event) do
+    adapter = Map.get(chat.adapters, adapter_name)
+    channel = Map.get(event, :channel) || build_channel_handle(chat, adapter_name, event)
+    thread = Map.get(event, :thread) || build_thread_handle(chat, adapter_name, event, channel)
+    message = Map.get(event, :message) || build_message_handle(event, thread, channel)
+
+    related_channel =
+      Map.get(event, :related_channel) || build_related_channel_handle(chat, adapter_name, event)
+
+    related_thread =
+      Map.get(event, :related_thread) ||
+        build_related_thread_handle(chat, adapter_name, event, related_channel)
+
+    related_message =
+      Map.get(event, :related_message) ||
+        build_related_message_handle(event, related_thread, related_channel)
+
+    struct(event,
+      adapter: adapter,
+      thread: thread,
+      channel: channel,
+      message: message,
+      related_thread: related_thread,
+      related_channel: related_channel,
+      related_message: related_message,
+      thread_id: Map.get(event, :thread_id) || (thread && thread.id),
+      channel_id: Map.get(event, :channel_id) || (channel && channel.id),
+      message_id: Map.get(event, :message_id) || (message && message.id)
+    )
+  end
+
+  defp build_channel_handle(%__MODULE__{} = chat, adapter_name, event) do
+    case channel_external_id(
+           adapter_name,
+           Map.get(event, :channel_id) || Map.get(event, :thread_id)
+         ) do
+      nil -> nil
+      external_id -> channel(chat, adapter_name, external_id)
+    end
+  end
+
+  defp build_thread_handle(%__MODULE__{} = chat, adapter_name, event, channel) do
+    cond do
+      is_binary(Map.get(event, :thread_id)) ->
+        case parse_thread_identifier(adapter_name, Map.get(event, :thread_id)) do
+          {external_room_id, external_thread_id} ->
+            thread(chat, adapter_name, external_room_id,
+              id: Map.get(event, :thread_id),
+              external_thread_id: external_thread_id,
+              is_dm: is_dm_channel?(channel)
+            )
+
+          _ ->
+            nil
+        end
+
+      match?(%ChannelRef{}, channel) ->
+        thread(chat, adapter_name, channel.external_id,
+          id: "#{adapter_name}:#{channel.external_id}",
+          is_dm: is_dm_channel?(channel)
+        )
+
+      true ->
+        nil
+    end
+  end
+
+  defp build_message_handle(event, thread, channel) do
+    case Map.get(event, :message_id) do
+      nil ->
+        nil
+
+      message_id ->
+        external_room_id =
+          cond do
+            match?(%Thread{}, thread) -> thread.external_room_id
+            match?(%ChannelRef{}, channel) -> channel.external_id
+            true -> nil
+          end
+
+        Message.new(%{
+          id: to_string(message_id),
+          thread_id: thread && thread.id,
+          channel_id: channel && channel.id,
+          external_room_id: external_room_id,
+          external_message_id: to_string(message_id)
+        })
+    end
+  end
+
+  defp build_related_channel_handle(%__MODULE__{} = chat, adapter_name, event) do
+    related_channel_id =
+      Map.get(event.metadata, :related_channel_id) ||
+        Map.get(event.metadata, "related_channel_id")
+
+    case channel_external_id(adapter_name, related_channel_id) do
+      nil -> nil
+      external_id -> channel(chat, adapter_name, external_id)
+    end
+  end
+
+  defp build_related_thread_handle(%__MODULE__{} = chat, adapter_name, event, related_channel) do
+    related_thread_id =
+      Map.get(event.metadata, :related_thread_id) || Map.get(event.metadata, "related_thread_id")
+
+    cond do
+      is_binary(related_thread_id) ->
+        case parse_thread_identifier(adapter_name, related_thread_id) do
+          {external_room_id, external_thread_id} ->
+            thread(chat, adapter_name, external_room_id,
+              id: related_thread_id,
+              external_thread_id: external_thread_id,
+              is_dm: is_dm_channel?(related_channel)
+            )
+
+          _ ->
+            nil
+        end
+
+      match?(%ChannelRef{}, related_channel) ->
+        thread(chat, adapter_name, related_channel.external_id,
+          id: "#{adapter_name}:#{related_channel.external_id}",
+          is_dm: is_dm_channel?(related_channel)
+        )
+
+      true ->
+        nil
+    end
+  end
+
+  defp build_related_message_handle(event, thread, channel) do
+    related_message_id =
+      Map.get(event.metadata, :related_message_id) ||
+        Map.get(event.metadata, "related_message_id")
+
+    if is_binary(related_message_id) do
+      Message.new(%{
+        id: related_message_id,
+        thread_id: thread && thread.id,
+        channel_id: channel && channel.id,
+        external_room_id:
+          cond do
+            match?(%Thread{}, thread) -> thread.external_room_id
+            match?(%ChannelRef{}, channel) -> channel.external_id
+            true -> nil
+          end,
+        external_message_id: related_message_id
+      })
+    end
+  end
+
+  defp parse_thread_identifier(adapter_name, thread_id) when is_binary(thread_id) do
+    prefix = "#{adapter_name}:"
+
+    if String.starts_with?(thread_id, prefix) do
+      rest = String.trim_leading(thread_id, prefix)
+
+      case String.split(rest, ":", parts: 2) do
+        [external_room_id, external_thread_id] -> {external_room_id, external_thread_id}
+        [external_room_id] -> {external_room_id, nil}
+        _ -> nil
+      end
+    end
+  end
+
+  defp parse_thread_identifier(_adapter_name, _thread_id), do: nil
+
+  defp channel_external_id(adapter_name, channel_id) when is_binary(channel_id) do
+    prefix = "#{adapter_name}:"
+
+    if String.starts_with?(channel_id, prefix) do
+      String.trim_leading(channel_id, prefix)
+      |> String.split(":", parts: 2)
+      |> List.first()
+    end
+  end
+
+  defp channel_external_id(_adapter_name, _channel_id), do: nil
+
+  defp is_dm_channel?(%ChannelRef{metadata: metadata}) do
+    metadata[:is_dm] || metadata["is_dm"] || false
+  end
+
+  defp is_dm_channel?(_channel), do: false
 
   defp sync_state(state, %__MODULE__{} = chat) do
     snapshot = StateAdapter.snapshot(chat.state_adapter, state)

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Jido.Chat.MixProject do
   end
 
   def cli do
-    [preferred_envs: [quality: :test, q: :test]]
+    [preferred_envs: [quality: :test, q: :test, cover: :test]]
   end
 
   def application do
@@ -42,6 +42,7 @@ defmodule Jido.Chat.MixProject do
   defp aliases do
     [
       q: ["quality"],
+      cover: ["test --cover"],
       quality: [
         "format --check-formatted",
         "compile --warnings-as-errors",

--- a/test/jido/chat/adapter_conformance_test.exs
+++ b/test/jido/chat/adapter_conformance_test.exs
@@ -1,7 +1,17 @@
 defmodule Jido.Chat.AdapterConformanceTest do
   use ExUnit.Case, async: true
 
-  alias Jido.Chat.{Adapter, CapabilityMatrix, EventEnvelope, Incoming, Response, WebhookRequest}
+  alias Jido.Chat.{
+    Adapter,
+    CapabilityMatrix,
+    EventEnvelope,
+    FileUpload,
+    Incoming,
+    Modal,
+    PostPayload,
+    Response,
+    WebhookRequest
+  }
 
   defmodule GoodAdapter do
     use Adapter
@@ -59,6 +69,75 @@ defmodule Jido.Chat.AdapterConformanceTest do
     end
   end
 
+  defmodule FallbackAdapter do
+    use Adapter
+
+    @impl true
+    def channel_type, do: :fallback
+
+    @impl true
+    def transform_incoming(payload), do: {:ok, Incoming.new(payload)}
+
+    @impl true
+    def send_message(room_id, text, _opts) do
+      send(self(), {:send_message, room_id, text})
+
+      {:ok,
+       Response.new(%{
+         external_message_id: "msg_#{room_id}",
+         external_room_id: room_id,
+         metadata: %{text: text}
+       })}
+    end
+
+    @impl true
+    def send_file(room_id, file, opts) do
+      send(self(), {:send_file, room_id, file, opts})
+
+      {:ok,
+       Response.new(%{
+         external_message_id: "file_#{room_id}",
+         external_room_id: room_id,
+         metadata: %{caption: Keyword.get(opts, :caption)}
+       })}
+    end
+
+    @impl true
+    def edit_message(room_id, message_id, text, _opts) do
+      send(self(), {:edit_message, room_id, message_id, text})
+
+      {:ok,
+       Response.new(%{
+         external_message_id: message_id,
+         external_room_id: room_id,
+         metadata: %{text: text}
+       })}
+    end
+
+    @impl true
+    def open_modal(room_id, payload, _opts) do
+      send(self(), {:open_modal, room_id, payload})
+
+      {:ok, %{id: "modal_#{room_id}", external_room_id: room_id, status: :opened}}
+    end
+
+    @impl true
+    def capabilities do
+      %{
+        send_message: :native,
+        send_file: :native,
+        edit_message: :native,
+        open_modal: :native,
+        cards: :fallback,
+        modals: :native,
+        stream: :fallback,
+        verify_webhook: :fallback,
+        parse_event: :fallback,
+        format_webhook_response: :fallback
+      }
+    end
+  end
+
   test "capability matrix struct normalizes statuses" do
     matrix = Adapter.capability_matrix(GoodAdapter)
 
@@ -81,6 +160,69 @@ defmodule Jido.Chat.AdapterConformanceTest do
     assert {:error, :unsupported} = Adapter.edit_message(GoodAdapter, "room", "msg", "text", [])
     assert {:error, :unsupported} = Adapter.delete_message(GoodAdapter, "room", "msg", [])
     assert {:error, :unsupported} = Adapter.open_thread(GoodAdapter, "room", "msg", [])
+  end
+
+  test "post_message falls back to send_file for single-upload payloads" do
+    payload =
+      PostPayload.new(%{
+        text: "caption",
+        files: [%{path: "/tmp/demo.txt", filename: "demo.txt"}],
+        metadata: %{scope: :conformance}
+      })
+
+    assert {:ok, %Response{external_message_id: "file_room-1"}} =
+             Adapter.post_message(FallbackAdapter, "room-1", payload, [])
+
+    assert_received {:send_file, "room-1", %FileUpload{} = upload, opts}
+    assert upload.path == "/tmp/demo.txt"
+    assert upload.filename == "demo.txt"
+    assert Keyword.fetch!(opts, :caption) == "caption"
+    assert Keyword.fetch!(opts, :metadata) == %{scope: :conformance}
+  end
+
+  test "stream fallback preserves structured chunks through placeholder plus edit" do
+    assert {:ok, %Response{} = response} =
+             Adapter.stream(
+               FallbackAdapter,
+               "room-2",
+               [
+                 "alpha",
+                 %{kind: :step_start, payload: %{label: "Plan"}},
+                 %{kind: :plan, payload: ["one"]}
+               ],
+               fallback_mode: :post_edit,
+               placeholder_text: "working",
+               update_every: 2
+             )
+
+    assert response.external_message_id == "msg_room-2"
+    assert response.metadata.stream_fallback == :post_edit
+    assert_received {:send_message, "room-2", "working"}
+    assert_received {:edit_message, "room-2", "msg_room-2", intermediate_text}
+    assert intermediate_text =~ "alpha"
+    assert intermediate_text =~ "Plan"
+
+    assert_received {:edit_message, "room-2", "msg_room-2", final_text}
+    assert final_text =~ "alpha"
+    assert final_text =~ "Plan"
+    assert final_text =~ "- one"
+  end
+
+  test "typed card and modal helpers expose stable adapter-facing payloads" do
+    assert %{"title" => "Status"} = Adapter.render_card(%{title: "Status"})
+
+    assert {:ok, result} =
+             Adapter.open_modal(
+               FallbackAdapter,
+               "room-3",
+               Modal.new(%{callback_id: "deploy", title: "Deploy"}),
+               []
+             )
+
+    assert result.id == "modal_room-3"
+    assert_received {:open_modal, "room-3", payload}
+    assert payload["callback_id"] == "deploy"
+    assert payload["title"] == "Deploy"
   end
 
   test "default webhook parse path yields typed message envelope" do

--- a/test/jido/chat/ai_test.exs
+++ b/test/jido/chat/ai_test.exs
@@ -96,4 +96,30 @@ defmodule Jido.Chat.AITest do
     assert %{type: "text", text: "{\"ok\":true}", filename: "schema.json"} in ai_message.content
     assert %{type: "text", text: "unsupported:audio"} in ai_message.content
   end
+
+  test "to_ai_messages accepts Chat SDK-style camelCase option aliases" do
+    message =
+      Message.new(%{
+        id: "m1",
+        text: "hello",
+        attachments: [
+          %{type: :file, filename: "schema.json", media_type: "application/json"},
+          %{type: :audio, url: "https://example.com/audio.mp3", media_type: "audio/mpeg"}
+        ],
+        author: Author.new(%{user_id: "user", user_name: "casey"})
+      })
+
+    [ai_message] =
+      AI.to_ai_messages([message],
+        includeNames: true,
+        fetchAttachment: fn %{filename: "schema.json"} -> "{\"ok\":true}" end,
+        onUnsupportedAttachment: fn attachment, _message -> "unsupported:#{attachment.kind}" end,
+        transformMessage: fn ai_message, _message -> Map.put(ai_message, :source, :camel_case) end
+      )
+
+    assert ai_message.name == "casey"
+    assert ai_message.source == :camel_case
+    assert %{type: "text", text: "{\"ok\":true}", filename: "schema.json"} in ai_message.content
+    assert %{type: "text", text: "unsupported:audio"} in ai_message.content
+  end
 end

--- a/test/jido/chat/ai_test.exs
+++ b/test/jido/chat/ai_test.exs
@@ -1,0 +1,99 @@
+defmodule Jido.Chat.AITest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Chat.{AI, Author, Message}
+
+  test "to_messages sorts chronologically, maps roles, and includes names" do
+    assistant =
+      Message.new(%{
+        id: "m2",
+        text: "I can help",
+        created_at: ~U[2026-04-12 22:00:01Z],
+        author: Author.new(%{user_id: "bot", user_name: "jido", is_me: true})
+      })
+
+    user =
+      Message.new(%{
+        id: "m1",
+        text: "hello",
+        created_at: ~U[2026-04-12 22:00:00Z],
+        author: Author.new(%{user_id: "user", user_name: "casey"})
+      })
+
+    system =
+      Message.new(%{
+        id: "m0",
+        text: "policy",
+        created_at: ~U[2026-04-12 21:59:59Z],
+        metadata: %{role: :system}
+      })
+
+    assert [
+             %{role: "system", content: "policy"},
+             %{role: "user", content: "hello", name: "casey"},
+             %{role: "assistant", content: "I can help", name: "jido"}
+           ] = AI.to_messages([assistant, user, system], include_names: true)
+  end
+
+  test "to_messages emits multipart content for images and text-like files" do
+    message =
+      Message.new(%{
+        id: "m1",
+        text: "review these",
+        attachments: [
+          %{type: :image, url: "https://example.com/photo.png", media_type: "image/png"},
+          %{
+            type: :file,
+            filename: "notes.txt",
+            media_type: "text/plain",
+            metadata: %{data: "note body"}
+          }
+        ]
+      })
+
+    assert [
+             %{
+               role: "user",
+               content: [
+                 %{type: "text", text: "review these"},
+                 %{
+                   type: "image",
+                   url: "https://example.com/photo.png",
+                   media_type: "image/png",
+                   metadata: %{}
+                 },
+                 %{type: "text", text: "note body", filename: "notes.txt"}
+               ]
+             }
+           ] = AI.to_messages([message])
+  end
+
+  test "to_messages can fetch text attachments and handle unsupported media with hooks" do
+    message =
+      Message.new(%{
+        id: "m1",
+        text: "context",
+        attachments: [
+          %{type: :file, filename: "schema.json", media_type: "application/json"},
+          %{type: :audio, url: "https://example.com/audio.mp3", media_type: "audio/mpeg"}
+        ]
+      })
+
+    [ai_message] =
+      AI.to_messages([message],
+        fetch_attachment: fn
+          %{filename: "schema.json"} -> {:ok, "{\"ok\":true}"}
+          _ -> nil
+        end,
+        unsupported_attachment: fn attachment, _message ->
+          "unsupported:#{attachment.kind}"
+        end,
+        transform: fn ai_message, _message -> Map.put(ai_message, :metadata, %{source: :test}) end
+      )
+
+    assert ai_message.role == "user"
+    assert ai_message.metadata == %{source: :test}
+    assert %{type: "text", text: "{\"ok\":true}", filename: "schema.json"} in ai_message.content
+    assert %{type: "text", text: "unsupported:audio"} in ai_message.content
+  end
+end

--- a/test/jido/chat/capabilities_test.exs
+++ b/test/jido/chat/capabilities_test.exs
@@ -1,13 +1,15 @@
 defmodule Jido.Chat.CapabilitiesTest do
   use ExUnit.Case, async: true
 
-  alias Jido.Chat.Capabilities
+  alias Jido.Chat.{Capabilities, PostPayload, Postable}
   alias Jido.Chat.Content.{Audio, Image, Text, ToolResult, ToolUse}
 
   test "supports?/2 and all/0" do
     assert Capabilities.supports?([:text, :image], :image)
     refute Capabilities.supports?([:text], :image)
     assert :file in Capabilities.all()
+    assert :multi_file in Capabilities.all()
+    assert :cards in Capabilities.all()
     refute :message_edit in Capabilities.all()
   end
 
@@ -33,6 +35,28 @@ defmodule Jido.Chat.CapabilitiesTest do
     assert [%Audio{}] = Capabilities.unsupported_content(content, [:text, :image])
   end
 
+  test "can_deliver?/2 handles outbound post payloads" do
+    assert Capabilities.can_deliver?(
+             [:text, :file],
+             Postable.text("hello", files: ["/tmp/report.pdf"])
+           )
+
+    refute Capabilities.can_deliver?(
+             [:text, :file],
+             Postable.text("hello", files: ["/tmp/report.pdf", "/tmp/other.pdf"])
+           )
+
+    assert Capabilities.can_deliver?(
+             [:text],
+             PostPayload.new(%{kind: :card, card: %{title: "Card"}, fallback_text: "fallback"})
+           )
+
+    refute Capabilities.can_deliver?(
+             [:text],
+             PostPayload.new(%{kind: :stream, stream: ["hello"]})
+           )
+  end
+
   test "channel_capabilities/1 defaults to [:text] for adapters without an explicit matrix" do
     defmodule AdapterWithoutCapabilities do
       @behaviour Jido.Chat.Adapter
@@ -47,10 +71,10 @@ defmodule Jido.Chat.CapabilitiesTest do
       def send_message(_, _, _), do: {:error, :not_implemented}
     end
 
-    assert Capabilities.channel_capabilities(AdapterWithoutCapabilities) == [:text]
+    assert Capabilities.channel_capabilities(AdapterWithoutCapabilities) == [:text, :streaming]
   end
 
-  test "channel_capabilities/1 derives content and operational support from adapter capability matrices" do
+  test "channel_capabilities/1 derives delivery support from adapter capability matrices" do
     defmodule AdapterWithThreading do
       @behaviour Jido.Chat.Adapter
 
@@ -65,6 +89,8 @@ defmodule Jido.Chat.CapabilitiesTest do
         %{
           send_message: :native,
           post_message: :native,
+          cards: :native,
+          modals: :native,
           open_thread: :native,
           list_threads: :native,
           add_reaction: :native,
@@ -87,6 +113,9 @@ defmodule Jido.Chat.CapabilitiesTest do
              :audio,
              :video,
              :file,
+             :multi_file,
+             :cards,
+             :modals,
              :threads,
              :reactions,
              :typing,

--- a/test/jido/chat/capabilities_test.exs
+++ b/test/jido/chat/capabilities_test.exs
@@ -122,4 +122,28 @@ defmodule Jido.Chat.CapabilitiesTest do
              :streaming
            ]
   end
+
+  test "channel_capabilities/1 preserves legacy list-based adapter capabilities" do
+    defmodule AdapterWithLegacyListCapabilities do
+      @behaviour Jido.Chat.Adapter
+
+      @impl true
+      def channel_type, do: :legacy_caps
+
+      @impl true
+      def capabilities, do: [:text, :image, :threads]
+
+      @impl true
+      def transform_incoming(_), do: {:error, :not_implemented}
+
+      @impl true
+      def send_message(_, _, _), do: {:error, :not_implemented}
+    end
+
+    assert Capabilities.channel_capabilities(AdapterWithLegacyListCapabilities) == [
+             :text,
+             :image,
+             :threads
+           ]
+  end
 end

--- a/test/jido/chat/concurrency_test.exs
+++ b/test/jido/chat/concurrency_test.exs
@@ -1,0 +1,92 @@
+defmodule Jido.Chat.ConcurrencyTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Chat
+
+  test "reject strategy blocks overlapping owners until release" do
+    chat = Chat.new()
+
+    assert {:acquired, chat} = Chat.acquire_lock(chat, "thread:1", "owner-1")
+    assert {:busy, _chat} = Chat.acquire_lock(chat, "thread:1", "owner-2")
+
+    assert {{:released, []}, chat} = Chat.release_lock(chat, "thread:1", "owner-1")
+    assert {:acquired, _chat} = Chat.acquire_lock(chat, "thread:1", "owner-2")
+  end
+
+  test "queue strategy preserves pending owners in order" do
+    chat = Chat.new() |> Chat.configure_concurrency(strategy: :queue)
+
+    assert {:acquired, chat} = Chat.acquire_lock(chat, "thread:queue", "owner-1")
+
+    assert {:queued, chat} =
+             Chat.acquire_lock(chat, "thread:queue", "owner-2",
+               concurrency: [strategy: :queue],
+               metadata: %{message_id: "m2"}
+             )
+
+    assert {:queued, chat} =
+             Chat.acquire_lock(chat, "thread:queue", "owner-3",
+               concurrency: [strategy: :queue],
+               metadata: %{message_id: "m3"}
+             )
+
+    assert {{:released, pending}, _chat} = Chat.release_lock(chat, "thread:queue", "owner-1")
+    assert Enum.map(pending, & &1.owner) == ["owner-2", "owner-3"]
+    assert Enum.map(pending, & &1.metadata.message_id) == ["m2", "m3"]
+  end
+
+  test "debounce strategy only keeps the latest pending owner" do
+    chat = Chat.new() |> Chat.configure_concurrency(strategy: :debounce)
+
+    assert {:acquired, chat} = Chat.acquire_lock(chat, "thread:debounce", "owner-1")
+
+    assert {:debounced, chat} =
+             Chat.acquire_lock(chat, "thread:debounce", "owner-2",
+               concurrency: [strategy: :debounce],
+               metadata: %{message_id: "m2"}
+             )
+
+    assert {:debounced, chat} =
+             Chat.acquire_lock(chat, "thread:debounce", "owner-3",
+               concurrency: [strategy: :debounce],
+               metadata: %{message_id: "m3"}
+             )
+
+    assert {{:released, [%{owner: "owner-3", metadata: %{message_id: "m3"}}]}, _chat} =
+             Chat.release_lock(chat, "thread:debounce", "owner-1")
+  end
+
+  test "concurrent strategy never stores locks" do
+    chat = Chat.new() |> Chat.configure_concurrency(strategy: :concurrent)
+
+    assert {:acquired, chat} =
+             Chat.acquire_lock(chat, "thread:concurrent", "owner-1",
+               concurrency: [strategy: :concurrent]
+             )
+
+    assert {:acquired, chat} =
+             Chat.acquire_lock(chat, "thread:concurrent", "owner-2",
+               concurrency: [strategy: :concurrent]
+             )
+
+    assert %{locks: %{}, pending_locks: %{}} = Chat.lock_snapshot(chat)
+  end
+
+  test "force release drains pending lock snapshots and serialization preserves state" do
+    chat = Chat.new() |> Chat.configure_concurrency(strategy: :queue)
+
+    assert {:acquired, chat} = Chat.acquire_lock(chat, "thread:force", "owner-1")
+
+    assert {:queued, chat} =
+             Chat.acquire_lock(chat, "thread:force", "owner-2", concurrency: [strategy: :queue])
+
+    assert {{:released, [%{owner: "owner-2"}]}, chat} =
+             Chat.force_release_lock(chat, "thread:force")
+
+    encoded = Chat.to_map(chat)
+    revived = Chat.from_map(encoded)
+
+    assert encoded["pending_locks"] == %{}
+    assert %{locks: %{}, pending_locks: %{}} = Chat.lock_snapshot(revived)
+  end
+end

--- a/test/jido/chat/event_envelope_test.exs
+++ b/test/jido/chat/event_envelope_test.exs
@@ -1,0 +1,112 @@
+defmodule Jido.Chat.EventEnvelopeTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Chat.{
+    ActionEvent,
+    AssistantContextChangedEvent,
+    AssistantThreadStartedEvent,
+    EventEnvelope,
+    EventNormalizer,
+    Incoming,
+    ModalCloseEvent,
+    ModalSubmitEvent,
+    ReactionEvent,
+    SlashCommandEvent
+  }
+
+  test "event envelope round-trips each supported payload type" do
+    payloads = [
+      {:message,
+       Incoming.new(%{external_room_id: "room-1", external_message_id: "msg-1", text: "hi"})},
+      {:reaction, ReactionEvent.new(%{emoji: "👍", message_id: "msg-1"})},
+      {:action, ActionEvent.new(%{action_id: "approve", message_id: "msg-2"})},
+      {:modal_submit, ModalSubmitEvent.new(%{callback_id: "deploy", values: %{env: "prod"}})},
+      {:modal_close, ModalCloseEvent.new(%{callback_id: "deploy"})},
+      {:slash_command, SlashCommandEvent.new(%{command: "/deploy", text: "prod"})},
+      {:assistant_thread_started, AssistantThreadStartedEvent.new(%{thread_id: "thr-1"})},
+      {:assistant_context_changed,
+       AssistantContextChangedEvent.new(%{thread_id: "thr-1", context: %{a: 1}})}
+    ]
+
+    for {event_type, payload} <- payloads do
+      envelope =
+        EventEnvelope.new(%{
+          adapter_name: :telegram,
+          event_type: event_type,
+          payload: payload,
+          raw: %{"source" => "test"}
+        })
+
+      round_tripped = envelope |> EventEnvelope.to_map() |> EventEnvelope.from_map()
+
+      assert round_tripped.event_type == event_type
+      assert round_tripped.adapter_name == :telegram
+      assert round_tripped.raw == %{"source" => "test"}
+      assert round_tripped.payload.__struct__ == payload.__struct__
+    end
+  end
+
+  test "event envelope normalizes string event types and infers missing event types" do
+    reaction_envelope =
+      EventEnvelope.new(%{
+        adapter_name: :discord,
+        event_type: "reaction",
+        payload: ReactionEvent.new(%{emoji: "🔥", message_id: "msg-9"})
+      })
+
+    assert reaction_envelope.event_type == :reaction
+
+    assert {:ok, inferred} =
+             EventNormalizer.ensure_event_envelope(
+               %{payload: %{emoji: "🔥", message_id: "msg-9"}},
+               :discord
+             )
+
+    assert inferred.event_type == :reaction
+    assert inferred.adapter_name == :discord
+  end
+
+  test "event normalizer enriches payload-derived ids and normalizes event user maps" do
+    assert {:ok, reaction} =
+             EventNormalizer.ensure_reaction_event(
+               %{
+                 emoji: "👍",
+                 thread_id: "thread-1",
+                 channel_id: "chan-1",
+                 message_id: "msg-1",
+                 user: %{id: "user-1", username: "casey", name: "Casey"}
+               },
+               :slack
+             )
+
+    assert reaction.adapter_name == :slack
+    assert reaction.user.user_id == "user-1"
+    assert reaction.user.user_name == "casey"
+    assert reaction.user.full_name == "Casey"
+
+    envelope =
+      EventEnvelope.new(%{adapter_name: :telegram, event_type: :message, payload: nil})
+      |> EventNormalizer.with_envelope_payload(
+        Incoming.new(%{
+          external_room_id: "room-42",
+          external_thread_id: "thread-77",
+          external_message_id: "msg-88",
+          text: "hello"
+        })
+      )
+
+    assert envelope.thread_id == "telegram:room-42:thread-77"
+    assert envelope.channel_id == "room-42"
+    assert envelope.message_id == "msg-88"
+  end
+
+  test "event normalizer returns tagged errors for invalid inputs" do
+    assert {:error, {:invalid_incoming, :bad}} = EventNormalizer.ensure_incoming(:bad)
+
+    assert {:error, {:invalid_reaction_event, :bad}} =
+             EventNormalizer.ensure_reaction_event(:bad, :slack)
+
+    assert {:error, {:invalid_event_envelope, :bad}} =
+             EventNormalizer.ensure_event_envelope(:bad, :slack)
+  end
+end

--- a/test/jido/chat/runtime_test.exs
+++ b/test/jido/chat/runtime_test.exs
@@ -205,6 +205,7 @@ defmodule Jido.Chat.RuntimeTest do
        %{
          external_room_id: room_id,
          external_thread_id: "thr_#{message_id}",
+         delivery_external_room_id: "delivery_#{message_id}",
          metadata: %{root_message_id: message_id}
        }}
     end
@@ -862,6 +863,7 @@ defmodule Jido.Chat.RuntimeTest do
 
     assert thread.external_thread_id == "thr_msg-1"
     assert thread.metadata.root_message_id == "msg-1"
+    assert thread.metadata.delivery_external_room_id == "delivery_msg-1"
   end
 
   test "channel post preserves postable payload fields in sent handle" do

--- a/test/jido/chat/runtime_test.exs
+++ b/test/jido/chat/runtime_test.exs
@@ -230,6 +230,43 @@ defmodule Jido.Chat.RuntimeTest do
     end
   end
 
+  defmodule EditFallbackAdapter do
+    use Jido.Chat.Adapter
+
+    @impl true
+    def channel_type, do: :edit_fallback
+
+    @impl true
+    def transform_incoming(payload) when is_map(payload), do: {:ok, Incoming.new(payload)}
+
+    @impl true
+    def send_message(room_id, text, _opts) do
+      send(self(), {:fallback_send, room_id, text})
+
+      {:ok,
+       Response.new(%{
+         external_message_id: "stream_msg_#{room_id}",
+         external_room_id: room_id,
+         channel_type: :edit_fallback,
+         metadata: %{sent: text}
+       })}
+    end
+
+    @impl true
+    def edit_message(room_id, message_id, text, _opts) do
+      send(self(), {:fallback_edit, room_id, message_id, text})
+
+      {:ok,
+       Response.new(%{
+         external_message_id: message_id,
+         external_room_id: room_id,
+         status: :edited,
+         channel_type: :edit_fallback,
+         metadata: %{edited: text}
+       })}
+    end
+  end
+
   defmodule RichPostAdapter do
     use Jido.Chat.Adapter
 
@@ -488,6 +525,41 @@ defmodule Jido.Chat.RuntimeTest do
 
     assert sent.id == "stream_room-stream-postable"
     assert_received {:stream, "room-stream-postable", "abc"}
+  end
+
+  test "stream fallback posts placeholder then edits structured output without native stream" do
+    chat = Chat.new(adapters: %{edit_fallback: EditFallbackAdapter})
+    thread = Chat.thread(chat, :edit_fallback, "room-stream-fallback", [])
+
+    assert {:ok, %SentMessage{} = sent} =
+             Thread.post(
+               thread,
+               Postable.stream([
+                 "alpha",
+                 %{kind: :step_start, payload: %{label: "Plan"}},
+                 %{kind: :plan, payload: ["one", "two"]},
+                 "omega"
+               ]),
+               placeholder_text: "working",
+               fallback_mode: :post_edit,
+               update_every: 2
+             )
+
+    assert sent.id == "stream_msg_room-stream-fallback"
+    assert sent.response.metadata.stream_fallback == :post_edit
+    assert_received {:fallback_send, "room-stream-fallback", "working"}
+
+    assert_received {:fallback_edit, "room-stream-fallback", "stream_msg_room-stream-fallback",
+                     first_edit}
+
+    assert first_edit =~ "alpha"
+    assert first_edit =~ "Plan"
+
+    assert_received {:fallback_edit, "room-stream-fallback", "stream_msg_room-stream-fallback",
+                     final_edit}
+
+    assert final_edit =~ "- one"
+    assert final_edit =~ "omega"
   end
 
   test "adapter render helpers expose canonical markdown and card payloads" do

--- a/test/jido/chat/runtime_test.exs
+++ b/test/jido/chat/runtime_test.exs
@@ -495,8 +495,14 @@ defmodule Jido.Chat.RuntimeTest do
 
     assert {:ok, %SentMessage{} = sent} = Thread.post(thread, "hello")
 
-    assert {:ok, %SentMessage{} = edited} = SentMessage.edit(sent, "updated")
+    assert {:ok, %SentMessage{} = edited} =
+             SentMessage.edit(sent, Postable.markdown("**updated**"))
+
     assert edited.response.status == :edited
+    assert edited.text == "**updated**"
+
+    assert {:error, :edit_attachments_unsupported} =
+             SentMessage.edit(sent, Postable.text("updated", files: ["/tmp/report.pdf"]))
 
     assert :ok = SentMessage.delete(sent)
     assert_received {:deleted, "room-6", "msg_room-6"}
@@ -520,6 +526,36 @@ defmodule Jido.Chat.RuntimeTest do
 
     assert ephemeral.used_fallback == true
     assert ephemeral.thread_id == "test:dm-user-7"
+    assert ephemeral.text == "secret"
+  end
+
+  test "ephemeral payloads can use file delivery through DM fallback" do
+    chat = Chat.new(adapters: %{test: TestAdapter})
+    thread = Chat.thread(chat, :test, "room-ephemeral-file", [])
+
+    assert {:ok, ephemeral} =
+             Thread.post_ephemeral(
+               thread,
+               "user-ephemeral",
+               Postable.text("secret", files: [%{path: "/tmp/report.pdf"}]),
+               fallback_to_dm: true
+             )
+
+    assert ephemeral.used_fallback == true
+    assert ephemeral.text == "secret"
+    assert [%{filename: "report.pdf"}] = Enum.map(ephemeral.attachments, &Map.from_struct/1)
+  end
+
+  test "ephemeral file payloads are rejected without DM fallback" do
+    chat = Chat.new(adapters: %{test: TestAdapter})
+    channel = Chat.channel(chat, :test, "chan-ephemeral-file")
+
+    assert {:error, :ephemeral_attachments_unsupported} =
+             Jido.Chat.ChannelRef.post_ephemeral(
+               channel,
+               "user-ephemeral",
+               Postable.text("secret", files: [%{path: "/tmp/report.pdf"}])
+             )
   end
 
   test "thread messages and all_messages pagination" do

--- a/test/jido/chat/runtime_test.exs
+++ b/test/jido/chat/runtime_test.exs
@@ -5,12 +5,15 @@ defmodule Jido.Chat.RuntimeTest do
 
   alias Jido.Chat.{
     Attachment,
+    Card,
     CapabilityMatrix,
     ChannelInfo,
     EventEnvelope,
     Incoming,
     IngressResult,
+    Markdown,
     MessagePage,
+    Modal,
     ModalResult,
     PostPayload,
     Postable,
@@ -428,6 +431,26 @@ defmodule Jido.Chat.RuntimeTest do
     assert upload_opts[:thread_id] == nil
   end
 
+  test "thread post flattens typed card payloads through text fallback" do
+    chat = Chat.new(adapters: %{test: TestAdapter})
+    thread = Chat.thread(chat, :test, "room-card", [])
+
+    card =
+      Card.new(%{
+        title: "Deploy",
+        summary: "Ready",
+        components: [
+          Card.fields([Card.field("Version", "1.2.3")]),
+          Card.actions([Card.button("Approve", "deploy:approve")])
+        ]
+      })
+
+    assert {:ok, %SentMessage{} = sent} = Thread.post(thread, Postable.card(card))
+    assert sent.text =~ "Deploy"
+    assert sent.text =~ "Version: 1.2.3"
+    assert sent.id == "msg_room-card"
+  end
+
   test "thread send_file routes through adapter upload callback" do
     chat = Chat.new(adapters: %{test: TestAdapter})
     thread = Chat.thread(chat, :test, "room-file", [])
@@ -464,6 +487,19 @@ defmodule Jido.Chat.RuntimeTest do
     assert_received {:stream, "room-stream-postable", "abc"}
   end
 
+  test "adapter render helpers expose canonical markdown and card payloads" do
+    markdown =
+      Markdown.root([
+        Markdown.heading(3, "Plan"),
+        Markdown.list(["one", "two"])
+      ])
+
+    card = Card.new(%{title: "Status", components: [Card.button("Run", "run")]})
+
+    assert Jido.Chat.Adapter.render_markdown(markdown) =~ "### Plan"
+    assert %{"title" => "Status"} = Jido.Chat.Adapter.render_card(card)
+  end
+
   test "thread/channel open_modal route through adapter and normalize typed result" do
     chat = Chat.new(adapters: %{test: TestAdapter})
     thread = Chat.thread(chat, :test, "room-modal", [])
@@ -480,6 +516,28 @@ defmodule Jido.Chat.RuntimeTest do
 
     assert channel_result.status == :opened
     assert_received {:open_modal, "room-modal", %{custom_id: "feedback", title: "Feedback"}}
+  end
+
+  test "open_modal accepts typed modal payloads" do
+    chat = Chat.new(adapters: %{test: TestAdapter})
+    thread = Chat.thread(chat, :test, "room-modal-typed", [])
+
+    modal =
+      Modal.new(%{
+        title: "Feedback",
+        callback_id: "feedback",
+        elements: [Modal.text_input("summary", "Summary")]
+      })
+
+    assert {:ok, %ModalResult{} = result} = Thread.open_modal(thread, modal)
+    assert result.external_room_id == "room-modal-typed"
+
+    assert_received {:open_modal, "room-modal-typed",
+                     %{
+                       "title" => "Feedback",
+                       "callback_id" => "feedback",
+                       "elements" => [%{"id" => "summary", "kind" => :text_input}]
+                     }}
   end
 
   test "open_modal returns unsupported when adapter does not implement it" do

--- a/test/jido/chat/runtime_test.exs
+++ b/test/jido/chat/runtime_test.exs
@@ -5,6 +5,8 @@ defmodule Jido.Chat.RuntimeTest do
 
   alias Jido.Chat.{
     Attachment,
+    ActionEvent,
+    Author,
     Card,
     CapabilityMatrix,
     ChannelInfo,
@@ -18,6 +20,7 @@ defmodule Jido.Chat.RuntimeTest do
     PostPayload,
     Postable,
     Response,
+    SlashCommandEvent,
     SentMessage,
     Thread,
     ThreadPage,
@@ -540,6 +543,64 @@ defmodule Jido.Chat.RuntimeTest do
                      }}
   end
 
+  test "filtered action handlers run before catch-all handlers and preserve event context" do
+    chat =
+      Chat.new(adapters: %{test: TestAdapter})
+      |> Chat.on_action("deploy:approve", fn _event -> send(self(), {:action_hit, 1}) end)
+      |> Chat.on_action(fn _event -> send(self(), {:action_hit, 2}) end)
+
+    assert {:ok, _chat, %ActionEvent{} = event} =
+             Chat.process_action(
+               chat,
+               :test,
+               %{
+                 thread_id: "test:room-action:thread-1",
+                 channel_id: "test:room-action",
+                 message_id: "msg-1",
+                 action_id: "deploy:approve",
+                 trigger_id: "trigger-1",
+                 metadata: %{related_message_id: "msg-root"}
+               },
+               []
+             )
+
+    assert %Thread{id: "test:room-action:thread-1"} = event.thread
+    assert %Jido.Chat.ChannelRef{id: "test:room-action"} = event.channel
+    assert %Jido.Chat.Message{id: "msg-1"} = event.message
+    assert %Jido.Chat.Message{id: "msg-root"} = event.related_message
+    assert_receive {:action_hit, 1}
+    assert_receive {:action_hit, 2}
+
+    assert {:ok, %ModalResult{external_room_id: "room-action"}} =
+             ActionEvent.open_modal(event, Modal.new(%{title: "Approval"}))
+  end
+
+  test "filtered slash command handlers match identifiers and expose modal helpers" do
+    chat =
+      Chat.new(adapters: %{test: TestAdapter})
+      |> Chat.on_slash_command("/deploy", fn _event -> send(self(), :slash_specific) end)
+      |> Chat.on_slash_command(fn _event -> send(self(), :slash_all) end)
+
+    assert {:ok, _chat, %SlashCommandEvent{} = event} =
+             Chat.process_slash_command(
+               chat,
+               :test,
+               %{
+                 command: "/deploy",
+                 channel_id: "test:room-slash",
+                 trigger_id: "trigger-2"
+               },
+               []
+             )
+
+    assert %Jido.Chat.ChannelRef{id: "test:room-slash"} = event.channel
+    assert_receive :slash_specific
+    assert_receive :slash_all
+
+    assert {:ok, %ModalResult{external_room_id: "room-slash"}} =
+             SlashCommandEvent.open_modal(event, Modal.new(%{title: "Deploy"}))
+  end
+
   test "open_modal returns unsupported when adapter does not implement it" do
     chat = Chat.new(adapters: %{no_modal: NoModalAdapter})
     thread = Chat.thread(chat, :no_modal, "room-unsupported", [])
@@ -572,6 +633,18 @@ defmodule Jido.Chat.RuntimeTest do
     assert_received {:reaction_remove, "room-6", "msg_room-6", "👍"}
   end
 
+  test "emoji helpers render named reactions for lifecycle APIs" do
+    chat = Chat.new(adapters: %{test: TestAdapter})
+    thread = Chat.thread(chat, :test, "room-emoji", [])
+
+    assert {:ok, %SentMessage{} = sent} = Thread.post(thread, "emoji")
+    assert Chat.emoji(:rocket) == "🚀"
+    assert Chat.emoji(":custom_deploy:", custom: %{custom_deploy: "<deploy>"}) == "<deploy>"
+
+    assert :ok = SentMessage.add_reaction(sent, :thumbs_up)
+    assert_received {:reaction_add, "room-emoji", "msg_room-emoji", "👍"}
+  end
+
   test "thread typing and ephemeral fallback" do
     chat = Chat.new(adapters: %{test: TestAdapter})
     thread = Chat.thread(chat, :test, "room-7", [])
@@ -585,6 +658,29 @@ defmodule Jido.Chat.RuntimeTest do
     assert ephemeral.used_fallback == true
     assert ephemeral.thread_id == "test:dm-user-7"
     assert ephemeral.text == "secret"
+  end
+
+  test "ephemeral card payloads use canonical fallback text through DM fallback" do
+    chat = Chat.new(adapters: %{test: TestAdapter})
+    thread = Chat.thread(chat, :test, "room-ephemeral-card", [])
+
+    card =
+      Card.new(%{
+        title: "Secret",
+        components: [Card.field("Scope", "private")]
+      })
+
+    assert {:ok, ephemeral} =
+             Thread.post_ephemeral(
+               thread,
+               "user-ephemeral-card",
+               Postable.card(card),
+               fallback_to_dm: true
+             )
+
+    assert ephemeral.used_fallback == true
+    assert ephemeral.text =~ "Secret"
+    assert ephemeral.text =~ "Scope: private"
   end
 
   test "ephemeral payloads can use file delivery through DM fallback" do
@@ -664,6 +760,26 @@ defmodule Jido.Chat.RuntimeTest do
     assert thread.external_room_id == "chan-files"
     assert thread.external_thread_id == "thr_root-123"
     assert thread.id == "test:chan-files:thr_root-123"
+  end
+
+  test "open_dm infers adapter from author metadata, prefixed ids, and single-adapter chats" do
+    chat = Chat.new(adapters: %{test: TestAdapter})
+
+    author =
+      Author.new(%{
+        user_id: "user-author",
+        user_name: "author",
+        metadata: %{adapter_name: :test}
+      })
+
+    assert {:ok, %Thread{external_room_id: "dm-user-author", is_dm: true}} =
+             Chat.open_dm(chat, author, [])
+
+    assert {:ok, %Thread{external_room_id: "dm-user-prefixed", is_dm: true}} =
+             Chat.open_dm(chat, "test:user-prefixed", [])
+
+    assert {:ok, %Thread{external_room_id: "dm-user-inferred", is_dm: true}} =
+             Chat.open_dm(chat, "user-inferred", [])
   end
 
   test "chat open_thread routes through adapter helper" do
@@ -883,6 +999,53 @@ defmodule Jido.Chat.RuntimeTest do
     assert_received :slash_hit
     assert_received :assistant_thread_hit
     assert_received :assistant_context_hit
+  end
+
+  test "filtered reaction and modal handlers only fire on matching identifiers" do
+    chat =
+      Chat.new(adapters: %{test: TestAdapter})
+      |> Chat.on_reaction("👍", fn _event -> send(self(), :reaction_specific) end)
+      |> Chat.on_modal_submit("feedback", fn _event -> send(self(), :modal_submit_specific) end)
+      |> Chat.on_modal_close("feedback", fn _event -> send(self(), :modal_close_specific) end)
+
+    assert {:ok, _chat, _event} =
+             Chat.process_reaction(chat, :test, %{thread_id: "test:room-r", emoji: "👍"}, [])
+
+    assert {:ok, _chat, _event} =
+             Chat.process_modal_submit(chat, :test, %{callback_id: "feedback"}, [])
+
+    assert {:ok, _chat, _event} =
+             Chat.process_modal_close(chat, :test, %{callback_id: "feedback"}, [])
+
+    assert_received :reaction_specific
+    assert_received :modal_submit_specific
+    assert_received :modal_close_specific
+
+    assert {:ok, _chat, _event} = Chat.process_reaction(chat, :test, %{emoji: "👎"}, [])
+    refute_received :reaction_specific
+  end
+
+  test "assistant events gain thread and channel handles" do
+    chat = Chat.new(adapters: %{test: TestAdapter})
+
+    assert {:ok, _chat, assistant_started} =
+             Chat.process_assistant_thread_started(chat, :test, %{
+               thread_id: "test:room-assistant:thr-1",
+               channel_id: "test:room-assistant"
+             })
+
+    assert %Thread{id: "test:room-assistant:thr-1"} = assistant_started.thread
+    assert %Jido.Chat.ChannelRef{id: "test:room-assistant"} = assistant_started.channel
+
+    assert {:ok, _chat, assistant_changed} =
+             Chat.process_assistant_context_changed(chat, :test, %{
+               thread_id: "test:room-assistant:thr-1",
+               channel_id: "test:room-assistant",
+               context: %{phase: :thinking}
+             })
+
+    assert %Thread{id: "test:room-assistant:thr-1"} = assistant_changed.thread
+    assert assistant_changed.context == %{phase: :thinking}
   end
 
   test "process_event routes typed envelopes" do

--- a/test/jido/chat/runtime_test.exs
+++ b/test/jido/chat/runtime_test.exs
@@ -453,6 +453,17 @@ defmodule Jido.Chat.RuntimeTest do
     assert_received {:stream, "room-stream-post", "abc"}
   end
 
+  test "thread post routes stream postables through adapter stream callback" do
+    chat = Chat.new(adapters: %{test: TestAdapter})
+    thread = Chat.thread(chat, :test, "room-stream-postable", [])
+
+    assert {:ok, %SentMessage{} = sent} =
+             Thread.post(thread, Postable.stream(["a", "b", "c"]))
+
+    assert sent.id == "stream_room-stream-postable"
+    assert_received {:stream, "room-stream-postable", "abc"}
+  end
+
   test "thread/channel open_modal route through adapter and normalize typed result" do
     chat = Chat.new(adapters: %{test: TestAdapter})
     thread = Chat.thread(chat, :test, "room-modal", [])
@@ -599,6 +610,26 @@ defmodule Jido.Chat.RuntimeTest do
     assert_received {:send_file, "chan-post-file", %{kind: :file, filename: "doc.pdf"},
                      upload_opts}
 
+    assert upload_opts[:caption] == "hello"
+    assert upload_opts[:text] == "hello"
+  end
+
+  test "channel post routes file-bearing payloads through send_file" do
+    chat = Chat.new(adapters: %{test: TestAdapter})
+    channel = Chat.channel(chat, :test, "chan-post-upload")
+
+    assert {:ok, %SentMessage{} = sent} =
+             Jido.Chat.ChannelRef.post(
+               channel,
+               Postable.text("hello", files: [%{path: "/tmp/report.pdf"}])
+             )
+
+    assert sent.id == "file_chan-post-upload"
+
+    assert [%{kind: :file, filename: "report.pdf"}] =
+             Enum.map(sent.attachments, &Map.from_struct/1)
+
+    assert_received {:send_file, "chan-post-upload", %{path: "/tmp/report.pdf"}, upload_opts}
     assert upload_opts[:caption] == "hello"
     assert upload_opts[:text] == "hello"
   end

--- a/test/jido/chat/serialization_test.exs
+++ b/test/jido/chat/serialization_test.exs
@@ -5,13 +5,17 @@ defmodule Jido.Chat.SerializationTest do
 
   alias Jido.Chat.{
     Attachment,
+    Card,
     CapabilityMatrix,
     ChannelRef,
     EventEnvelope,
     FileUpload,
     IngressResult,
+    Markdown,
     Message,
+    Modal,
     ModalResult,
+    ModalResponse,
     PostPayload,
     Response,
     SentMessage,
@@ -206,6 +210,37 @@ defmodule Jido.Chat.SerializationTest do
            } = payload |> PostPayload.to_map() |> PostPayload.from_map()
   end
 
+  test "markdown, card, modal, and modal response round-trip" do
+    markdown =
+      Markdown.root([
+        Markdown.heading(2, "Release"),
+        Markdown.paragraph("Ready")
+      ])
+
+    card =
+      Card.new(%{
+        title: "Deploy",
+        summary: "Ready",
+        components: [Card.button("Approve", "deploy:approve")]
+      })
+
+    modal =
+      Modal.new(%{
+        title: "Feedback",
+        callback_id: "feedback",
+        elements: [Modal.text_input("summary", "Summary")]
+      })
+
+    response = ModalResponse.push(modal)
+
+    assert %Markdown{} = markdown |> Markdown.to_map() |> Markdown.from_map()
+    assert %Card{} = card |> Card.to_map() |> Card.from_map()
+    assert %Modal{} = modal |> Modal.to_map() |> Modal.from_map()
+
+    assert %ModalResponse{action: :push, modal: %Modal{callback_id: "feedback"}} =
+             response |> ModalResponse.to_map() |> ModalResponse.from_map()
+  end
+
   test "event and webhook structs round-trip" do
     envelope =
       EventEnvelope.new(%{
@@ -316,5 +351,17 @@ defmodule Jido.Chat.SerializationTest do
 
     assert %ModalResult{} =
              reviver.(ModalResult.new(%{id: "modal_1"}) |> ModalResult.to_map())
+
+    assert %Markdown{} =
+             reviver.(Markdown.root([Markdown.paragraph("hello")]) |> Markdown.to_map())
+
+    assert %Card{} =
+             reviver.(Card.new(%{title: "Status"}) |> Card.to_map())
+
+    assert %Modal{} =
+             reviver.(Modal.new(%{title: "Feedback"}) |> Modal.to_map())
+
+    assert %ModalResponse{} =
+             reviver.(ModalResponse.close() |> ModalResponse.to_map())
   end
 end

--- a/test/jido/chat/serialization_test.exs
+++ b/test/jido/chat/serialization_test.exs
@@ -18,18 +18,65 @@ defmodule Jido.Chat.SerializationTest do
     WebhookResponse
   }
 
+  defmodule WrappedStateAdapter do
+    @behaviour Jido.Chat.StateAdapter
+
+    alias Jido.Chat.StateAdapters.Memory
+
+    @impl true
+    def init(snapshot, opts), do: {:wrapped, Memory.init(snapshot, opts)}
+
+    @impl true
+    def snapshot({:wrapped, state}), do: Memory.snapshot(state)
+
+    @impl true
+    def subscribed?({:wrapped, state}, thread_id), do: Memory.subscribed?(state, thread_id)
+
+    @impl true
+    def subscribe({:wrapped, state}, thread_id),
+      do: {:wrapped, Memory.subscribe(state, thread_id)}
+
+    @impl true
+    def unsubscribe({:wrapped, state}, thread_id),
+      do: {:wrapped, Memory.unsubscribe(state, thread_id)}
+
+    @impl true
+    def thread_state({:wrapped, state}, thread_id), do: Memory.thread_state(state, thread_id)
+
+    @impl true
+    def put_thread_state({:wrapped, state}, thread_id, value),
+      do: {:wrapped, Memory.put_thread_state(state, thread_id, value)}
+
+    @impl true
+    def channel_state({:wrapped, state}, channel_id), do: Memory.channel_state(state, channel_id)
+
+    @impl true
+    def put_channel_state({:wrapped, state}, channel_id, value),
+      do: {:wrapped, Memory.put_channel_state(state, channel_id, value)}
+
+    @impl true
+    def duplicate?({:wrapped, state}, key), do: Memory.duplicate?(state, key)
+
+    @impl true
+    def mark_dedupe({:wrapped, state}, key, limit),
+      do: {:wrapped, Memory.mark_dedupe(state, key, limit)}
+  end
+
   test "chat serialization is JSON-safe and explicitly non-serializable for handlers" do
     chat =
-      Chat.new(adapters: %{test: __MODULE__}, metadata: %{env: :test})
+      Chat.new(
+        adapters: %{test: __MODULE__},
+        metadata: %{env: :test},
+        dedupe: MapSet.new([{:test, "m1"}]),
+        dedupe_order: [{:test, "m1"}]
+      )
       |> Chat.on_new_mention(fn _thread, _incoming -> :ok end)
       |> Chat.on_new_message(~r/^ping$/, fn _thread, _incoming -> :ok end)
-      |> then(fn value ->
-        %{value | dedupe: MapSet.new([{:test, "m1"}]), dedupe_order: [{:test, "m1"}]}
-      end)
 
     encoded = Chat.to_map(chat)
 
     assert encoded["__type__"] == "chat"
+    assert encoded["state_adapter"] == "Elixir.Jido.Chat.StateAdapters.Memory"
     assert encoded["handlers"]["serializable"] == false
     assert encoded["handlers"]["counts"]["mention"] == 1
     assert encoded["handlers"]["counts"]["message"] == 1
@@ -42,6 +89,31 @@ defmodule Jido.Chat.SerializationTest do
     assert revived.dedupe_order == [{:test, "m1"}]
     assert revived.handlers.mention == []
     assert revived.handlers.message == []
+  end
+
+  test "chat serialization preserves custom state adapter snapshots" do
+    chat =
+      Chat.new(
+        adapters: %{test: __MODULE__},
+        state_adapter: WrappedStateAdapter,
+        subscriptions: ["test:room-1"],
+        thread_state: %{"test:room-1" => %{phase: :open}}
+      )
+      |> Chat.subscribe("test:room-2")
+      |> Chat.put_channel_state("test:chan-1", %{topic: "general"})
+
+    encoded = Chat.to_map(chat)
+
+    assert encoded["state_adapter"] == "Elixir.Jido.Chat.SerializationTest.WrappedStateAdapter"
+
+    revived = Chat.from_map(encoded)
+
+    assert revived.state_adapter == WrappedStateAdapter
+    assert match?({:wrapped, _}, revived.state)
+    assert Chat.subscribed?(revived, "test:room-1")
+    assert Chat.subscribed?(revived, "test:room-2")
+    assert Chat.thread_state(revived, "test:room-1") == %{"phase" => :open}
+    assert Chat.channel_state(revived, "test:chan-1") == %{"topic" => "general"}
   end
 
   test "thread and channel refs round-trip with module adapters" do

--- a/test/jido/chat/serialization_test.exs
+++ b/test/jido/chat/serialization_test.exs
@@ -8,11 +8,14 @@ defmodule Jido.Chat.SerializationTest do
     CapabilityMatrix,
     ChannelRef,
     EventEnvelope,
+    FileUpload,
     IngressResult,
     Message,
     ModalResult,
+    PostPayload,
     Response,
     SentMessage,
+    StreamChunk,
     Thread,
     WebhookRequest,
     WebhookResponse
@@ -173,6 +176,34 @@ defmodule Jido.Chat.SerializationTest do
 
     assert %SentMessage{attachments: [%Attachment{filename: "report.pdf"}]} =
              sent |> SentMessage.to_map() |> SentMessage.from_map()
+  end
+
+  test "file upload, stream chunk, and post payload round-trip" do
+    payload =
+      PostPayload.new(%{
+        kind: :card,
+        card: %{title: "Card"},
+        fallback_text: "Card fallback",
+        files: [%{path: "/tmp/report.pdf", media_type: "application/pdf"}],
+        stream: ["hello", %{kind: :status, text: "working"}]
+      })
+
+    assert %FileUpload{filename: "report.pdf"} =
+             %{path: "/tmp/report.pdf", media_type: "application/pdf"}
+             |> FileUpload.normalize()
+             |> FileUpload.to_map()
+             |> FileUpload.from_map()
+
+    assert %StreamChunk{kind: :status, text: "working"} =
+             StreamChunk.new(%{kind: :status, text: "working"})
+             |> StreamChunk.to_map()
+             |> StreamChunk.from_map()
+
+    assert %PostPayload{
+             kind: :card,
+             fallback_text: "Card fallback",
+             files: [%FileUpload{filename: "report.pdf"}]
+           } = payload |> PostPayload.to_map() |> PostPayload.from_map()
   end
 
   test "event and webhook structs round-trip" do

--- a/test/jido/chat/serialization_test.exs
+++ b/test/jido/chat/serialization_test.exs
@@ -4,20 +4,28 @@ defmodule Jido.Chat.SerializationTest do
   alias Jido.Chat
 
   alias Jido.Chat.{
+    ActionEvent,
+    AssistantContextChangedEvent,
+    AssistantThreadStartedEvent,
     Attachment,
     Card,
     CapabilityMatrix,
     ChannelRef,
     EventEnvelope,
     FileUpload,
+    Incoming,
     IngressResult,
     Markdown,
     Message,
     Modal,
+    ModalCloseEvent,
     ModalResult,
+    ModalSubmitEvent,
     ModalResponse,
     PostPayload,
+    ReactionEvent,
     Response,
+    SlashCommandEvent,
     SentMessage,
     StreamChunk,
     Thread,
@@ -288,6 +296,90 @@ defmodule Jido.Chat.SerializationTest do
 
     assert %IngressResult{adapter_name: :test, mode: :request} =
              ingress_result |> IngressResult.to_map() |> IngressResult.from_map()
+  end
+
+  test "typed event payloads survive envelope serialization and reviving" do
+    reviver = Chat.reviver()
+
+    thread =
+      Thread.new(%{
+        id: "test:room-1:thr-1",
+        adapter_name: :test,
+        adapter: __MODULE__,
+        external_room_id: "room-1",
+        external_thread_id: "thr-1"
+      })
+
+    channel =
+      ChannelRef.new(%{
+        id: "test:room-1",
+        adapter_name: :test,
+        adapter: __MODULE__,
+        external_id: "room-1"
+      })
+
+    message =
+      Message.new(%{
+        id: "m1",
+        thread_id: thread.id,
+        channel_id: channel.id,
+        external_room_id: "room-1",
+        external_message_id: "m1"
+      })
+
+    reaction =
+      ReactionEvent.new(%{
+        adapter_name: :test,
+        thread_id: thread.id,
+        channel_id: channel.id,
+        message_id: "m1",
+        emoji: "👍",
+        thread: thread,
+        channel: channel,
+        message: message
+      })
+
+    envelope =
+      EventEnvelope.new(%{
+        adapter_name: :test,
+        event_type: :reaction,
+        payload: reaction
+      })
+
+    assert %EventEnvelope{payload: %ReactionEvent{thread: %Thread{}, channel: %ChannelRef{}}} =
+             envelope |> EventEnvelope.to_map() |> EventEnvelope.from_map()
+
+    assert %Incoming{} =
+             reviver.(
+               Incoming.new(%{external_room_id: "room-2", external_message_id: "m2"})
+               |> Incoming.to_map()
+             )
+
+    assert %ReactionEvent{} = reviver.(reaction |> ReactionEvent.to_map())
+
+    assert %ActionEvent{} =
+             reviver.(ActionEvent.new(%{action_id: "approve"}) |> ActionEvent.to_map())
+
+    assert %ModalSubmitEvent{} =
+             reviver.(ModalSubmitEvent.new(%{callback_id: "form"}) |> ModalSubmitEvent.to_map())
+
+    assert %ModalCloseEvent{} =
+             reviver.(ModalCloseEvent.new(%{callback_id: "form"}) |> ModalCloseEvent.to_map())
+
+    assert %SlashCommandEvent{} =
+             reviver.(SlashCommandEvent.new(%{command: "/help"}) |> SlashCommandEvent.to_map())
+
+    assert %AssistantThreadStartedEvent{} =
+             reviver.(
+               AssistantThreadStartedEvent.new(%{thread_id: "test:room:thr"})
+               |> AssistantThreadStartedEvent.to_map()
+             )
+
+    assert %AssistantContextChangedEvent{} =
+             reviver.(
+               AssistantContextChangedEvent.new(%{thread_id: "test:room:thr", context: %{a: 1}})
+               |> AssistantContextChangedEvent.to_map()
+             )
   end
 
   test "chat reviver supports all typed payloads" do

--- a/test/jido/chat/serialization_test.exs
+++ b/test/jido/chat/serialization_test.exs
@@ -75,6 +75,20 @@ defmodule Jido.Chat.SerializationTest do
     @impl true
     def mark_dedupe({:wrapped, state}, key, limit),
       do: {:wrapped, Memory.mark_dedupe(state, key, limit)}
+
+    @impl true
+    def lock({:wrapped, state}, key, owner, strategy, metadata),
+      do: unwrap_lock(Memory.lock(state, key, owner, strategy, metadata))
+
+    @impl true
+    def release_lock({:wrapped, state}, key, owner),
+      do: unwrap_lock(Memory.release_lock(state, key, owner))
+
+    @impl true
+    def force_release_lock({:wrapped, state}, key),
+      do: unwrap_lock(Memory.force_release_lock(state, key))
+
+    defp unwrap_lock({result, state}), do: {result, {:wrapped, state}}
   end
 
   test "chat serialization is JSON-safe and explicitly non-serializable for handlers" do

--- a/test/jido/chat/structs_test.exs
+++ b/test/jido/chat/structs_test.exs
@@ -16,11 +16,15 @@ defmodule Jido.Chat.StructsTest do
     FileUpload,
     FetchOptions,
     Incoming,
+    Card,
     Media,
+    Markdown,
     Mention,
     Message,
     MessagePage,
+    Modal,
     ModalResult,
+    ModalResponse,
     ModalCloseEvent,
     ModalSubmitEvent,
     Participant,
@@ -188,17 +192,114 @@ defmodule Jido.Chat.StructsTest do
       assert is_binary(raw_payload.text)
 
       ast_payload = Postable.ast(%{node: :p}) |> Postable.to_payload()
-      assert ast_payload.ast == %{node: :p}
+      assert %Markdown{} = ast_payload.ast
       assert ast_payload.raw == %{node: :p}
       assert ast_payload.metadata.format == :ast
 
       card_payload =
         Postable.card(%{title: "Card"}, fallback_text: "fallback card") |> Postable.to_payload()
 
-      assert card_payload.card == %{title: "Card"}
-      assert card_payload.raw == %{title: "Card"}
+      assert %Card{title: "Card"} = card_payload.card
+      assert %Card{title: "Card"} = card_payload.raw
       assert card_payload.fallback_text == "fallback card"
       assert card_payload.metadata.format == :card
+    end
+
+    test "markdown helpers provide stringify, plain text, walk, and table fallbacks" do
+      markdown =
+        Markdown.root([
+          Markdown.heading(2, "Overview"),
+          Markdown.paragraph([
+            Markdown.text("hello "),
+            Markdown.strong("world"),
+            Markdown.text(" from "),
+            Markdown.link("jido", "https://example.com")
+          ]),
+          Markdown.table([
+            ["Name", "Role"],
+            ["Ada", "admin"],
+            ["Bea", "editor"]
+          ])
+        ])
+
+      walked =
+        Markdown.walk(markdown, fn
+          %Jido.Chat.Markdown.Node{type: :text, text: "world"} = node ->
+            %{node | text: "team"}
+
+          node ->
+            node
+        end)
+
+      assert Markdown.stringify(markdown) =~ "## Overview"
+      assert Markdown.plain_text(walked) =~ "hello team from jido"
+      assert Markdown.table_to_ascii(markdown) =~ "Name"
+      assert Markdown.parse("## Parsed\n\nhello").root.type == :root
+    end
+
+    test "typed markdown and card payloads preserve canonical rich content" do
+      markdown =
+        Markdown.root([
+          Markdown.heading(2, "Status"),
+          Markdown.paragraph("Everything is green.")
+        ])
+
+      ast_payload = Postable.ast(markdown) |> Postable.to_payload()
+      assert %Markdown{} = ast_payload.ast
+      assert ast_payload.text == "Status\n\nEverything is green."
+      assert ast_payload.formatted =~ "## Status"
+
+      card =
+        Card.new(%{
+          title: "Deployment",
+          summary: "Ready to ship",
+          components: [
+            Card.fields([
+              Card.field("Version", "1.2.3"),
+              Card.field("Region", "us-central")
+            ]),
+            Card.actions([
+              Card.button("Approve", "deploy:approve", value: "ship"),
+              Card.link_button("Logs", "https://example.com/logs")
+            ]),
+            Card.table(["Name", "State"], [["api", "ok"], ["worker", "ok"]])
+          ]
+        })
+
+      card_payload = Postable.card(card) |> Postable.to_payload()
+
+      assert %Card{} = card_payload.card
+      assert card_payload.fallback_text =~ "Deployment"
+      assert card_payload.fallback_text =~ "Version: 1.2.3"
+      assert card_payload.text == card_payload.fallback_text
+    end
+
+    test "modal builders and modal responses normalize canonical lifecycle data" do
+      modal =
+        Modal.new(%{
+          title: "Feedback",
+          callback_id: "feedback",
+          notify_on_close: true,
+          private_metadata: "thread:test:1",
+          elements: [
+            Modal.text_input("summary", "Summary", required: true),
+            Modal.radio_select("sentiment", "Sentiment", [
+              Modal.select_option("Good", "good"),
+              Modal.select_option("Bad", "bad")
+            ])
+          ]
+        })
+
+      assert modal.callback_id == "feedback"
+      assert Enum.map(modal.elements, & &1.kind) == [:text_input, :radio_select]
+
+      assert %ModalResponse{action: :close} = ModalResponse.close()
+
+      assert %ModalResponse{action: :errors, errors: %{"summary" => "required"}} =
+               ModalResponse.errors(%{"summary" => "required"})
+
+      assert %ModalResponse{action: :update, modal: %Modal{title: "Feedback"}} =
+               ModalResponse.update(modal)
     end
 
     test "post payloads normalize outbound attachments into typed structs" do
@@ -269,6 +370,7 @@ defmodule Jido.Chat.StructsTest do
         Postable.stream([
           "hello",
           %{kind: :status, text: "working", metadata: %{phase: 1}},
+          %{kind: :step_start, payload: %{label: "Draft response"}},
           StreamChunk.text("done")
         ])
         |> Postable.to_payload()
@@ -276,7 +378,9 @@ defmodule Jido.Chat.StructsTest do
       assert payload.kind == :stream
       assert payload.stream |> Enum.at(0) == "hello"
       assert %StreamChunk{kind: :status, text: "working"} = Enum.at(payload.stream, 1)
-      assert %StreamChunk{kind: :text, text: "done"} = Enum.at(payload.stream, 2)
+      assert %StreamChunk{kind: :step_start} = Enum.at(payload.stream, 2)
+      assert %StreamChunk{kind: :text, text: "done"} = Enum.at(payload.stream, 3)
+      assert payload.fallback_text == "helloworkingDraft responsedone"
     end
 
     test "event placeholder structs parse cleanly" do

--- a/test/jido/chat/structs_test.exs
+++ b/test/jido/chat/structs_test.exs
@@ -13,6 +13,7 @@ defmodule Jido.Chat.StructsTest do
     ChannelMeta,
     EphemeralMessage,
     EventEnvelope,
+    FileUpload,
     FetchOptions,
     Incoming,
     Media,
@@ -30,6 +31,7 @@ defmodule Jido.Chat.StructsTest do
     Room,
     SentMessage,
     SlashCommandEvent,
+    StreamChunk,
     ThreadPage,
     ThreadSummary,
     WebhookRequest,
@@ -177,6 +179,7 @@ defmodule Jido.Chat.StructsTest do
       assert text_payload.formatted == "hello"
 
       markdown_payload = Postable.markdown("**hello**") |> Postable.to_payload()
+      assert markdown_payload.markdown == "**hello**"
       assert markdown_payload.text == "**hello**"
       assert markdown_payload.metadata.format == :markdown
 
@@ -185,11 +188,16 @@ defmodule Jido.Chat.StructsTest do
       assert is_binary(raw_payload.text)
 
       ast_payload = Postable.ast(%{node: :p}) |> Postable.to_payload()
+      assert ast_payload.ast == %{node: :p}
       assert ast_payload.raw == %{node: :p}
       assert ast_payload.metadata.format == :ast
 
-      card_payload = Postable.card(%{title: "Card"}) |> Postable.to_payload()
+      card_payload =
+        Postable.card(%{title: "Card"}, fallback_text: "fallback card") |> Postable.to_payload()
+
+      assert card_payload.card == %{title: "Card"}
       assert card_payload.raw == %{title: "Card"}
+      assert card_payload.fallback_text == "fallback card"
       assert card_payload.metadata.format == :card
     end
 
@@ -222,6 +230,53 @@ defmodule Jido.Chat.StructsTest do
                  media_type: "application/pdf"
                }
              ] = payload.attachments
+    end
+
+    test "post payloads normalize outbound files into typed structs" do
+      payload =
+        Postable.new(%{
+          markdown: "**hello**",
+          files: [
+            "/tmp/report.pdf",
+            %{url: "https://example.com/photo.jpg", media_type: "image/jpeg"}
+          ]
+        })
+        |> Postable.to_payload()
+
+      assert payload.kind == :markdown
+
+      assert [
+               %FileUpload{
+                 kind: :file,
+                 path: "/tmp/report.pdf",
+                 filename: "report.pdf"
+               },
+               %FileUpload{
+                 kind: :image,
+                 url: "https://example.com/photo.jpg",
+                 media_type: "image/jpeg"
+               }
+             ] = payload.files
+
+      assert [
+               %Attachment{filename: "report.pdf", kind: :file},
+               %Attachment{kind: :image, url: "https://example.com/photo.jpg"}
+             ] = PostPayload.outbound_attachments(payload)
+    end
+
+    test "stream postables preserve text chunks and normalize structured chunks" do
+      payload =
+        Postable.stream([
+          "hello",
+          %{kind: :status, text: "working", metadata: %{phase: 1}},
+          StreamChunk.text("done")
+        ])
+        |> Postable.to_payload()
+
+      assert payload.kind == :stream
+      assert payload.stream |> Enum.at(0) == "hello"
+      assert %StreamChunk{kind: :status, text: "working"} = Enum.at(payload.stream, 1)
+      assert %StreamChunk{kind: :text, text: "done"} = Enum.at(payload.stream, 2)
     end
 
     test "event placeholder structs parse cleanly" do


### PR DESCRIPTION
Refs #8

## Summary
- add the canonical outbound payload contract across text, markdown, cards, files, and structured streams
- route attachment-bearing thread and channel posts through `Adapter.post_message/4` so single-upload payloads can fall back to `send_file/3`
- replace inferred capability reporting with explicit capability matrices and deterministic fallback behavior
- add markdown, card, modal, emoji, richer event, direct-message, and assistant workflow surfaces
- add structured stream fallback and framework-agnostic AI history conversion helpers
- harden capability discovery for explicit matrices and legacy list-based adapters
- preserve adapter-provided delivery room metadata when `open_thread/3` normalizes thread handles
- accept Chat SDK-style AI helper option aliases for smoother cross-port migration while keeping Elixir-native defaults
- add targeted event envelope and event normalizer tests around typed payload round-trips and inference
- narrow the package docs and parity language so `jido_chat` is clearly the adapter/data-model layer, not the production runtime/process-tree layer

## What This PR Means
This PR brings `jido_chat` to functional parity with the adapter and canonical data-model surfaces of the Chat SDK that make sense in an Elixir/OTP port: typed event routing, canonical outbound payloads, adapter capability negotiation, stream fallback, modal/card payload modeling, and AI history conversion.

It does **not** claim byte-for-byte or naming-level parity with the TypeScript SDK, and it does **not** treat `jido_chat` as the production runtime package. Supervision, ingress plumbing, delivery queues, retries, room/session state, and bridge lifecycle belong in `jido_messaging`.

## Breaking Changes
- `Jido.Chat.StateAdapter` now requires `lock/5`, `release_lock/3`, and `force_release_lock/2`
- state adapter snapshots now include `locks` and `pending_locks`
- adapters should declare support explicitly in `capabilities/0`
- `Jido.Chat.PostPayload` is now the canonical outbound contract for files, cards, streams, and rich fallback text

## Validation
- `mix quality` passes
- `121` tests, `0` failures
- `mix cover` currently reports `66.08%` total coverage against the active `90%` threshold, so this PR does **not** claim exhaustive coverage

## Remaining Deliberate Gaps
- `jido_chat` still ships lightweight state/concurrency hooks today even though production ownership belongs higher in the stack
- structured stream fallback does not attempt markdown healing or table buffering
- platform-native card and modal rendering remain adapter-specific
- the AI conversion helper is structurally compatible with Chat SDK / AI SDK message shapes, but keeps Elixir-native naming and callback conventions
