### PR TITLE
feat: preserve stable authors and shallow reply context

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The package is intentionally scoped to the adapter layer:
 
 - `jido_chat` owns typed content/event models, adapter contracts, typed thread/channel handles, and deterministic fallback behavior.
 - `jido_messaging` owns supervised runtime concerns such as webhook ingress, delivery queues, retries, room/session state, bridge lifecycle, and process trees.
+- A trusted application/runtime resolver owns stable identity resolution. In an `Author`, `id` is the framework-neutral stable identity and `user_id` is the provider identity. Adapters may pass an `Author.id` supplied by that resolver, but they must not infer it from provider IDs, display names, usernames, or email addresses, and they must not call a provider to obtain it for this contract.
 
 It provides:
 
@@ -60,7 +61,10 @@ upload hook used by the core fallback path for single-upload posts.
 2. Declare explicit surface support through `capabilities/0` instead of relying on callback inference.
 3. If you build directly on the lightweight `Jido.Chat` facade and ship a custom `Jido.Chat.StateAdapter`, implement `lock/5`, `release_lock/3`, and `force_release_lock/2`, and persist `locks` plus `pending_locks` in snapshots.
 4. Treat `Jido.Chat.PostPayload` as the canonical outbound contract. It can now carry text, markdown, raw payloads, cards, streams, attachments, and `FileUpload` values.
-5. Run `mix quality` before publishing adapter changes.
+5. Preserve compatibility with legacy inbound payloads. Existing messages, wire maps, and adapter payloads do not need `author` or reply fields; normalization keeps their useful values and leaves the enriched fields unset.
+6. Treat `Author.id` as trusted, framework-neutral stable identity. Only pass it through when an application/runtime resolver supplied it. Never derive it from a provider ID, display name, username, or email, and do not make provider profile calls to resolve it for this contract.
+7. Reply context is shallow and uses only data already present in the event. It does not perform replied-message lookup.
+8. Run `mix quality` before publishing adapter changes.
 
 ## Usage (Core Loop)
 

--- a/lib/jido/chat/ai.ex
+++ b/lib/jido/chat/ai.ex
@@ -189,6 +189,7 @@ defmodule Jido.Chat.AI do
       role in [:system, "system"] -> "system"
       role in [:assistant, "assistant"] -> "assistant"
       role in [:user, "user"] -> "user"
+      author && author.is_system -> "system"
       author && author.is_me -> "assistant"
       true -> "user"
     end

--- a/lib/jido/chat/author.ex
+++ b/lib/jido/chat/author.ex
@@ -6,11 +6,14 @@ defmodule Jido.Chat.Author do
   @schema Zoi.struct(
             __MODULE__,
             %{
+              id: Zoi.string() |> Zoi.nullish(),
               user_id: Zoi.string(),
               user_name: Zoi.string(),
               full_name: Zoi.string() |> Zoi.nullish(),
+              email: Zoi.string() |> Zoi.nullish(),
               is_bot: Zoi.boolean() |> Zoi.default(false),
               is_me: Zoi.boolean() |> Zoi.default(false),
+              is_system: Zoi.boolean() |> Zoi.default(false),
               metadata: Zoi.map() |> Zoi.default(%{})
             },
             coerce: true

--- a/lib/jido/chat/event_envelope.ex
+++ b/lib/jido/chat/event_envelope.ex
@@ -11,6 +11,7 @@ defmodule Jido.Chat.EventEnvelope do
     ModalCloseEvent,
     ModalSubmitEvent,
     ReactionEvent,
+    Message,
     SlashCommandEvent,
     Wire
   }
@@ -107,6 +108,7 @@ defmodule Jido.Chat.EventEnvelope do
   end
 
   defp serialize_payload(%Incoming{} = payload), do: Incoming.to_map(payload)
+  defp serialize_payload(%Message{} = payload), do: Message.to_map(payload)
   defp serialize_payload(%ReactionEvent{} = payload), do: ReactionEvent.to_map(payload)
   defp serialize_payload(%ActionEvent{} = payload), do: ActionEvent.to_map(payload)
   defp serialize_payload(%ModalSubmitEvent{} = payload), do: ModalSubmitEvent.to_map(payload)
@@ -122,6 +124,7 @@ defmodule Jido.Chat.EventEnvelope do
   defp serialize_payload(payload), do: Wire.to_plain(payload)
 
   defp deserialize_payload(%{"__type__" => "incoming"} = payload), do: Incoming.from_map(payload)
+  defp deserialize_payload(%{"__type__" => "message"} = payload), do: Message.from_map(payload)
 
   defp deserialize_payload(%{"__type__" => "reaction_event"} = payload),
     do: ReactionEvent.from_map(payload)

--- a/lib/jido/chat/event_normalizer.ex
+++ b/lib/jido/chat/event_normalizer.ex
@@ -168,17 +168,27 @@ defmodule Jido.Chat.EventNormalizer do
         map
 
       %{} = user ->
