### PR TITLE
ci: roll out jido workflows v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,64 +1,30 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
+  merge_group:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
 
 jobs:
-  lint:
-    name: Lint
-    uses: agentjido/github-actions/.github/workflows/elixir-lint.yml@v3
+  ci:
+    name: CI
+    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@v4
+    secrets: inherit
     with:
-      otp_version: "27.3"
-      elixir_version: "1.18.4"
-      validate_hex_package: false
-
-  test:
-    name: Test
-    uses: agentjido/github-actions/.github/workflows/elixir-test.yml@v3
-    with:
-      otp_versions: '["27.3"]'
-      elixir_versions: '["1.18.4"]'
+      otp_versions: '["27", "28"]'
+      elixir_versions: '["1.18", "1.19"]'
+      experimental_compile_elixir_versions: '["v1.20.0-rc.4"]'
+      experimental_compile_otp_versions: '["28.4.1"]'
+      experimental_compile_otp_name: '28'
+      docs_command: mix docs -f html
       test_command: mix test
-
-  coverage:
-    name: Coverage
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Set up Elixir
-        uses: erlef/setup-beam@v1
-        with:
-          otp-version: "27.3"
-          elixir-version: "1.18.4"
-
-      - name: Restore cached deps
-        uses: actions/cache@v5
-        with:
-          path: |
-            deps
-            _build
-          key: ${{ runner.os }}-coverage-${{ hashFiles('mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-coverage-
-
-      - name: Install Hex/Rebar
-        run: |
-          set -euo pipefail
-          mix local.hex --force
-          mix local.rebar --force
-
-      - name: Install dependencies
-        run: mix deps.get
-
-      - name: Run coverage
-        run: mix coveralls
-
-      - name: Upload coverage
-        uses: codecov/codecov-action@v5
-        with:
-          files: ./cover/excoveralls.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,6 @@ jobs:
       experimental_compile_elixir_versions: '["v1.20.0-rc.4"]'
       experimental_compile_otp_versions: '["28.4.1"]'
       experimental_compile_otp_name: '28'
+      credo_command: mix credo --min-priority higher
       docs_command: mix docs -f html
       test_command: mix test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,25 @@
 name: Release
 
 on:
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
+      operation:
+        description: "Release operation: auto, prepare, or publish"
+        required: false
+        type: choice
+        default: auto
+        options:
+          - auto
+          - prepare
+          - publish
+      tag_name:
+        description: "Optional v-prefixed tag for publish simulation"
+        required: false
+        type: string
+        default: ""
       dry_run:
         description: "Dry run (no git push, no tag, no GitHub release, no Hex publish)"
         required: false
@@ -18,18 +35,25 @@ on:
         required: false
         type: boolean
         default: false
+      version_override:
+        description: "Optional bare SemVer override (for example 1.2.3, not v1.2.3)"
+        required: false
+        type: string
+        default: ""
 
 permissions:
+  actions: read
   contents: write
 
 jobs:
   release:
     name: Release
-    uses: agentjido/github-actions/.github/workflows/elixir-release.yml@v3
+    uses: agentjido/github-actions/.github/workflows/jido-release.yml@v4
     with:
-      otp_version: "27.3"
-      elixir_version: "1.18.4"
-      dry_run: ${{ inputs.dry_run }}
-      hex_dry_run: ${{ inputs.hex_dry_run }}
-      skip_tests: ${{ inputs.skip_tests }}
+      operation: ${{ inputs.operation || 'auto' }}
+      tag_name: ${{ inputs.tag_name || '' }}
+      dry_run: ${{ inputs.dry_run || false }}
+      hex_dry_run: ${{ inputs.hex_dry_run || false }}
+      skip_tests: ${{ inputs.skip_tests || false }}
+      version_override: ${{ inputs.version_override || '' }}
     secrets: inherit

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,21 @@
+name: Jido Review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  review:
+    name: Jido Review
+    uses: agentjido/github-actions/.github/workflows/jido-review.yml@v4


### PR DESCRIPTION
## Summary
- replace legacy shared v3 CI and release callers with stock Jido workflows v4
- add the stock Jido Review workflow

## Validation
- ruby workflow YAML parse
- git diff --check
- actionlint
- stale shared workflow reference scan