### PR TITLE
feat: add media type resolution policy

### DIFF
--- a/lib/jido/chat/attachment.ex
+++ b/lib/jido/chat/attachment.ex
@@ -4,7 +4,7 @@ defmodule Jido.Chat.Attachment do
   """
 
   alias Jido.Chat.Content.{Audio, File, Image, Video}
-  alias Jido.Chat.{FileUpload, Media}
+  alias Jido.Chat.{FileUpload, Media, MediaType}
 
   @schema Zoi.struct(
             __MODULE__,
@@ -115,7 +115,7 @@ defmodule Jido.Chat.Attachment do
 
   def normalize(%File{} = file) do
     new(%{
-      kind: infer_kind(file.media_type, file.filename, file.url),
+      kind: MediaType.kind(file.media_type, file.filename || file.url),
       url: file.url,
       data: file.data,
       media_type: file.media_type,
@@ -128,7 +128,7 @@ defmodule Jido.Chat.Attachment do
 
   def normalize(reference) when is_binary(reference) do
     new(%{
-      kind: infer_kind(nil, filename_from_reference(reference), reference),
+      kind: MediaType.kind(nil, filename_from_reference(reference) || reference),
       url: if(remote_reference?(reference), do: reference, else: nil),
       path: if(remote_reference?(reference), do: nil, else: reference),
       filename: filename_from_reference(reference)
@@ -156,7 +156,7 @@ defmodule Jido.Chat.Attachment do
     %{
       kind:
         normalize_kind(attrs[:kind] || attrs["kind"] || attrs[:type] || attrs["type"]) ||
-          infer_kind(media_type, filename, url || path),
+          MediaType.kind(media_type, filename || url || path),
       url: url,
       path: path,
       data: attrs[:data] || attrs["data"],
@@ -214,27 +214,6 @@ defmodule Jido.Chat.Attachment do
   end
 
   defp normalize_kind(_kind), do: nil
-
-  defp infer_kind(media_type, filename, reference) do
-    cond do
-      is_binary(media_type) and String.starts_with?(media_type, "image/") -> :image
-      is_binary(media_type) and String.starts_with?(media_type, "audio/") -> :audio
-      is_binary(media_type) and String.starts_with?(media_type, "video/") -> :video
-      extension_kind(filename || reference) != :file -> extension_kind(filename || reference)
-      true -> :file
-    end
-  end
-
-  defp extension_kind(nil), do: :file
-
-  defp extension_kind(value) when is_binary(value) do
-    case value |> Path.extname() |> String.downcase() do
-      ext when ext in [".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"] -> :image
-      ext when ext in [".mp3", ".wav", ".ogg", ".m4a", ".flac", ".aac"] -> :audio
-      ext when ext in [".mp4", ".mov", ".avi", ".mkv", ".webm", ".m4v"] -> :video
-      _ -> :file
-    end
-  end
 
   defp filename_from_reference(nil), do: nil
 

--- a/lib/jido/chat/attachment.ex
+++ b/lib/jido/chat/attachment.ex
@@ -82,7 +82,7 @@ defmodule Jido.Chat.Attachment do
       kind: :image,
       url: image.url,
       data: image.data,
-      media_type: image.media_type,
+      media_type: MediaType.normalize(image.media_type),
       width: image.width,
       height: image.height,
       metadata: compact_metadata(%{alt_text: image.alt_text})
@@ -94,7 +94,7 @@ defmodule Jido.Chat.Attachment do
       kind: :audio,
       url: audio.url,
       data: audio.data,
-      media_type: audio.media_type,
+      media_type: MediaType.normalize(audio.media_type),
       duration: audio.duration,
       metadata: compact_metadata(%{transcript: audio.transcript})
     })
@@ -105,7 +105,7 @@ defmodule Jido.Chat.Attachment do
       kind: :video,
       url: video.url,
       data: video.data,
-      media_type: video.media_type,
+      media_type: MediaType.normalize(video.media_type),
       width: video.width,
       height: video.height,
       duration: video.duration,
@@ -114,11 +114,13 @@ defmodule Jido.Chat.Attachment do
   end
 
   def normalize(%File{} = file) do
+    media_type = MediaType.normalize(file.media_type)
+
     new(%{
-      kind: MediaType.kind(file.media_type, file.filename || file.url),
+      kind: MediaType.kind(media_type, reference_hint([file.filename, file.url])),
       url: file.url,
       data: file.data,
-      media_type: file.media_type,
+      media_type: media_type,
       filename: file.filename,
       size_bytes: file.size
     })
@@ -149,6 +151,8 @@ defmodule Jido.Chat.Attachment do
     media_type =
       attrs[:media_type] || attrs["media_type"] || attrs[:mime_type] || attrs["mime_type"]
 
+    media_type = MediaType.normalize(media_type)
+
     filename = attrs[:filename] || attrs["filename"] || attrs[:name] || attrs["name"]
     url = attrs[:url] || attrs["url"]
     path = attrs[:path] || attrs["path"]
@@ -156,7 +160,7 @@ defmodule Jido.Chat.Attachment do
     %{
       kind:
         normalize_kind(attrs[:kind] || attrs["kind"] || attrs[:type] || attrs["type"]) ||
-          MediaType.kind(media_type, filename || url || path),
+          MediaType.kind(media_type, reference_hint([filename, url, path])),
       url: url,
       path: path,
       data: attrs[:data] || attrs["data"],
@@ -214,6 +218,13 @@ defmodule Jido.Chat.Attachment do
   end
 
   defp normalize_kind(_kind), do: nil
+
+  defp reference_hint(values) do
+    Enum.find_value(values, fn
+      value when is_binary(value) -> if(String.trim(value) == "", do: nil, else: value)
+      _other -> nil
+    end)
+  end
 
   defp filename_from_reference(nil), do: nil
 

--- a/lib/jido/chat/media.ex
+++ b/lib/jido/chat/media.ex
@@ -4,6 +4,7 @@ defmodule Jido.Chat.Media do
   """
 
   alias Jido.Chat.Content.{Audio, File, Image, Video}