-        normalized_user = %{
-          user_id: to_string(user[:user_id] || user["user_id"] || user[:id] || user["id"] || "unknown"),
-          user_name:
-            user[:user_name] || user["user_name"] || user[:username] || user["username"] ||
-              to_string(user[:id] || user["id"] || "unknown"),
-          full_name:
-            user[:full_name] || user["full_name"] || user[:name] || user["name"] ||
-              user[:global_name] || user["global_name"],
-          is_bot: user[:is_bot] || user["is_bot"] || false,
-          is_me: user[:is_me] || user["is_me"] || false
-        }
+        normalized_user =
+          Map.merge(user, %{
+            user_id: to_string(user[:user_id] || user["user_id"] || user[:id] || user["id"] || "unknown"),
+            user_name:
+              user[:user_name] || user["user_name"] || user[:username] || user["username"] ||
+                to_string(user[:id] || user["id"] || "unknown"),
+            full_name:
+              user[:full_name] || user["full_name"] || user[:name] || user["name"] ||
+                user[:global_name] || user["global_name"],
+            is_bot: user[:is_bot] || user["is_bot"] || false,
+            is_me: user[:is_me] || user["is_me"] || false,
+            is_system: user[:is_system] || user["is_system"] || false,
+            metadata: user[:metadata] || user["metadata"] || %{}
+          })
+
+        normalized_user =
+          if Map.has_key?(user, :user_id) or Map.has_key?(user, "user_id") do
+            normalized_user
+          else
+            normalized_user |> Map.delete(:id) |> Map.delete("id")
+          end
 
         Map.put(map, :user, Author.new(normalized_user))
 

--- a/lib/jido/chat/event_normalizer.ex
+++ b/lib/jido/chat/event_normalizer.ex
@@ -190,7 +190,9 @@ defmodule Jido.Chat.EventNormalizer do
           metadata: user[:metadata] || user["metadata"] || %{}
         }
 
-        Map.put(map, :user, Author.new(normalized_user))
+        map
+        |> Map.delete("user")
+        |> Map.put(:user, Author.new(normalized_user))
 
       _ ->
         map

--- a/lib/jido/chat/event_normalizer.ex
+++ b/lib/jido/chat/event_normalizer.ex
@@ -168,27 +168,27 @@ defmodule Jido.Chat.EventNormalizer do
         map
 
       %{} = user ->
-        normalized_user =
-          Map.merge(user, %{
-            user_id: to_string(user[:user_id] || user["user_id"] || user[:id] || user["id"] || "unknown"),
-            user_name:
-              user[:user_name] || user["user_name"] || user[:username] || user["username"] ||
-                to_string(user[:id] || user["id"] || "unknown"),
-            full_name:
-              user[:full_name] || user["full_name"] || user[:name] || user["name"] ||
-                user[:global_name] || user["global_name"],
-            is_bot: user[:is_bot] || user["is_bot"] || false,
-            is_me: user[:is_me] || user["is_me"] || false,
-            is_system: user[:is_system] || user["is_system"] || false,
-            metadata: user[:metadata] || user["metadata"] || %{}
-          })
+        provider_user_id = user[:user_id] || user["user_id"]
+        provider_alias_id = user[:id] || user["id"]
 
-        normalized_user =
-          if Map.has_key?(user, :user_id) or Map.has_key?(user, "user_id") do
-            normalized_user
-          else
-            normalized_user |> Map.delete(:id) |> Map.delete("id")
-          end
+        normalized_user = %{
+          id:
+            if(Map.has_key?(user, :user_id) or Map.has_key?(user, "user_id"),
+              do: provider_alias_id
+            ),
+          user_id: to_string(provider_user_id || provider_alias_id || "unknown"),
+          user_name:
+            user[:user_name] || user["user_name"] || user[:username] || user["username"] ||
+              to_string(provider_alias_id || "unknown"),
+          full_name:
+            user[:full_name] || user["full_name"] || user[:name] || user["name"] ||
+              user[:global_name] || user["global_name"],
+          email: user[:email] || user["email"],
+          is_bot: user[:is_bot] || user["is_bot"] || false,
+          is_me: user[:is_me] || user["is_me"] || false,
+          is_system: user[:is_system] || user["is_system"] || false,
+          metadata: user[:metadata] || user["metadata"] || %{}
+        }
 
         Map.put(map, :user, Author.new(normalized_user))
 

