### PR TITLE
fix(type): external_message_id can be any type

### DIFF
--- a/lib/jido/chat/adapter.ex
+++ b/lib/jido/chat/adapter.ex
@@ -858,13 +858,16 @@ defmodule Jido.Chat.Adapter do
 
   defp normalize_response(adapter_module, %Response{} = response) do
     response
-    |> Map.put_new(:channel_type, adapter_type(adapter_module))
+    |> Map.put(:channel_type, Map.get(response, :channel_type) || adapter_type(adapter_module))
     |> Response.new()
   end
 
   defp normalize_response(adapter_module, map) when is_map(map) do
     map
-    |> Map.put_new(:channel_type, adapter_type(adapter_module))
+    |> Map.put(
+      :channel_type,
+      Map.get(map, :channel_type) || Map.get(map, "channel_type") || adapter_type(adapter_module)
+    )
     |> Response.new()
   end
 

--- a/lib/jido/chat/capability_matrix.ex
+++ b/lib/jido/chat/capability_matrix.ex
@@ -63,42 +63,59 @@ defmodule Jido.Chat.CapabilityMatrix do
   def from_map(map) when is_map(map), do: new(map)
 
   defp normalize_capabilities(capabilities) when is_map(capabilities) do
-    capabilities
-    |> Enum.map(fn {capability, status} ->
-      {normalize_capability_key(capability), normalize_status(status)}
+    Enum.reduce(capabilities, %{}, fn {capability, status}, acc ->
+      case normalize_capability_key(capability) do
+        {:ok, capability_key} -> Map.put(acc, capability_key, normalize_status(status))
+        :error -> acc
+      end
     end)
-    |> Map.new()
   end
 
   defp normalize_capabilities(capabilities) when is_list(capabilities) do
-    capabilities
-    |> Enum.map(fn capability ->
-      {normalize_capability_key(capability), :native}
+    Enum.reduce(capabilities, %{}, fn capability, acc ->
+      case normalize_capability_key(capability) do
+        {:ok, capability_key} -> Map.put(acc, capability_key, :native)
+        :error -> acc
+      end
     end)
-    |> Map.new()
   end
 
   defp normalize_capabilities(_), do: %{}
 
-  defp normalize_capability_key(capability) when is_atom(capability), do: capability
+  defp normalize_capability_key(capability) when is_atom(capability), do: {:ok, capability}
 
   defp normalize_capability_key(capability) when is_binary(capability) do
-    capability
-    |> String.trim()
-    |> String.to_atom()
+    capability = String.trim(capability)
+
+    case capability do
+      "" ->
+        :error
+
+      _ ->
+        try do
+          {:ok, String.to_existing_atom(capability)}
+        rescue
+          ArgumentError -> :error
+        end
+    end
   end
 
-  defp normalize_capability_key(capability), do: capability
+  defp normalize_capability_key(_capability), do: :error
 
   defp normalize_status(status) when status in @statuses, do: status
 
   defp normalize_status(status) when is_binary(status) do
-    status
-    |> String.trim()
-    |> String.to_atom()
-    |> normalize_status()
-  rescue
-    _ -> :unsupported
+    status = String.trim(status)
+
+    case status do
+      "" -> :unsupported
+      _ ->
+        try do
+          String.to_existing_atom(status) |> normalize_status()
+        rescue
+          ArgumentError -> :unsupported
+        end
+    end
   end
 
   defp normalize_status(_), do: :unsupported

--- a/lib/jido/chat/emoji.ex
+++ b/lib/jido/chat/emoji.ex
@@ -64,12 +64,22 @@ defmodule Jido.Chat.Emoji do
   defp normalize_name(value) when is_atom(value), do: value
 
   defp normalize_name(value) when is_binary(value) do
-    value
-    |> String.trim()
-    |> String.trim_leading(":")
-    |> String.trim_trailing(":")
-    |> String.replace("-", "_")
-    |> String.to_atom()
+    normalized =
+      value
+      |> String.trim()
+      |> String.trim_leading(":")
+      |> String.trim_trailing(":")
+      |> String.replace("-", "_")
+
+    case normalized do
+      "" -> ""
+      _ ->
+        try do
+          String.to_existing_atom(normalized)
+        rescue
+          ArgumentError -> normalized
+        end
+    end
   end
 
   defp fallback_token(value) when is_binary(value), do: value

--- a/lib/jido/chat/response.ex
+++ b/lib/jido/chat/response.ex
@@ -6,14 +6,14 @@ defmodule Jido.Chat.Response do
   @schema Zoi.struct(
             __MODULE__,
             %{
-              external_message_id: Zoi.string() |> Zoi.nullish(),
+              external_message_id: Zoi.any() |> Zoi.nullish(),
               external_room_id: Zoi.any() |> Zoi.nullish(),
               timestamp: Zoi.any() |> Zoi.nullish(),
               channel_type: Zoi.atom() |> Zoi.nullish(),
               status: Zoi.enum([:sent, :edited, :accepted, :failed]) |> Zoi.default(:sent),
               raw: Zoi.any() |> Zoi.nullish(),
               metadata: Zoi.map() |> Zoi.default(%{}),
-              message_id: Zoi.any() |> Zoi.nullish(),
+              message_id: Zoi.string() |> Zoi.nullish(),
               chat_id: Zoi.any() |> Zoi.nullish(),
               channel_id: Zoi.any() |> Zoi.nullish(),
               date: Zoi.any() |> Zoi.nullish()
@@ -55,14 +55,14 @@ defmodule Jido.Chat.Response do
       end
 
     %{
-      external_message_id: stringify(external_message_id),
+      external_message_id: external_message_id,
       external_room_id: external_room_id,
       timestamp: normalized_timestamp,
       channel_type: channel_type,
       status: fetch.(:status) || :sent,
       raw: fetch.(:raw),
       metadata: fetch.(:metadata) || %{},
-      message_id: external_message_id,
+      message_id: stringify(external_message_id),
       chat_id: fetch.(:chat_id) || maybe_chat_id(channel_type, external_room_id),
       channel_id: fetch.(:channel_id) || maybe_channel_id(channel_type, external_room_id),
       date: fetch.(:date) || raw_timestamp

--- a/lib/jido/chat/sent_message.ex
+++ b/lib/jido/chat/sent_message.ex
@@ -8,7 +8,7 @@ defmodule Jido.Chat.SentMessage do
   @schema Zoi.struct(
             __MODULE__,
             %{
-              id: Zoi.string(),
+              id: Zoi.any(),
               thread_id: Zoi.string(),
               adapter: Zoi.any(),
               external_room_id: Zoi.any() |> Zoi.nullish(),

--- a/lib/jido/chat/serialization.ex
+++ b/lib/jido/chat/serialization.ex
@@ -146,11 +146,14 @@ defmodule Jido.Chat.Serialization do
 
   defp deserialize_adapters(adapters) when is_map(adapters) do
     adapters
-    |> Enum.map(fn {key, value} ->
-      {normalize_key_atom(key), Wire.decode_module(value)}
+    |> Enum.reduce(%{}, fn {key, value}, acc ->
+      with {:ok, adapter_key} <- normalize_key_atom(key),
+           adapter_module when not is_nil(adapter_module) <- Wire.decode_module(value) do
+        Map.put(acc, adapter_key, adapter_module)
+      else
+        _ -> acc
+      end
     end)
-    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
-    |> Map.new()
   end
 
   defp deserialize_adapters(_), do: %{}
@@ -174,11 +177,15 @@ defmodule Jido.Chat.Serialization do
 
   defp deserialize_handlers(_handlers, defaults), do: defaults
 
-  defp normalize_key_atom(key) when is_atom(key), do: key
+  defp normalize_key_atom(key) when is_atom(key), do: {:ok, key}
 
   defp normalize_key_atom(key) when is_binary(key) do
-    String.to_atom(key)
+    try do
+      {:ok, String.to_existing_atom(key)}
+    rescue
+      ArgumentError -> :error
+    end
   end
 
-  defp normalize_key_atom(key), do: key
+  defp normalize_key_atom(_key), do: :error
 end

--- a/lib/jido/chat/state_adapter.ex
+++ b/lib/jido/chat/state_adapter.ex
@@ -204,10 +204,16 @@ defmodule Jido.Chat.StateAdapter do
         dedupe when is_list(dedupe) ->
           Enum.reduce(dedupe, MapSet.new(), fn
             [adapter_name, message_id], acc ->
-              MapSet.put(acc, {normalize_key_atom(adapter_name), to_string(message_id)})
+              case normalize_key_atom(adapter_name) do
+                {:ok, adapter_atom} -> MapSet.put(acc, {adapter_atom, to_string(message_id)})
+                :error -> acc
+              end
 
             {adapter_name, message_id}, acc ->
-              MapSet.put(acc, {normalize_key_atom(adapter_name), to_string(message_id)})
+              case normalize_key_atom(adapter_name) do
+                {:ok, adapter_atom} -> MapSet.put(acc, {adapter_atom, to_string(message_id)})
+                :error -> acc
+              end
 
             _other, acc ->
               acc
@@ -226,10 +232,16 @@ defmodule Jido.Chat.StateAdapter do
         dedupe_order when is_list(dedupe_order) ->
           Enum.reduce(dedupe_order, [], fn
             [adapter_name, message_id], acc ->
-              [{normalize_key_atom(adapter_name), to_string(message_id)} | acc]
+              case normalize_key_atom(adapter_name) do
+                {:ok, adapter_atom} -> [{adapter_atom, to_string(message_id)} | acc]
+                :error -> acc
+              end
 
             {adapter_name, message_id}, acc ->
-              [{normalize_key_atom(adapter_name), to_string(message_id)} | acc]
+              case normalize_key_atom(adapter_name) do
+                {:ok, adapter_atom} -> [{adapter_atom, to_string(message_id)} | acc]
+                :error -> acc
+              end
 
             _other, acc ->
               acc
@@ -297,7 +309,15 @@ defmodule Jido.Chat.StateAdapter do
     %{snapshot | pending_locks: pending_locks}
   end
 
-  defp normalize_key_atom(key) when is_atom(key), do: key
-  defp normalize_key_atom(key) when is_binary(key), do: String.to_atom(key)
-  defp normalize_key_atom(key), do: key
+  defp normalize_key_atom(key) when is_atom(key), do: {:ok, key}
+
+  defp normalize_key_atom(key) when is_binary(key) do
+    try do
+      {:ok, String.to_existing_atom(key)}
+    rescue
+      ArgumentError -> :error
+    end
+  end
+
+  defp normalize_key_atom(_key), do: :error
 end

--- a/lib/jido_chat.ex
+++ b/lib/jido_chat.ex
@@ -986,12 +986,11 @@ defmodule Jido.Chat do
        when is_binary(target) do
     case String.split(target, ":", parts: 2) do
       [adapter_name, external_user_id] when external_user_id != "" ->
-        adapter_atom = String.to_atom(adapter_name)
-
-        if Map.has_key?(adapters, adapter_atom) do
+        with {:ok, adapter_atom} <- parse_existing_adapter_name(adapter_name),
+             true <- Map.has_key?(adapters, adapter_atom) do
           {:ok, adapter_atom, external_user_id}
         else
-          :error
+          _ -> :error
         end
 
       _ ->
@@ -1000,6 +999,14 @@ defmodule Jido.Chat do
   end
 
   defp parse_adapter_prefixed_target(_chat, _target), do: :error
+
+  defp parse_existing_adapter_name(adapter_name) when is_binary(adapter_name) do
+    try do
+      {:ok, String.to_existing_atom(adapter_name)}
+    rescue
+      ArgumentError -> :error
+    end
+  end
 
   defp enrich_event_context(%__MODULE__{} = chat, adapter_name, event) do
     adapter = Map.get(chat.adapters, adapter_name)

--- a/test/jido/chat/adapter_conformance_test.exs
+++ b/test/jido/chat/adapter_conformance_test.exs
@@ -138,6 +138,31 @@ defmodule Jido.Chat.AdapterConformanceTest do
     end
   end
 
+  defmodule NilChannelTypeAdapter do
+    use Adapter
+
+    @impl true
+    def channel_type, do: :nil_channel_type
+
+    @impl true
+    def transform_incoming(payload), do: {:ok, Incoming.new(payload)}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok,
+       %Response{
+         external_message_id: "m1",
+         external_room_id: room_id,
+         channel_type: nil
+       }}
+    end
+
+    @impl true
+    def capabilities do
+      %{send_message: :native}
+    end
+  end
+
   test "capability matrix struct normalizes statuses" do
     matrix = Adapter.capability_matrix(GoodAdapter)
 
@@ -178,6 +203,14 @@ defmodule Jido.Chat.AdapterConformanceTest do
     assert upload.filename == "demo.txt"
     assert Keyword.fetch!(opts, :caption) == "caption"
     assert Keyword.fetch!(opts, :metadata) == %{scope: :conformance}
+  end
+
+  test "response normalization fills in a missing channel_type on response structs" do
+    assert {:ok, %Response{} = response} =
+             Adapter.send_message(NilChannelTypeAdapter, "room-4", "hello", [])
+
+    assert response.channel_type == :nil_channel_type
+    assert response.external_message_id == "m1"
   end
 
   test "stream fallback preserves structured chunks through placeholder plus edit" do

--- a/test/jido/chat/emoji_test.exs
+++ b/test/jido/chat/emoji_test.exs
@@ -1,0 +1,16 @@
+defmodule Jido.Chat.EmojiTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Chat.Emoji
+
+  test "render keeps built-in tokens and preserves unknown named tokens" do
+    assert Emoji.render(":thumbs_up:") == "👍"
+    assert Emoji.render(":custom-flag:") == ":custom-flag:"
+  end
+
+  test "put_custom supports custom names without requiring preexisting atoms" do
+    registry = Emoji.put_custom(%{}, "custom-emoji", "🎯")
+
+    assert Emoji.render(":custom-emoji:", custom: registry) == "🎯"
+  end
+end


### PR DESCRIPTION
fixes #21 

verifications made:
- mix test
- mix quality
- QA on Zaq with Mattermost and Telegram adapters