+  alias Jido.Chat.MediaType
 
   @schema Zoi.struct(
             __MODULE__,
@@ -79,7 +80,7 @@ defmodule Jido.Chat.Media do
 
   def normalize(%File{} = file) do
     new(%{
-      kind: infer_kind(file.media_type, file.filename, file.url),
+      kind: MediaType.kind(file.media_type, file.filename || file.url),
       url: file.url,
       media_type: file.media_type,
       filename: file.filename,
@@ -92,7 +93,7 @@ defmodule Jido.Chat.Media do
 
   def normalize(reference) when is_binary(reference) do
     new(%{
-      kind: infer_kind(nil, filename_from_reference(reference), reference),
+      kind: MediaType.kind(nil, filename_from_reference(reference) || reference),
       url: if(remote_reference?(reference), do: reference, else: nil),
       filename: filename_from_reference(reference),
       metadata:
@@ -121,7 +122,7 @@ defmodule Jido.Chat.Media do
     %{
       kind:
         normalize_kind(attrs[:kind] || attrs["kind"] || attrs[:type] || attrs["type"]) ||
-          infer_kind(media_type, filename, url),
+          MediaType.kind(media_type, filename || url),
       url: url,
       media_type: media_type,
       filename: filename,
@@ -164,27 +165,6 @@ defmodule Jido.Chat.Media do
   end
 
   defp normalize_kind(_kind), do: nil
-
-  defp infer_kind(media_type, filename, url) do
-    cond do
-      is_binary(media_type) and String.starts_with?(media_type, "image/") -> :image
-      is_binary(media_type) and String.starts_with?(media_type, "audio/") -> :audio
-      is_binary(media_type) and String.starts_with?(media_type, "video/") -> :video
-      extension_kind(filename || url) != :file -> extension_kind(filename || url)
-      true -> :file
-    end
-  end
-
-  defp extension_kind(nil), do: :file
-
-  defp extension_kind(value) when is_binary(value) do
-    case value |> Path.extname() |> String.downcase() do
-      ext when ext in [".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"] -> :image
-      ext when ext in [".mp3", ".wav", ".ogg", ".m4a", ".flac", ".aac"] -> :audio
-      ext when ext in [".mp4", ".mov", ".avi", ".mkv", ".webm", ".m4v"] -> :video
-      _ -> :file
-    end
-  end
 
   defp filename_from_reference(reference) when is_binary(reference) do
     case remote_reference?(reference) do

--- a/lib/jido/chat/media.ex
+++ b/lib/jido/chat/media.ex
@@ -1,6 +1,11 @@
 defmodule Jido.Chat.Media do
   @moduledoc """
   Normalized media entry used in `Jido.Chat.Incoming`.
+
+  Explicit provider MIME values are normalized with `Jido.Chat.MediaType`.
+  Filename and URL hints can recover `kind`, but they do not add an exact
+  `media_type`. Adapters can call `Jido.Chat.MediaType.resolve/2` when they have
+  stronger provider, response-header, or downloaded-byte evidence.
   """
 
   alias Jido.Chat.Content.{Audio, File, Image, Video}
@@ -45,7 +50,7 @@ defmodule Jido.Chat.Media do
     new(%{
       kind: :image,
       url: image.url,
-      media_type: image.media_type,
+      media_type: MediaType.normalize(image.media_type),
       width: image.width,
       height: image.height,
       metadata: compact_metadata(%{data: image.data, alt_text: image.alt_text})
@@ -56,7 +61,7 @@ defmodule Jido.Chat.Media do
     new(%{
       kind: :audio,
       url: audio.url,
-      media_type: audio.media_type,
+      media_type: MediaType.normalize(audio.media_type),
       duration: audio.duration,
       metadata: compact_metadata(%{data: audio.data, transcript: audio.transcript})
     })
@@ -66,7 +71,7 @@ defmodule Jido.Chat.Media do
     new(%{
       kind: :video,
       url: video.url,
-      media_type: video.media_type,
+      media_type: MediaType.normalize(video.media_type),
       width: video.width,
       height: video.height,
       duration: video.duration,
@@ -79,10 +84,12 @@ defmodule Jido.Chat.Media do
   end
 
   def normalize(%File{} = file) do
+    media_type = MediaType.normalize(file.media_type)
+
     new(%{
-      kind: MediaType.kind(file.media_type, file.filename || file.url),
+      kind: MediaType.kind(media_type, reference_hint([file.filename, file.url])),
       url: file.url,
-      media_type: file.media_type,
+      media_type: media_type,
       filename: file.filename,
       size_bytes: file.size,
       metadata: compact_metadata(%{data: file.data})
@@ -116,13 +123,15 @@ defmodule Jido.Chat.Media do
     media_type =
       attrs[:media_type] || attrs["media_type"] || attrs[:mime_type] || attrs["mime_type"]
 
+    media_type = MediaType.normalize(media_type)
+
     filename = attrs[:filename] || attrs["filename"] || attrs[:name] || attrs["name"]
     url = attrs[:url] || attrs["url"]
 
     %{
       kind:
         normalize_kind(attrs[:kind] || attrs["kind"] || attrs[:type] || attrs["type"]) ||
-          MediaType.kind(media_type, filename || url),
+          MediaType.kind(media_type, reference_hint([filename, url])),
       url: url,
       media_type: media_type,
       filename: filename,
@@ -165,6 +174,13 @@ defmodule Jido.Chat.Media do
   end
 
   defp normalize_kind(_kind), do: nil
+
+  defp reference_hint(values) do
+    Enum.find_value(values, fn
+      value when is_binary(value) -> if(String.trim(value) == "", do: nil, else: value)
+      _other -> nil
+    end)
+  end
 
   defp filename_from_reference(reference) when is_binary(reference) do
     case remote_reference?(reference) do

--- a/lib/jido/chat/media_type.ex
+++ b/lib/jido/chat/media_type.ex
@@ -1,0 +1,137 @@
+defmodule Jido.Chat.MediaType do
+  @moduledoc """
+  Resolves media types without applying a provider-independent default.
+
+  Adapters should use evidence in this order:
+
+  1. A valid MIME value declared by the provider.
+  2. A default that the provider contract guarantees for the downloadable file.
+  3. A file signature, when the bytes have already been downloaded.
+  4. A filename or URL extension as a best-effort hint.
+
+  `resolve/2` follows this order. A provider default is never added unless the
+  caller supplies `:provider_default`. Normalization and MIME resolution do not
+  change media bytes.
+  """
+
+  @type kind :: :image | :audio | :video | :file
+
+  @extension_media_types %{
+    ".aac" => "audio/aac",
+    ".avi" => "video/x-msvideo",
+    ".avif" => "image/avif",
+    ".bmp" => "image/bmp",
+    ".csv" => "text/csv",
+    ".flac" => "audio/flac",
+    ".gif" => "image/gif",
+    ".gz" => "application/gzip",
+    ".heic" => "image/heic",
+    ".heif" => "image/heif",
+    ".html" => "text/html",
+    ".jpeg" => "image/jpeg",
+    ".jpg" => "image/jpeg",
+    ".json" => "application/json",
+    ".m4a" => "audio/mp4",
+    ".m4v" => "video/x-m4v",
+    ".md" => "text/markdown",
+    ".mkv" => "video/x-matroska",
+    ".mov" => "video/quicktime",
+    ".mp3" => "audio/mpeg",
+    ".mp4" => "video/mp4",
+    ".ogg" => "audio/ogg",
+    ".pdf" => "application/pdf",
+    ".png" => "image/png",
+    ".svg" => "image/svg+xml",
+    ".tif" => "image/tiff",
+    ".tiff" => "image/tiff",
+    ".txt" => "text/plain",
+    ".wav" => "audio/wav",
+    ".webm" => "video/webm",
+    ".webp" => "image/webp",
+    ".zip" => "application/zip"
+  }
+
+  @doc """
+  Resolves the best available MIME value.
+
+  Supported options are `:provider_default`, `:data`, `:filename`, `:url`, and
+  `:path`. Filename and reference values are hints and have the lowest priority.
+  """
+  @spec resolve(term(), keyword()) :: String.t() | nil
+  def resolve(provider_value, opts \\ []) when is_list(opts) do
+    normalize(provider_value) ||
+      normalize(Keyword.get(opts, :provider_default)) ||
+      sniff(Keyword.get(opts, :data)) ||
+      from_filename(reference(opts))
+  end
+
+  @doc "Returns a normalized MIME value or `nil` for blank and invalid values."
+  @spec normalize(term()) :: String.t() | nil
+  def normalize(value) when is_binary(value) do
+    media_type =
+      value
+      |> String.split(";", parts: 2)
+      |> hd()
+      |> String.trim()
+      |> String.downcase()
+
+    if Regex.match?(~r/^[a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+$/, media_type),
+      do: media_type,
+      else: nil
+  end
+
+  def normalize(_value), do: nil
+
+  @doc "Returns a MIME hint from a filename, path, or URL extension."
+  @spec from_filename(term()) :: String.t() | nil
+  def from_filename(value) when is_binary(value) do
+    value
+    |> reference_path()
+    |> Path.extname()
+    |> String.downcase()
+    |> then(&Map.get(@extension_media_types, &1))
+  end
+
+  def from_filename(_value), do: nil
+
+  @doc "Detects common binary formats from their file signatures."
+  @spec sniff(term()) :: String.t() | nil
+  def sniff(<<0xFF, 0xD8, 0xFF, _rest::binary>>), do: "image/jpeg"
+  def sniff(<<0x89, "PNG", 0x0D, 0x0A, 0x1A, 0x0A, _rest::binary>>), do: "image/png"
+  def sniff(<<"GIF87a", _rest::binary>>), do: "image/gif"
+  def sniff(<<"GIF89a", _rest::binary>>), do: "image/gif"
+  def sniff(<<"RIFF", _size::binary-size(4), "WEBP", _rest::binary>>), do: "image/webp"
+  def sniff(<<"BM", _rest::binary>>), do: "image/bmp"
+  def sniff(<<"%PDF-", _rest::binary>>), do: "application/pdf"
+  def sniff(<<0x1F, 0x8B, _rest::binary>>), do: "application/gzip"
+
+  def sniff(<<"PK", marker::binary-size(2), _rest::binary>>)
+      when marker in [<<3, 4>>, <<5, 6>>, <<7, 8>>],
+      do: "application/zip"
+
+  def sniff(_data), do: nil
+
+  @doc "Returns the canonical media kind from MIME data or a reference hint."
+  @spec kind(term(), term()) :: kind()
+  def kind(media_type, reference \\ nil) do
+    case normalize(media_type) || from_filename(reference) do
+      "image/" <> _rest -> :image
+      "audio/" <> _rest -> :audio
+      "video/" <> _rest -> :video
+      _other -> :file
+    end
+  end
+
+  defp reference(opts) do
+    Keyword.get(opts, :filename) ||
+      Keyword.get(opts, :url) ||
+      Keyword.get(opts, :path)
+  end
+
+  defp reference_path(value) do
+    case URI.parse(value) do
+      %URI{scheme: scheme, path: path} when is_binary(scheme) and is_binary(path) -> path
+      _other -> value
+    end
+  end
+end

--- a/lib/jido/chat/media_type.ex
+++ b/lib/jido/chat/media_type.ex
@@ -6,15 +6,19 @@ defmodule Jido.Chat.MediaType do
 
   1. A valid MIME value declared by the provider.
   2. A default that the provider contract guarantees for the downloadable file.
-  3. A file signature, when the bytes have already been downloaded.
-  4. A filename or URL extension as a best-effort hint.
+  3. A valid HTTP `Content-Type`, when it comes from the media download response.
+  4. A file signature, when the bytes have already been downloaded.
+  5. A filename or URL extension as a best-effort hint.
 
-  `resolve/2` follows this order. A provider default is never added unless the
-  caller supplies `:provider_default`. Normalization and MIME resolution do not
-  change media bytes.
+  Pass the provider payload value as the first argument to `resolve/2`. Pass a
+  download response `Content-Type` as `:response_media_type`. A provider default
+  is never added unless the caller supplies `:provider_default`. Normalization
+  and MIME resolution do not change media bytes.
   """
 
   @type kind :: :image | :audio | :video | :file
+
+  @media_type_pattern ~r/^[a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+$/
 
   @extension_media_types %{
     ".aac" => "audio/aac",
@@ -54,13 +58,15 @@ defmodule Jido.Chat.MediaType do
   @doc """
   Resolves the best available MIME value.
 
-  Supported options are `:provider_default`, `:data`, `:filename`, `:url`, and
-  `:path`. Filename and reference values are hints and have the lowest priority.
+  Supported options are `:provider_default`, `:response_media_type`, `:data`,
+  `:filename`, `:url`, and `:path`. Filename and reference values are hints and
+  have the lowest priority.
   """
   @spec resolve(term(), keyword()) :: String.t() | nil
   def resolve(provider_value, opts \\ []) when is_list(opts) do
     normalize(provider_value) ||
       normalize(Keyword.get(opts, :provider_default)) ||
+      normalize(Keyword.get(opts, :response_media_type)) ||
       sniff(Keyword.get(opts, :data)) ||
       from_filename(reference(opts))
   end
@@ -75,7 +81,7 @@ defmodule Jido.Chat.MediaType do
       |> String.trim()
       |> String.downcase()
 
-    if Regex.match?(~r/^[a-z0-9!#$&^_.+-]+\/[a-z0-9!#$&^_.+-]+$/, media_type),
+    if Regex.match?(@media_type_pattern, media_type),
       do: media_type,
       else: nil
   end
@@ -123,14 +129,17 @@ defmodule Jido.Chat.MediaType do
   end
 
   defp reference(opts) do
-    Keyword.get(opts, :filename) ||
-      Keyword.get(opts, :url) ||
-      Keyword.get(opts, :path)
+    Enum.find_value([:filename, :url, :path], fn key ->
+      case Keyword.get(opts, key) do
+        value when is_binary(value) -> if(String.trim(value) == "", do: nil, else: value)
+        _other -> nil
+      end
+    end)
   end
 
   defp reference_path(value) do
     case URI.parse(value) do
-      %URI{scheme: scheme, path: path} when is_binary(scheme) and is_binary(path) -> path
+      %URI{path: path} when is_binary(path) and path != "" -> path
       _other -> value
     end
   end

--- a/test/jido/chat/media_type_test.exs
+++ b/test/jido/chat/media_type_test.exs
@@ -1,0 +1,47 @@
+defmodule Jido.Chat.MediaTypeTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Chat.{Attachment, Media, MediaType}
+
+  test "normalizes valid provider MIME values and rejects invalid values" do
+    assert MediaType.normalize(" Image/PNG; charset=binary ") == "image/png"
+    assert MediaType.normalize("") == nil
+    assert MediaType.normalize("png") == nil
+  end
+
+  test "uses only caller-supplied provider defaults" do
+    assert MediaType.resolve(nil) == nil
+    assert MediaType.resolve(nil, provider_default: "image/jpeg") == "image/jpeg"
+    assert MediaType.resolve("image/png", provider_default: "image/jpeg") == "image/png"
+  end
+
+  test "prefers downloaded byte signatures over filename hints" do
+    png = <<0x89, "PNG", 0x0D, 0x0A, 0x1A, 0x0A, "payload">>
+
+    assert MediaType.resolve(nil, data: png, filename: "misleading.jpg") == "image/png"
+    assert MediaType.sniff(<<0xFF, 0xD8, 0xFF, "jpeg">>) == "image/jpeg"
+    assert MediaType.sniff("unknown") == nil
+  end
+
+  test "uses filename and URL extensions only as last-choice hints" do
+    assert MediaType.from_filename("photo.JPEG") == "image/jpeg"
+
+    assert MediaType.from_filename("https://example.test/files/photo.png?token=secret") ==
+             "image/png"
+
+    assert MediaType.from_filename("https://example.test/download") == nil
+  end
+
+  test "infers media kind without inventing media_type" do
+    media = Media.new(%{filename: "photo.png"})
+    attachment = Attachment.new(%{url: "https://example.test/audio.ogg"})
+    misleading = Media.new(%{media_type: "application/pdf", filename: "photo.png"})
+
+    assert media.kind == :image
+    assert media.media_type == nil
+    assert attachment.kind == :audio
+    assert attachment.media_type == nil
+    assert misleading.kind == :file
+    assert misleading.media_type == "application/pdf"
+  end
+end

--- a/test/jido/chat/media_type_test.exs
+++ b/test/jido/chat/media_type_test.exs
@@ -7,12 +7,33 @@ defmodule Jido.Chat.MediaTypeTest do
     assert MediaType.normalize(" Image/PNG; charset=binary ") == "image/png"
     assert MediaType.normalize("") == nil
     assert MediaType.normalize("png") == nil
+
+    assert %Media{kind: :image, media_type: "image/png"} =
+             Media.new(%{media_type: " Image/PNG; charset=binary "})
+
+    assert %Media{kind: :image, media_type: nil} =
+             Media.new(%{media_type: "not-a-mime", filename: "photo.png"})
   end
 
   test "uses only caller-supplied provider defaults" do
     assert MediaType.resolve(nil) == nil
     assert MediaType.resolve(nil, provider_default: "image/jpeg") == "image/jpeg"
     assert MediaType.resolve("image/png", provider_default: "image/jpeg") == "image/png"
+  end
+
+  test "uses a valid download response media type before byte and filename hints" do
+    png = <<0x89, "PNG", 0x0D, 0x0A, 0x1A, 0x0A, "payload">>
+
+    assert MediaType.resolve(nil,
+             response_media_type: " Image/WebP; charset=binary ",
+             data: png,
+             filename: "photo.jpg"
+           ) == "image/webp"
+
+    assert MediaType.resolve(nil,
+             provider_default: "image/jpeg",
+             response_media_type: "image/webp"
+           ) == "image/jpeg"
   end
 
   test "prefers downloaded byte signatures over filename hints" do
@@ -30,6 +51,13 @@ defmodule Jido.Chat.MediaTypeTest do
              "image/png"
 
     assert MediaType.from_filename("https://example.test/download") == nil
+
+    assert MediaType.resolve(nil,
+             filename: " ",
+             url: "https://example.test/files/photo.PNG?token=secret"
+           ) == "image/png"
+
+    assert MediaType.resolve(nil, filename: 123, path: "/tmp/audio.ogg") == "audio/ogg"
   end
 
   test "infers media kind without inventing media_type" do


### PR DESCRIPTION
## Summary

- add Jido.Chat.MediaType as the shared MIME resolution policy
- use this evidence order: valid provider value, guaranteed provider default, download response Content-Type, downloaded byte signature, then filename or URL hint
- normalize only valid explicit MIME values
- use filename and URL hints for media kind without adding a false exact MIME value
- handle blank filename fields, signed URLs, invalid MIME values, and misleading extensions

## Validation

- mix test: 131 tests passed
- mix quality: passed

## Live integration

Core has no platform live target. Adapter live coverage is recorded in the linked adapter PRs.

Closes #33