--- a/lib/jido/chat/incoming.ex
+++ b/lib/jido/chat/incoming.ex
@@ -3,7 +3,7 @@ defmodule Jido.Chat.Incoming do
   Canonical normalized inbound message/event payload.
   """
 
-  alias Jido.Chat.{Author, ChannelMeta, Media, Mention}
+  alias Jido.Chat.{Author, ChannelMeta, Media, Mention, ReplyContext}
   alias Jido.Chat.Wire
 
   @schema Zoi.struct(
@@ -17,6 +17,7 @@ defmodule Jido.Chat.Incoming do
               display_name: Zoi.string() |> Zoi.nullish(),
               external_message_id: Zoi.any() |> Zoi.nullish(),
               external_reply_to_id: Zoi.any() |> Zoi.nullish(),
+              reply_context: Zoi.struct(ReplyContext) |> Zoi.nullish(),
               external_thread_id: Zoi.string() |> Zoi.nullish(),
               delivery_external_room_id: Zoi.string() |> Zoi.nullish(),
               timestamp: Zoi.any() |> Zoi.nullish(),
@@ -44,6 +45,7 @@ defmodule Jido.Chat.Incoming do
   def new(attrs) when is_map(attrs) do
     attrs
     |> maybe_attach_author()
+    |> maybe_normalize_reply_context()
     |> maybe_normalize_mentions()
     |> maybe_normalize_media()
     |> maybe_normalize_channel_meta()
@@ -62,6 +64,20 @@ defmodule Jido.Chat.Incoming do
   @doc "Builds an incoming payload from serialized map data."
   @spec from_map(map()) :: t()
   def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp maybe_normalize_reply_context(%{reply_context: %ReplyContext{}} = attrs),
+    do: Map.delete(attrs, "reply_context")
+
+  defp maybe_normalize_reply_context(%{reply_context: context} = attrs) when is_map(context),
+    do: Map.put(attrs, :reply_context, ReplyContext.new(context))
+
+  defp maybe_normalize_reply_context(%{"reply_context" => %ReplyContext{}} = attrs), do: attrs
+
+  defp maybe_normalize_reply_context(%{"reply_context" => context} = attrs)
+       when is_map(context),
+       do: attrs |> Map.delete("reply_context") |> Map.put(:reply_context, ReplyContext.new(context))
+
+  defp maybe_normalize_reply_context(attrs), do: attrs
 
   defp maybe_attach_author(%{author: %Author{}} = attrs), do: attrs
 

--- a/lib/jido/chat/incoming.ex
+++ b/lib/jido/chat/incoming.ex
@@ -68,6 +68,11 @@ defmodule Jido.Chat.Incoming do
   defp maybe_attach_author(%{author: author} = attrs) when is_map(author),
     do: Map.put(attrs, :author, Author.new(author))
 
+  defp maybe_attach_author(%{"author" => %Author{}} = attrs), do: attrs
+
+  defp maybe_attach_author(%{"author" => author} = attrs) when is_map(author),
+    do: attrs |> Map.delete("author") |> Map.put(:author, Author.new(author))
+
   defp maybe_attach_author(attrs) do
     user_id = attrs[:external_user_id] || attrs["external_user_id"]
     username = attrs[:username] || attrs["username"]

--- a/lib/jido/chat/message.ex
+++ b/lib/jido/chat/message.ex
@@ -3,7 +3,7 @@ defmodule Jido.Chat.Message do
   Chat SDK-style normalized message model.
   """
 
-  alias Jido.Chat.{Author, Incoming, Media}
+  alias Jido.Chat.{Author, Incoming, Media, ReplyContext}
 
   @schema Zoi.struct(
             __MODULE__,
@@ -21,7 +21,9 @@ defmodule Jido.Chat.Message do
               created_at: Zoi.any() |> Zoi.nullish(),
               updated_at: Zoi.any() |> Zoi.nullish(),
               external_message_id: Zoi.string() |> Zoi.nullish(),
-              external_room_id: Zoi.any() |> Zoi.nullish()
+              external_room_id: Zoi.any() |> Zoi.nullish(),
+              external_reply_to_id: Zoi.any() |> Zoi.nullish(),
+              reply_context: Zoi.struct(ReplyContext) |> Zoi.nullish()
             },
             coerce: true
           )
@@ -39,6 +41,7 @@ defmodule Jido.Chat.Message do
     attrs
     |> attach_defaults()
     |> normalize_author()
+    |> normalize_reply_context()
     |> normalize_attachments()
     |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
   end
@@ -67,7 +70,9 @@ defmodule Jido.Chat.Message do
       is_mention: incoming.was_mentioned,
       created_at: incoming.timestamp,
       external_message_id: stringify(incoming.external_message_id),
-      external_room_id: incoming.external_room_id
+      external_room_id: incoming.external_room_id,
+      external_reply_to_id: incoming.external_reply_to_id,
+      reply_context: incoming.reply_context
     })
   end
 
@@ -117,6 +122,11 @@ defmodule Jido.Chat.Message do
       stringify(attrs[:external_message_id] || attrs["external_message_id"] || id)
     )
     |> Map.put_new(:external_room_id, external_room_id)
+    |> Map.put_new(
+      :external_reply_to_id,
+      attrs[:external_reply_to_id] || attrs["external_reply_to_id"]
+    )
+    |> Map.put_new(:reply_context, attrs[:reply_context] || attrs["reply_context"])
   end
 
   defp normalize_author(%{author: %Author{}} = attrs), do: attrs
@@ -130,6 +140,19 @@ defmodule Jido.Chat.Message do
     do: Map.put(attrs, :author, Author.new(author))
 
   defp normalize_author(attrs), do: attrs
+
+  defp normalize_reply_context(%{reply_context: %ReplyContext{}} = attrs),
+    do: Map.delete(attrs, "reply_context")
+
+  defp normalize_reply_context(%{reply_context: context} = attrs) when is_map(context),
+    do: attrs |> Map.delete("reply_context") |> Map.put(:reply_context, ReplyContext.new(context))
+
+  defp normalize_reply_context(%{"reply_context" => %ReplyContext{}} = attrs), do: attrs
+
+  defp normalize_reply_context(%{"reply_context" => context} = attrs) when is_map(context),
+    do: attrs |> Map.delete("reply_context") |> Map.put(:reply_context, ReplyContext.new(context))
+
+  defp normalize_reply_context(attrs), do: attrs
 
   defp normalize_attachments(attrs) do
     attachments = attrs[:attachments] || attrs["attachments"] || []

--- a/lib/jido/chat/message.ex
+++ b/lib/jido/chat/message.ex
@@ -137,7 +137,7 @@ defmodule Jido.Chat.Message do
   defp normalize_author(%{"author" => %Author{}} = attrs), do: attrs
 
   defp normalize_author(%{"author" => author} = attrs) when is_map(author),
-    do: Map.put(attrs, :author, Author.new(author))
+    do: attrs |> Map.delete("author") |> Map.put(:author, Author.new(author))
 
   defp normalize_author(attrs), do: attrs
 

--- a/lib/jido/chat/reply_context.ex
+++ b/lib/jido/chat/reply_context.ex
@@ -1,0 +1,73 @@
+defmodule Jido.Chat.ReplyContext do
+  @moduledoc """
+  Shallow quoted-message context preserved with a message reply.
+
+  This is intentionally not a nested message. It contains only the quoted
+  message ID, provider ID, text, and author fields that providers can supply
+  without lookup.
+  """
+
+  alias Jido.Chat.Author
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              id: Zoi.string() |> Zoi.nullish(),
+              external_message_id: Zoi.any() |> Zoi.nullish(),
+              text: Zoi.string() |> Zoi.nullish(),
+              author: Zoi.struct(Author) |> Zoi.nullish()
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the Zoi schema for ReplyContext."
+  def schema, do: @schema
+
+  @doc "Creates a shallow reply context from map input."
+  @spec new(map()) :: t()
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_author()
+    |> select_fields()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Serializes the reply context with a revivable type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = context) do
+    context
+    |> Map.from_struct()
+    |> Jido.Chat.Wire.to_plain()
+    |> Map.put("__type__", "reply_context")
+  end
+
+  @doc "Builds a reply context from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_author(%{author: %Author{}} = attrs), do: attrs
+
+  defp normalize_author(%{author: author} = attrs) when is_map(author),
+    do: Map.put(attrs, :author, Author.new(author))
+
+  defp normalize_author(%{"author" => %Author{}} = attrs), do: attrs
+
+  defp normalize_author(%{"author" => author} = attrs) when is_map(author),
+    do: attrs |> Map.delete("author") |> Map.put(:author, Author.new(author))
+
+  defp normalize_author(attrs), do: attrs
+
+  defp select_fields(attrs) do
+    %{
+      id: attrs[:id] || attrs["id"],
+      external_message_id: attrs[:external_message_id] || attrs["external_message_id"],
+      text: attrs[:text] || attrs["text"],
+      author: attrs[:author] || attrs["author"]
+    }
+  end
+end

--- a/lib/jido/chat/serialization.ex
+++ b/lib/jido/chat/serialization.ex
@@ -21,6 +21,7 @@ defmodule Jido.Chat.Serialization do
     ModalResponse,
     PostPayload,
     ReactionEvent,
+    ReplyContext,
     SentMessage,
     SlashCommandEvent,
     StreamChunk,
@@ -106,6 +107,7 @@ defmodule Jido.Chat.Serialization do
   def revive(%{"__type__" => "modal"} = map), do: Modal.from_map(map)
   def revive(%{"__type__" => "modal_element"} = map), do: Jido.Chat.Modal.Element.from_map(map)
   def revive(%{"__type__" => "message"} = map), do: Message.from_map(map)
+  def revive(%{"__type__" => "reply_context"} = map), do: ReplyContext.from_map(map)
   def revive(%{"__type__" => "file_upload"} = map), do: FileUpload.from_map(map)
   def revive(%{"__type__" => "post_payload"} = map), do: PostPayload.from_map(map)
   def revive(%{"__type__" => "sent_message"} = map), do: SentMessage.from_map(map)

--- a/test/jido/chat/adapter_conformance_test.exs
+++ b/test/jido/chat/adapter_conformance_test.exs
@@ -7,6 +7,7 @@ defmodule Jido.Chat.AdapterConformanceTest do
     EventEnvelope,
     FileUpload,
     Incoming,
+    Message,
     Modal,
     PostPayload,
     Response,
@@ -306,5 +307,61 @@ defmodule Jido.Chat.AdapterConformanceTest do
     assert {:ok, %EventEnvelope{} = envelope} = Adapter.parse_event(GoodAdapter, request, [])
     assert envelope.event_type == :message
     assert %Incoming{external_message_id: "msg-1"} = envelope.payload
+  end
+
+  test "legacy and trusted enriched inbound payloads use the same adapter callback" do
+    legacy_payload = %{
+      external_room_id: "room-legacy",
+      external_user_id: "provider-user-1",
+      external_message_id: "msg-legacy",
+      text: "hello from an old adapter payload"
+    }
+
+    assert {:ok, %Incoming{} = legacy_incoming} = GoodAdapter.transform_incoming(legacy_payload)
+
+    legacy_message = Message.from_incoming(legacy_incoming, adapter_name: :good)
+
+    assert legacy_message.id == "msg-legacy"
+    assert legacy_message.text == "hello from an old adapter payload"
+    assert legacy_message.external_room_id == "room-legacy"
+    assert legacy_message.author.user_id == "provider-user-1"
+    assert legacy_message.author.id == nil
+    assert legacy_message.external_reply_to_id == nil
+    assert legacy_message.reply_context == nil
+
+    enriched_payload = %{
+      external_room_id: "room-enriched",
+      external_user_id: "provider-user-2",
+      external_message_id: "msg-enriched",
+      text: "reply with trusted identity",
+      author: %{
+        id: "stable-user-2",
+        user_id: "provider-user-2",
+        user_name: "provider-name",
+        full_name: "Provider Name"
+      },
+      external_reply_to_id: "msg-parent",
+      reply_context: %{
+        id: "parent-1",
+        external_message_id: "msg-parent",
+        text: "parent message",
+        author: %{
+          id: "stable-parent",
+          user_id: "provider-parent",
+          user_name: "parent-name"
+        }
+      }
+    }
+
+    assert {:ok, %Incoming{} = enriched_incoming} =
+             GoodAdapter.transform_incoming(enriched_payload)
+
+    enriched_message = Message.from_incoming(enriched_incoming, adapter_name: :good)
+
+    assert enriched_message.author.id == "stable-user-2"
+    assert enriched_message.author.user_id == "provider-user-2"
+    assert enriched_message.external_reply_to_id == "msg-parent"
+    assert enriched_message.reply_context.id == "parent-1"
+    assert enriched_message.reply_context.author.id == "stable-parent"
   end
 end

--- a/test/jido/chat/ai_test.exs
+++ b/test/jido/chat/ai_test.exs
@@ -35,6 +35,34 @@ defmodule Jido.Chat.AITest do
            ] = AI.to_messages([assistant, user, system], include_names: true)
   end
 
+  test "system author role takes precedence below explicit role and above is_me" do
+    system_author =
+      Message.new(%{
+        id: "system",
+        text: "system message",
+        author: Author.new(%{user_id: "system", user_name: "policy", is_system: true, is_me: true})
+      })
+
+    explicit_user =
+      Message.new(%{
+        id: "explicit",
+        text: "explicit user",
+        metadata: %{role: :user},
+        author: Author.new(%{user_id: "system", user_name: "policy", is_system: true})
+      })
+
+    explicit_assistant =
+      Message.new(%{
+        id: "explicit-assistant",
+        text: "explicit assistant",
+        metadata: %{role: :assistant},
+        author: Author.new(%{user_id: "system", user_name: "policy", is_system: true})
+      })
+
+    assert [%{role: "system"}, %{role: "user"}, %{role: "assistant"}] =
+             AI.to_messages([system_author, explicit_user, explicit_assistant])
+  end
+
   test "to_messages emits multipart content for images and text-like files" do
     message =
       Message.new(%{

--- a/test/jido/chat/event_envelope_test.exs
+++ b/test/jido/chat/event_envelope_test.exs
@@ -98,6 +98,47 @@ defmodule Jido.Chat.EventEnvelopeTest do
     assert envelope.message_id == "msg-88"
   end
 
+  test "event user normalization preserves enriched author fields" do
+    assert {:ok, reaction} =
+             EventNormalizer.ensure_reaction_event(
+               %{
+                 emoji: "👍",
+                 user: %{
+                   "user_id" => "provider-1",
+                   "user_name" => "bot",
+                   "full_name" => "Test Bot",
+                   "id" => "stable-1",
+                   "email" => "bot@example.com",
+                   "is_bot" => true,
+                   "is_system" => true,
+                   "is_me" => true,
+                   "metadata" => %{"source" => "test"}
+                 }
+               },
+               :slack
+             )
+
+    assert reaction.user.id == "stable-1"
+    assert reaction.user.email == "bot@example.com"
+    assert reaction.user.user_name == "bot"
+    assert reaction.user.full_name == "Test Bot"
+    assert reaction.user.is_bot
+    assert reaction.user.is_system
+    assert reaction.user.is_me
+    assert reaction.user.metadata == %{"source" => "test"}
+  end
+
+  test "event user provider-only id does not become stable author id" do
+    assert {:ok, reaction} =
+             EventNormalizer.ensure_reaction_event(
+               %{emoji: "👍", user: %{"id" => "provider-only", "username" => "casey"}},
+               :slack
+             )
+
+    assert reaction.user.user_id == "provider-only"
+    assert reaction.user.id == nil
+  end
+
   test "event normalizer returns tagged errors for invalid inputs" do
     assert {:error, {:invalid_incoming, :bad}} = EventNormalizer.ensure_incoming(:bad)
 

--- a/test/jido/chat/event_envelope_test.exs
+++ b/test/jido/chat/event_envelope_test.exs
@@ -139,6 +139,42 @@ defmodule Jido.Chat.EventEnvelopeTest do
     assert reaction.user.id == nil
   end
 
+  test "event normalizer accepts fully string-key legacy users" do
+    assert {:ok, reaction} =
+             EventNormalizer.ensure_reaction_event(
+               %{
+                 "emoji" => "👍",
+                 "user" => %{"id" => "provider-only", "username" => "casey"}
+               },
+               :slack
+             )
+
+    assert reaction.user.user_id == "provider-only"
+    assert reaction.user.id == nil
+    assert reaction.user.user_name == "casey"
+  end
+
+  test "event normalizer accepts fully string-key enriched users" do
+    assert {:ok, reaction} =
+             EventNormalizer.ensure_reaction_event(
+               %{
+                 "emoji" => "👍",
+                 "user" => %{
+                   "user_id" => "provider-1",
+                   "id" => "stable-1",
+                   "user_name" => "bot",
+                   "full_name" => "Test Bot"
+                 }
+               },
+               :slack
+             )
+
+    assert reaction.user.user_id == "provider-1"
+    assert reaction.user.id == "stable-1"
+    assert reaction.user.user_name == "bot"
+    assert reaction.user.full_name == "Test Bot"
+  end
+
   test "event normalizer returns tagged errors for invalid inputs" do
     assert {:error, {:invalid_incoming, :bad}} = EventNormalizer.ensure_incoming(:bad)
 

--- a/test/jido/chat/serialization_test.exs
+++ b/test/jido/chat/serialization_test.exs
@@ -8,6 +8,7 @@ defmodule Jido.Chat.SerializationTest do
     AssistantContextChangedEvent,
     AssistantThreadStartedEvent,
     Attachment,
+    Author,
     Card,
     CapabilityMatrix,
     ChannelRef,
@@ -17,6 +18,7 @@ defmodule Jido.Chat.SerializationTest do
     IngressResult,
     Markdown,
     Message,
+    ReplyContext,
     Modal,
     ModalCloseEvent,
     ModalResult,
@@ -202,6 +204,78 @@ defmodule Jido.Chat.SerializationTest do
 
     assert %SentMessage{attachments: [%Attachment{filename: "report.pdf"}]} =
              sent |> SentMessage.to_map() |> SentMessage.from_map()
+  end
+
+  test "reply context, incoming, and message preserve one-level reply data" do
+    assert ReplyContext.new(%{id: 42}).id == "42"
+
+    context =
+      ReplyContext.new(%{
+        id: "quoted-context",
+        external_message_id: "quoted-provider-id",
+        text: "quoted text",
+        author: %{user_id: "u1", user_name: "quoted", id: "stable-u1"},
+        reply_context: %{id: "nested-must-be-dropped"}
+      })
+
+    assert %ReplyContext{author: %Author{id: "stable-u1"}} =
+             context |> ReplyContext.to_map() |> ReplyContext.from_map()
+
+    incoming =
+      Incoming.new(%{
+        external_room_id: "room-1",
+        external_message_id: "transport-id",
+        external_reply_to_id: "transport-parent",
+        reply_context: context
+      })
+
+    message = Message.from_incoming(incoming)
+    encoded = Message.to_map(message)
+
+    assert encoded["external_reply_to_id"] == "transport-parent"
+    assert encoded["reply_context"]["id"] == "quoted-context"
+    refute Map.has_key?(encoded["reply_context"], "reply_context")
+
+    assert %Message{
+             external_reply_to_id: "transport-parent",
+             reply_context: %ReplyContext{external_message_id: "quoted-provider-id"}
+           } = Message.from_map(encoded)
+
+    assert %Incoming{reply_context: %ReplyContext{}} =
+             incoming |> Incoming.to_map() |> Incoming.from_map()
+  end
+
+  test "event envelope revives a message payload with reply data" do
+    reviver = Chat.reviver()
+
+    message =
+      Message.new(%{
+        id: "m1",
+        external_room_id: "room-1",
+        external_message_id: "m1",
+        external_reply_to_id: "parent-1",
+        reply_context: %{id: "quoted-1", text: "quoted"}
+      })
+
+    envelope =
+      EventEnvelope.new(%{adapter_name: :test, event_type: :message, payload: message})
+
+    assert %EventEnvelope{
+             payload: %Message{
+               external_reply_to_id: "parent-1",
+               reply_context: %ReplyContext{id: "quoted-1"}
+             }
+           } = envelope |> EventEnvelope.to_map() |> EventEnvelope.from_map()
+
+    assert %ReplyContext{id: "quoted-1"} = reviver.(ReplyContext.to_map(message.reply_context))
+  end
+
+  test "legacy incoming and message maps revive without reply fields" do
+    assert %Incoming{external_reply_to_id: nil, reply_context: nil} =
+             Incoming.from_map(%{"external_room_id" => "room", "external_message_id" => "m1"})
+
+    assert %Message{external_reply_to_id: nil, reply_context: nil} =
+             Message.from_map(%{"id" => "m1", "external_room_id" => "room"})
   end
 
   test "file upload, stream chunk, and post payload round-trip" do

--- a/test/jido/chat/serialization_test.exs
+++ b/test/jido/chat/serialization_test.exs
@@ -183,7 +183,8 @@ defmodule Jido.Chat.SerializationTest do
         thread_id: "test:room-1",
         external_room_id: "room-1",
         external_message_id: "m1",
-        text: "hello"
+        text: "hello",
+        author: %{id: "u1", user_id: "u1", user_name: "Ada"}
       })
 
     sent =
@@ -197,7 +198,8 @@ defmodule Jido.Chat.SerializationTest do
         response: Response.new(%{external_message_id: "m1", external_room_id: "room-1"})
       })
 
-    assert %Message{id: "m1", text: "hello"} = message |> Message.to_map() |> Message.from_map()
+    assert %Message{id: "m1", text: "hello", author: %Author{id: "u1", user_name: "Ada"}} =
+             message |> Message.to_map() |> Message.from_map()
 
     assert %SentMessage{id: "m1", adapter: __MODULE__} =
              sent |> SentMessage.to_map() |> SentMessage.from_map()

--- a/test/jido/chat/structs_test.exs
+++ b/test/jido/chat/structs_test.exs
@@ -59,6 +59,60 @@ defmodule Jido.Chat.StructsTest do
       assert message.is_mention == false
     end
 
+    test "Message.from_incoming/2 preserves independent reply identity and context" do
+      incoming =
+        Incoming.new(%{
+          external_room_id: "room_1",
+          external_message_id: "transport-message",
+          external_reply_to_id: "transport-parent",
+          reply_context: %{
+            "id" => "context-parent",
+            "external_message_id" => "quoted-message",
+            "text" => "quoted text",
+            "author" => %{
+              "user_id" => "quoted-user",
+              "user_name" => "quoted-user-name",
+              "id" => "stable-quoted-user"
+            },
+            "nested_reply" => %{id: "must-be-discarded"}
+          }
+        })
+
+      message = Message.from_incoming(incoming)
+
+      assert message.external_reply_to_id == "transport-parent"
+      assert message.reply_context.id == "context-parent"
+      assert message.reply_context.external_message_id == "quoted-message"
+      assert message.reply_context.text == "quoted text"
+      assert message.reply_context.author.user_id == "quoted-user"
+      refute Map.has_key?(Map.from_struct(message.reply_context), :nested_reply)
+    end
+
+    test "Incoming and Message normalize atom and string reply-context maps" do
+      atom_context = %{id: "atom-id", text: "atom text"}
+      string_context = %{"id" => "string-id", "text" => "string text"}
+
+      assert %Chat.ReplyContext{id: "atom-id"} =
+               Incoming.new(%{external_room_id: "room", reply_context: atom_context}).reply_context
+
+      assert %Chat.ReplyContext{id: "string-id"} =
+               Incoming.new(%{"external_room_id" => "room", "reply_context" => string_context}).reply_context
+
+      assert %Chat.ReplyContext{id: "atom-id"} =
+               Message.new(%{id: "m1", reply_context: atom_context}).reply_context
+
+      assert %Chat.ReplyContext{id: "string-id"} =
+               Message.new(%{"id" => "m1", "reply_context" => string_context}).reply_context
+    end
+
+    test "reply transport ID and context do not synthesize each other" do
+      assert %{external_reply_to_id: "parent", reply_context: nil} =
+               Message.new(%{id: "m1", external_reply_to_id: "parent"})
+
+      assert %{external_reply_to_id: nil, reply_context: %Chat.ReplyContext{id: "quoted"}} =
+               Message.new(%{id: "m1", reply_context: %{id: "quoted"}})
+    end
+
     test "Room.new/1 creates room with defaults" do
       room = Room.new(%{type: :direct})
 

--- a/test/jido/chat/structs_test.exs
+++ b/test/jido/chat/structs_test.exs
@@ -107,6 +107,56 @@ defmodule Jido.Chat.StructsTest do
                incoming.channel_meta
     end
 
+    test "Author.new/1 preserves stable identity, email, and system state" do
+      author =
+        Chat.Author.new(%{
+          user_id: "provider-1",
+          user_name: "casey",
+          id: "stable-1",
+          email: "casey@example.com",
+          is_system: true
+        })
+
+      assert author.id == "stable-1"
+      assert author.user_id == "provider-1"
+      assert author.email == "casey@example.com"
+      refute author.is_bot
+      assert author.is_system
+    end
+
+    test "legacy human Author.new/1 keeps enriched fields unset and defaults false" do
+      author = Chat.Author.new(%{user_id: "human-1", user_name: "casey"})
+
+      assert author.id == nil
+      assert author.email == nil
+      refute author.is_bot
+      refute author.is_system
+    end
+
+    test "Incoming.new/1 preserves enriched string-key author maps" do
+      incoming =
+        Incoming.new(%{
+          "external_room_id" => "room-1",
+          "external_user_id" => "provider-external",
+          "author" => %{
+            "user_id" => "provider-author",
+            "user_name" => "bot",
+            "id" => "stable-bot",
+            "email" => "bot@example.com",
+            "is_bot" => true,
+            "is_system" => true,
+            "metadata" => %{"source" => "test"}
+          }
+        })
+
+      assert incoming.author.user_id == "provider-author"
+      assert incoming.author.id == "stable-bot"
+      assert incoming.author.email == "bot@example.com"
+      assert incoming.author.is_bot
+      assert incoming.author.is_system
+      assert incoming.author.metadata == %{"source" => "test"}
+    end
+
     test "new typed structs normalize canonical bot-loop payloads" do
       fetch_options = FetchOptions.new(limit: 25, direction: :forward, cursor: "abc")
       assert fetch_options.limit == 25

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -10,5 +10,7 @@ and retries belong in `jido_messaging`.
 - Keep public APIs documented and typed.
 - Use Zoi-backed structs and Splode errors for new core data and errors.
 - Prefer explicit adapter capability declarations over inference.
+- Stable identity belongs to a trusted application/runtime resolver. `Jido.Chat.Author.id` is framework-neutral stable identity; `Author.user_id` is the provider identity. Adapters must not infer `Author.id` from provider IDs, display names, usernames, or email addresses, call provider profiles to obtain it, or generate a replacement stable ID.
+- Legacy messages, wire maps, and adapter payloads remain valid without author or reply enrichment. Reply context is shallow and uses only event data already present; adapters do not need a new callback or replied-message lookup.
 - Keep live integrations out of this package unless they are excluded by default.
 - Run `mix test`, `mix quality`, and `mix coveralls` before release work.


### PR DESCRIPTION
## Summary

Issue 36 can now carry stable author identity and quoted reply context through the core chat contract. This PR is the core-contract slice. A separate `jido_messaging` PR consumes these fields after the core release.

- `Author.id` now carries trusted, framework-neutral identity. `Author.user_id` remains the provider identity.
- `ReplyContext` preserves one shallow quoted-message snapshot and keeps it separate from the transport reply ID.
- Enriched author and reply fields survive conversion, event envelopes, wire maps, and revival.
- System authors map to the AI system role after an explicit message role and before `is_me`.
- Legacy maps and current adapter payloads remain valid. Adapters do not infer identity or call providers for this contract.

Session-settled decisions carried from planning: stable identity belongs on `Author.id` (user-approved); reply context is typed and one level deep (user-approved); adapter lookup and inference remain out of scope (user-approved).

## Validation

- `mix test`: 146 tests passed.
- `mix quality`: formatting, Credo, Dialyzer, and Doctor passed.
- Isolated cross-package checks: 6 focused tests passed; 6 default tests passed and 9 live tests were excluded.
- Code review: complete (`20260820-181537-31188bd5`); both validated P1 findings were fixed and verified.

## Related

Related: #36

Participant pairing, rebinding, and stable-ID collision policy remain in #40.

## Post-Deploy Monitoring & Validation

- Search application logs for `invalid Jido.Chat.Message`, `invalid_reaction_event`, and reply-context revival errors.
- Watch ingress-normalization failures and serialization/revival error counts for 24 hours after release.
- Healthy signal: no increase in normalization or revival failures, and system-author messages keep the expected role.
- Failure signal: new invalid-author, invalid-event, or reply-revival errors after consumers upgrade.
- Mitigation: roll consumers back to the prior `jido_chat` release and retain legacy payload fields.
- Owner: the package maintainer or release on-call.

## New concepts

### Stable identity and provider identity

`Author.id` identifies the same framework subject when a trusted application already knows that subject. `Author.user_id` identifies the account inside one provider.

The split prevents a Slack, Discord, or other provider ID from becoming a cross-provider identity by accident. For example, an adapter can pass `user_id: "U123"`, but it can set `id: "person:42"` only when a trusted resolver supplied that value.

Do not use this pattern to infer identity from email, display name, or username. Explicit pairing and collision handling need a separate policy.

### Shallow reply snapshots

`ReplyContext` stores only the quoted message IDs, text, and author. It is a value snapshot, not another nested `Message`.

The shallow shape keeps wire payloads bounded and avoids provider lookups. It also lets the transport reply ID disagree with the available quote without losing either value.

Do not use the snapshot as a transcript store or as the source of full reply history.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
