### PR TITLE
feat(test-kit): publish adapter conformance helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ It provides:
 - explicit adapter capability negotiation and fallback behavior (`Jido.Chat.Adapter`, `CapabilityMatrix`)
 - lightweight state and concurrency hooks used by `Jido.Chat` today (`StateAdapter`, `Concurrency`)
 - framework-agnostic AI history conversion (`Jido.Chat.AI`)
+- provider-free ExUnit adapter conformance support (`Jido.Chat.AdapterTestKit`)
 
 ## Installation
 
@@ -65,6 +66,10 @@ upload hook used by the core fallback path for single-upload posts.
 6. Treat `Author.id` as trusted, framework-neutral stable identity. Only pass it through when an application/runtime resolver supplied it. Never derive it from a provider ID, display name, username, or email, and do not make provider profile calls to resolve it for this contract.
 7. Reply context is shallow and uses only data already present in the event. It does not perform replied-message lookup.
 8. Run `mix quality` before publishing adapter changes.
+
+See the [Adapter Test Kit](guides/adapter_test_kit.md) guide for the reusable
+conformance case, deterministic factories and mocks, and provider-extension
+tests.
 
 ## Usage (Core Loop)
 

--- a/guides/adapter_test_kit.md
+++ b/guides/adapter_test_kit.md
@@ -1,0 +1,144 @@
+# Adapter Test Kit
+
+`Jido.Chat.AdapterTestKit` is provider-free ExUnit support for independent
+adapter packages. It is in the `jido_chat` Hex package under `lib/`. An adapter
+package does not need its provider SDK to compile or run the kit itself.
+
+Add `jido_chat` to the test environment if it is not already a runtime
+dependency:
+
+```elixir
+def deps do
+  [
+    {:jido_chat, "~> 1.1", only: :test}
+  ]
+end
+```
+
+## Minimal adapter
+
+The canonical adapter has three required callbacks. Declare each capability
+explicitly. A `:native` declaration must have its matching callback.
+
+```elixir
+defmodule MyAdapter do
+  use Jido.Chat.Adapter
+
+  @impl true
+  def channel_type, do: :my_provider
+
+  @impl true
+  def transform_incoming(payload) do
+    {:ok,
+     %{
+       external_room_id: payload["room_id"],
+       external_user_id: payload["user_id"],
+       external_message_id: payload["message_id"],
+       text: payload["text"],
+       raw: payload
+     }}
+  end
+
+  @impl true
+  def send_message(room_id, text, _opts) do
+    {:ok,
+     %{
+       external_room_id: room_id,
+       external_message_id: "provider-message-1",
+       metadata: %{text: text}
+     }}
+  end
+
+  @impl true
+  def capabilities do
+    %{
+      send_message: :native,
+      edit_message: :unsupported,
+      delete_message: :unsupported
+    }
+  end
+end
+```
+
+Add one baseline conformance module. The generated tests check capability
+coherence and stable results for unsupported operations.
+
+```elixir
+defmodule MyAdapter.ConformanceTest do
+  use Jido.Chat.AdapterTestKit, adapter: MyAdapter, async: true
+end
+```
+
+## Provider extensions
+
+Use `capability_test/3` for tests that need provider fixtures or a provider
+client mock. The body runs only when the capability is `:native` or
+`:fallback`.
+
+```elixir
+defmodule MyAdapter.ProviderContractTest do
+  use Jido.Chat.AdapterTestKit, adapter: MyAdapter, async: true
+
+  capability_test :edit_message, "normalizes an edit response" do
+    result =
+      Jido.Chat.Adapter.edit_message(
+        @adapter,
+        "room-1",
+        "provider-message-1",
+        "New text"
+      )
+
+    assert_capability_result(@adapter, :edit_message, result)
+  end
+
+  test "turns a provider webhook into an EventEnvelope" do
+    request =
+      webhook_request(
+        adapter_name: :my_provider,
+        payload: %{
+          "room_id" => "room-1",
+          "user_id" => "user-1",
+          "message_id" => "provider-message-1",
+          "text" => "Hello"
+        }
+      )
+
+    assert %Jido.Chat.EventEnvelope{} = assert_webhook_event(@adapter, request)
+  end
+end
+```
+
+`assert_capability_result/3` has contract checks for posting, editing,
+deletion, reactions, thread operations, file operations, media fetches, and
+message pages. Other shared assertions check normalized responses, message
+identifiers, canonical media, JSON serialization, and webhook event envelopes.
+
+## Factories and deterministic mocks
+
+`Jido.Chat.AdapterTestKit.Factories` supplies fixed authors, messages, media,
+incoming events, event envelopes, webhook requests, post payloads, and adapter
+responses. Each function accepts a map or keyword list of field overrides.
+
+`Jido.Chat.AdapterTestKit.MockState` gives each test a resettable state process.
+`Jido.Chat.AdapterTestKit.MockTransport` records ordered calls and consumes a
+response queue. `Jido.Chat.AdapterTestKit.MockAdapter` implements the common
+native operation shapes and can use the mock transport:
+
+```elixir
+transport = start_supervised!(Jido.Chat.AdapterTestKit.MockTransport)
+
+{:ok, response} =
+  Jido.Chat.Adapter.send_message(
+    Jido.Chat.AdapterTestKit.MockAdapter,
+    "room-1",
+    "Hello",
+    transport: transport
+  )
+
+assert response.external_message_id == "mock-message-1"
+assert [%{operation: :send_message}] =
+         Jido.Chat.AdapterTestKit.MockTransport.calls(transport)
+```
+
+The kit does not replace provider integration tests. Keep credential checks,
+provider emulators, and provider SDK behavior in the adapter package.

--- a/lib/jido/chat/adapter.ex
+++ b/lib/jido/chat/adapter.ex
@@ -40,6 +40,8 @@ defmodule Jido.Chat.Adapter do
   @type capability_status :: :native | :fallback | :unsupported
   @type capability_matrix :: %{optional(atom()) => capability_status()}
 
+  @capability_statuses [:native, :fallback, :unsupported]
+
   @type send_result :: {:ok, Response.t()} | {:error, term()}
   @type incoming_result :: {:ok, Incoming.t()} | {:error, term()}
   @type delete_result :: :ok | {:error, term()}
@@ -55,6 +57,24 @@ defmodule Jido.Chat.Adapter do
   @type media_result :: {:ok, binary()} | {:error, term()}
   @type file_input :: FileUpload.input()
   @type media_reference :: String.t() | Media.t() | map()
+
+  @core_fallback_capabilities [
+    :initialize,
+    :shutdown,
+    :post_message,
+    :fetch_metadata,
+    :fetch_thread,
+    :post_channel_message,
+    :stream,
+    :webhook,
+    :verify_webhook,
+    :parse_event,
+    :format_webhook_response
+  ]
+
+  @doc "Returns operations that always have a core fallback."
+  @spec core_fallback_capabilities() :: [atom()]
+  def core_fallback_capabilities, do: @core_fallback_capabilities
 
   @callback channel_type() :: atom()
   @callback transform_incoming(raw_payload()) :: incoming_result() | {:ok, map()}
@@ -261,41 +281,14 @@ defmodule Jido.Chat.Adapter do
   @doc "Returns capability matrix for adapter-native vs fallback support."
   @spec capabilities(module()) :: capability_matrix()
   def capabilities(adapter_module) do
-    if callback_exported?(adapter_module, :capabilities, 0) do
-      adapter_module.capabilities()
-      |> normalize_capability_matrix()
-      |> ensure_capability_defaults(adapter_module)
-    else
-      %{
-        initialize: support_status(adapter_module, :initialize, 1, :fallback),
-        shutdown: support_status(adapter_module, :shutdown, 1, :fallback),
-        send_message: :native,
-        send_file: support_status(adapter_module, :send_file, 3),
-        post_message: support_status(adapter_module, :post_message, 3),
-        edit_message: support_status(adapter_module, :edit_message, 4),
-        delete_message: support_status(adapter_module, :delete_message, 3),
-        start_typing: support_status(adapter_module, :start_typing, 2),
-        fetch_metadata: support_status(adapter_module, :fetch_metadata, 2, :fallback),
-        fetch_thread: support_status(adapter_module, :fetch_thread, 2, :fallback),
-        fetch_message: support_status(adapter_module, :fetch_message, 3, :fallback),
-        add_reaction: support_status(adapter_module, :add_reaction, 4),
-        remove_reaction: support_status(adapter_module, :remove_reaction, 4),
-        post_ephemeral: support_status(adapter_module, :post_ephemeral, 4),
-        open_dm: support_status(adapter_module, :open_dm, 2),
-        fetch_messages: support_status(adapter_module, :fetch_messages, 2),
-        fetch_channel_messages: support_status(adapter_module, :fetch_channel_messages, 2),
-        list_threads: support_status(adapter_module, :list_threads, 2),
-        open_thread: support_status(adapter_module, :open_thread, 3),
-        post_channel_message: support_status(adapter_module, :post_channel_message, 3, :fallback),
-        stream: support_status(adapter_module, :stream, 3, :fallback),
-        open_modal: support_status(adapter_module, :open_modal, 3),
-        webhook: support_status(adapter_module, :handle_webhook, 3, :fallback),
-        verify_webhook: support_status(adapter_module, :verify_webhook, 2, :fallback),
-        parse_event: support_status(adapter_module, :parse_event, 2, :fallback),
-        format_webhook_response: support_status(adapter_module, :format_webhook_response, 2, :fallback)
-      }
-      |> ensure_capability_defaults(adapter_module)
-    end
+    declared =
+      if callback_exported?(adapter_module, :capabilities, 0) do
+        normalize_capability_matrix(adapter_module.capabilities())
+      else
+        %{}
+      end
+
+    ensure_capability_defaults(declared, adapter_module)
   end
 
   @doc "Normalizes adapter inbound transformation to `Jido.Chat.Incoming`."
@@ -513,6 +506,21 @@ defmodule Jido.Chat.Adapter do
       with {:ok, message} <-
              adapter_module.fetch_message(external_room_id, external_message_id, opts) do
         {:ok, normalize_message(adapter_module, message, opts)}
+      end
+    else
+      {:error, :unsupported}
+    end
+  end
+
+  @doc "Fetches media bytes when supported by the adapter."
+  @spec fetch_media(module(), media_reference(), keyword()) :: media_result()
+  def fetch_media(adapter_module, reference, opts \\ []) do
+    if callback_exported?(adapter_module, :fetch_media, 2) do
+      case adapter_module.fetch_media(reference, opts) do
+        {:ok, bytes} when is_binary(bytes) -> {:ok, bytes}
+        {:ok, _other} -> {:error, :invalid_media_result}
+        {:error, _reason} = error -> error
+        _other -> {:error, :invalid_media_result}
       end
     else
       {:error, :unsupported}
@@ -815,29 +823,45 @@ defmodule Jido.Chat.Adapter do
   @doc "Validates capability declaration coherence with implemented callbacks."
   @spec validate_capabilities(module()) :: :ok | {:error, term()}
   def validate_capabilities(adapter_module) do
-    declared = capabilities(adapter_module)
+    with {:ok, raw_declared} <- raw_capability_declaration(adapter_module) do
+      invalid =
+        adapter_module
+        |> capabilities()
+        |> Enum.reduce([], fn {capability, status}, acc ->
+          callback = capability_callback(capability)
 
-    invalid =
-      Enum.reduce(declared, [], fn {capability, status}, acc ->
-        callback = capability_callback(capability)
+          case callback do
+            nil ->
+              acc
 
-        case callback do
-          nil ->
-            acc
+            {name, arity} ->
+              exported? = callback_exported?(adapter_module, name, arity)
+              declared_status = Map.get(raw_declared, capability, status)
 
-          {name, arity} ->
-            exported? = callback_exported?(adapter_module, name, arity)
+              case {declared_status, exported?} do
+                {:native, false} ->
+                  [{capability, :missing_callback} | acc]
 
-            case {status, exported?} do
-              {:native, false} -> [{capability, :missing_callback} | acc]
-              _ -> acc
-            end
-        end
-      end)
+                {:fallback, false} ->
+                  if core_fallback_capability?(capability) do
+                    acc
+                  else
+                    [{capability, :missing_fallback} | acc]
+                  end
 
-    case invalid do
-      [] -> :ok
-      _ -> {:error, {:invalid_capability_matrix, Enum.reverse(invalid)}}
+                {:unsupported, true} ->
+                  [{capability, :unsupported_callback} | acc]
+
+                _ ->
+                  acc
+              end
+          end
+        end)
+
+      case invalid do
+        [] -> :ok
+        _ -> {:error, {:invalid_capability_matrix, Enum.reverse(invalid)}}
+      end
     end
   end
 
@@ -859,12 +883,52 @@ defmodule Jido.Chat.Adapter do
     if callback_exported?(adapter_module, callback, arity), do: :native, else: fallback
   end
 
+  defp inferred_capability_status(adapter_module, capability) do
+    case capability_callback(capability) do
+      {callback, arity} ->
+        fallback = if core_fallback_capability?(capability), do: :fallback, else: :unsupported
+        support_status(adapter_module, callback, arity, fallback)
+
+      nil ->
+        :unsupported
+    end
+  end
+
+  defp core_fallback_capability?(capability), do: capability in @core_fallback_capabilities
+
   defp supported_status?(status), do: status in [:native, :fallback]
 
   defp normalize_capability_matrix(matrix) when is_map(matrix),
     do: matrix |> then(&CapabilityMatrix.new(%{capabilities: &1})) |> CapabilityMatrix.as_map()
 
   defp normalize_capability_matrix(_), do: %{}
+
+  defp raw_capability_declaration(adapter_module) do
+    if callback_exported?(adapter_module, :capabilities, 0) do
+      case adapter_module.capabilities() do
+        declaration when is_map(declaration) -> validate_capability_statuses(declaration)
+        _other -> {:error, {:invalid_capability_matrix, [capabilities: :invalid_map]}}
+      end
+    else
+      {:ok, %{}}
+    end
+  end
+
+  defp validate_capability_statuses(declaration) do
+    invalid =
+      Enum.reduce(declaration, [], fn {capability, status}, acc ->
+        if status in @capability_statuses do
+          acc
+        else
+          [{capability, :invalid_status} | acc]
+        end
+      end)
+
+    case invalid do
+      [] -> {:ok, declaration}
+      _ -> {:error, {:invalid_capability_matrix, Enum.reverse(invalid)}}
+    end
+  end
 
   defp normalize_incoming(%Incoming{} = incoming), do: incoming
   defp normalize_incoming(map) when is_map(map), do: Incoming.new(map)
@@ -1228,40 +1292,49 @@ defmodule Jido.Chat.Adapter do
   defp normalize_modal_payload(%{} = modal), do: modal
 
   defp ensure_capability_defaults(matrix, adapter_module) do
+    defaults = %{
+      initialize: inferred_capability_status(adapter_module, :initialize),
+      shutdown: inferred_capability_status(adapter_module, :shutdown),
+      send_message: :native,
+      send_file: inferred_capability_status(adapter_module, :send_file),
+      post_message: inferred_capability_status(adapter_module, :post_message),
+      edit_message: inferred_capability_status(adapter_module, :edit_message),
+      delete_message: inferred_capability_status(adapter_module, :delete_message),
+      start_typing: inferred_capability_status(adapter_module, :start_typing),
+      fetch_metadata: inferred_capability_status(adapter_module, :fetch_metadata),
+      fetch_thread: inferred_capability_status(adapter_module, :fetch_thread),
+      fetch_message: inferred_capability_status(adapter_module, :fetch_message),
+      fetch_media: inferred_capability_status(adapter_module, :fetch_media),
+      add_reaction: inferred_capability_status(adapter_module, :add_reaction),
+      remove_reaction: inferred_capability_status(adapter_module, :remove_reaction),
+      post_ephemeral: inferred_capability_status(adapter_module, :post_ephemeral),
+      open_dm: inferred_capability_status(adapter_module, :open_dm),
+      fetch_messages: inferred_capability_status(adapter_module, :fetch_messages),
+      fetch_channel_messages: inferred_capability_status(adapter_module, :fetch_channel_messages),
+      list_threads: inferred_capability_status(adapter_module, :list_threads),
+      open_thread: inferred_capability_status(adapter_module, :open_thread),
+      post_channel_message: inferred_capability_status(adapter_module, :post_channel_message),
+      stream: inferred_capability_status(adapter_module, :stream),
+      open_modal: inferred_capability_status(adapter_module, :open_modal),
+      webhook: inferred_capability_status(adapter_module, :webhook),
+      verify_webhook: inferred_capability_status(adapter_module, :verify_webhook),
+      parse_event: inferred_capability_status(adapter_module, :parse_event),
+      format_webhook_response: inferred_capability_status(adapter_module, :format_webhook_response)
+    }
+
+    matrix =
+      defaults
+      |> Map.merge(matrix)
+      |> Map.put(:send_message, :native)
+      |> canonicalize_core_fallback_capabilities(adapter_module)
+
     single_upload_supported? =
-      supported_status?(matrix[:send_file]) or supported_status?(matrix[:post_message])
+      supported_status?(matrix[:send_file]) or matrix[:post_message] == :native
 
     multi_upload_supported? =
-      supported_status?(matrix[:multi_file]) or supported_status?(matrix[:post_message])
+      supported_status?(matrix[:multi_file]) or matrix[:post_message] == :native
 
-    defaults = %{
-      initialize: support_status(adapter_module, :initialize, 1, :fallback),
-      shutdown: support_status(adapter_module, :shutdown, 1, :fallback),
-      send_message: :native,
-      send_file: support_status(adapter_module, :send_file, 3),
-      post_message: support_status(adapter_module, :post_message, 3),
-      edit_message: support_status(adapter_module, :edit_message, 4),
-      delete_message: support_status(adapter_module, :delete_message, 3),
-      start_typing: support_status(adapter_module, :start_typing, 2),
-      fetch_metadata: support_status(adapter_module, :fetch_metadata, 2, :fallback),
-      fetch_thread: support_status(adapter_module, :fetch_thread, 2, :fallback),
-      fetch_message: support_status(adapter_module, :fetch_message, 3, :fallback),
-      fetch_media: support_status(adapter_module, :fetch_media, 2),
-      add_reaction: support_status(adapter_module, :add_reaction, 4),
-      remove_reaction: support_status(adapter_module, :remove_reaction, 4),
-      post_ephemeral: support_status(adapter_module, :post_ephemeral, 4),
-      open_dm: support_status(adapter_module, :open_dm, 2),
-      fetch_messages: support_status(adapter_module, :fetch_messages, 2),
-      fetch_channel_messages: support_status(adapter_module, :fetch_channel_messages, 2),
-      list_threads: support_status(adapter_module, :list_threads, 2),
-      open_thread: support_status(adapter_module, :open_thread, 3),
-      post_channel_message: support_status(adapter_module, :post_channel_message, 3, :fallback),
-      stream: support_status(adapter_module, :stream, 3, :fallback),
-      open_modal: support_status(adapter_module, :open_modal, 3),
-      webhook: support_status(adapter_module, :handle_webhook, 3, :fallback),
-      verify_webhook: support_status(adapter_module, :verify_webhook, 2, :fallback),
-      parse_event: support_status(adapter_module, :parse_event, 2, :fallback),
-      format_webhook_response: support_status(adapter_module, :format_webhook_response, 2, :fallback),
+    presentation_defaults = %{
       text: :native,
       image: if(single_upload_supported?, do: :fallback, else: :unsupported),
       audio: if(single_upload_supported?, do: :fallback, else: :unsupported),
@@ -1280,7 +1353,19 @@ defmodule Jido.Chat.Adapter do
       assistant_events: :unsupported
     }
 
-    Map.merge(defaults, matrix)
+    Map.merge(presentation_defaults, matrix)
+  end
+
+  defp canonicalize_core_fallback_capabilities(matrix, adapter_module) do
+    Enum.reduce(@core_fallback_capabilities, matrix, fn capability, acc ->
+      inferred_status = inferred_capability_status(adapter_module, capability)
+
+      case {Map.fetch!(acc, capability), inferred_status} do
+        {:unsupported, status} -> Map.put(acc, capability, status)
+        {:fallback, :native} -> Map.put(acc, capability, :native)
+        _other -> acc
+      end
+    end)
   end
 
   defp normalize_webhook_request(%WebhookRequest{} = request, _opts), do: request

--- a/lib/jido/chat/adapter_test_kit.ex
+++ b/lib/jido/chat/adapter_test_kit.ex
@@ -1,0 +1,70 @@
+defmodule Jido.Chat.AdapterTestKit do
+  @moduledoc """
+  Reusable ExUnit support for independent `Jido.Chat.Adapter` packages.
+
+  Use this module in an adapter test module. It adds baseline tests for the
+  capability matrix and stable unsupported results. It also imports the
+  canonical factories and shared assertions.
+
+      defmodule MyAdapter.ConformanceTest do
+        use Jido.Chat.AdapterTestKit, adapter: MyAdapter, async: true
+      end
+
+  Provider-specific tests can use `capability_test/3`. The test body runs only
+  when the adapter declares the capability as `:native` or `:fallback`.
+  """
+
+  alias Jido.Chat.Adapter
+
+  @doc "Adds provider-free adapter conformance tests and shared test helpers."
+  @spec __using__(keyword()) :: Macro.t()
+  defmacro __using__(opts) do
+    adapter = Keyword.fetch!(opts, :adapter)
+    async = Keyword.get(opts, :async, true)
+
+    quote do
+      use ExUnit.Case, async: unquote(async)
+
+      import Jido.Chat.AdapterTestKit, only: [capability_test: 3]
+      import Jido.Chat.AdapterTestKit.Assertions
+      import Jido.Chat.AdapterTestKit.Factories
+
+      @adapter unquote(adapter)
+
+      test "adapter capability declarations are coherent" do
+        assert_capability_coherence(@adapter)
+      end
+
+      test "adapter operations match declared support" do
+        assert_unsupported_operations(@adapter)
+      end
+    end
+  end
+
+  @doc """
+  Defines a provider test that runs only when the adapter supports a capability.
+
+      capability_test :edit_message, "normalizes the provider edit result" do
+        result = Jido.Chat.Adapter.edit_message(@adapter, "room", "message", "new text")
+        assert_capability_result(@adapter, :edit_message, result)
+      end
+  """
+  @spec capability_test(atom(), String.t(), keyword()) :: Macro.t()
+  defmacro capability_test(capability, description, do: block) do
+    quote do
+      test "#{unquote(capability)}: #{unquote(description)}" do
+        if Jido.Chat.AdapterTestKit.supported?(@adapter, unquote(capability)) do
+          unquote(block)
+        else
+          :ok
+        end
+      end
+    end
+  end
+
+  @doc "Returns true when a capability is native or has a core fallback."
+  @spec supported?(module(), atom()) :: boolean()
+  def supported?(adapter, capability) when is_atom(adapter) and is_atom(capability) do
+    Adapter.capabilities(adapter)[capability] in [:native, :fallback]
+  end
+end

--- a/lib/jido/chat/adapter_test_kit/assertions.ex
+++ b/lib/jido/chat/adapter_test_kit/assertions.ex
@@ -1,0 +1,296 @@
+defmodule Jido.Chat.AdapterTestKit.Assertions do
+  @moduledoc """
+  Shared ExUnit assertions for adapter contract tests.
+
+  These functions use only the public adapter API and canonical `Jido.Chat`
+  types. They do not need a provider SDK.
+  """
+
+  import ExUnit.Assertions
+
+  alias Jido.Chat.{
+    Adapter,
+    ChannelInfo,
+    EphemeralMessage,
+    EventEnvelope,
+    Incoming,
+    Media,
+    Message,
+    MessagePage,
+    ModalResult,
+    Response,
+    Serialization,
+    Thread,
+    ThreadPage,
+    WebhookResponse
+  }
+
+  @stable_statuses [:native, :fallback, :unsupported]
+
+  @operation_specs %{
+    initialize: %{result: :ok},
+    shutdown: %{result: :ok},
+    send_message: %{result: :response},
+    send_file: %{result: :response, unsupported_call: :send_file},
+    post_message: %{result: :response},
+    post_channel_message: %{result: :response},
+    stream: %{result: :response},
+    edit_message: %{result: :response, unsupported_call: :edit_message},
+    delete_message: %{result: :ok, unsupported_call: :delete_message},
+    start_typing: %{result: :ok, unsupported_call: :start_typing},
+    fetch_metadata: %{result: :channel_info},
+    fetch_thread: %{result: :thread},
+    fetch_message: %{result: :message, unsupported_call: :fetch_message},
+    fetch_media: %{result: :media, unsupported_call: :fetch_media},
+    add_reaction: %{result: :ok, unsupported_call: :add_reaction},
+    remove_reaction: %{result: :ok, unsupported_call: :remove_reaction},
+    post_ephemeral: %{result: :ephemeral_message, unsupported_call: :post_ephemeral},
+    open_dm: %{result: :room_id},
+    open_modal: %{result: :modal_result, unsupported_call: :open_modal},
+    fetch_messages: %{result: :message_page, unsupported_call: :fetch_messages},
+    fetch_channel_messages: %{
+      result: :message_page,
+      unsupported_call: :fetch_channel_messages
+    },
+    list_threads: %{result: :thread_page, unsupported_call: :list_threads},
+    open_thread: %{result: :thread, unsupported_call: :open_thread},
+    webhook: %{result: :webhook},
+    verify_webhook: %{result: :ok},
+    parse_event: %{result: :event},
+    format_webhook_response: %{result: :webhook_response}
+  }
+
+  @doc "Asserts that capability statuses and native callbacks are coherent."
+  @spec assert_capability_coherence(module()) :: Jido.Chat.CapabilityMatrix.t()
+  def assert_capability_coherence(adapter) do
+    assert_required_callbacks(adapter)
+    assert_raw_capability_declaration(adapter)
+
+    matrix = Adapter.capability_matrix(adapter)
+
+    assert Enum.all?(matrix.capabilities, fn {_capability, status} ->
+             status in @stable_statuses
+           end),
+           "expected all capability statuses to be :native, :fallback, or :unsupported"
+
+    assert Adapter.validate_capabilities(adapter) == :ok
+    matrix
+  end
+
+  @doc "Asserts unsupported declarations are coherent without calling provider operations."
+  @spec assert_unsupported_operations(module()) :: :ok
+  def assert_unsupported_operations(adapter) do
+    matrix = assert_capability_coherence(adapter)
+
+    Enum.each(@operation_specs, fn {capability, spec} ->
+      if matrix.capabilities[capability] == :unsupported and spec[:unsupported_call] do
+        result = call_unsupported_operation(adapter, spec.unsupported_call)
+
+        assert result == {:error, :unsupported},
+               "expected #{inspect(capability)} to return {:error, :unsupported}, " <>
+                 "got: #{inspect(result)}"
+      end
+    end)
+
+    :ok
+  end
+
+  @doc "Asserts a normalized `Jido.Chat.Response` result with a message identifier."
+  @spec assert_normalized_response(term()) :: Response.t()
+  def assert_normalized_response(result) do
+    assert {:ok, %Response{} = response} = result
+    assert_message_identifier(response)
+    response
+  end
+
+  @doc "Asserts and returns a stable external message identifier."
+  @spec assert_message_identifier(Response.t() | Message.t() | Incoming.t()) :: String.t()
+  def assert_message_identifier(value) do
+    identifier = message_identifier(value)
+
+    assert not is_nil(identifier), "expected an external message identifier"
+
+    identifier = to_string(identifier)
+    assert String.trim(identifier) != "", "expected a non-empty external message identifier"
+    identifier
+  end
+
+  @doc "Asserts canonical media fields and returns the media value."
+  @spec assert_media(Media.t(), keyword()) :: Media.t()
+  def assert_media(media, expected \\ []) do
+    assert %Media{} = media
+
+    Enum.each(expected, fn {field, expected_value} ->
+      assert Map.fetch!(media, field) == expected_value,
+             "expected media #{field} to equal #{inspect(expected_value)}"
+    end)
+
+    media
+  end
+
+  @doc "Asserts JSON-safe serialization and revival for a typed value."
+  @spec assert_json_round_trip(struct()) :: struct()
+  def assert_json_round_trip(%module{} = value) do
+    assert function_exported?(module, :to_map, 1),
+           "expected #{inspect(module)} to export to_map/1"
+
+    revived =
+      value
+      |> module.to_map()
+      |> Jason.encode!()
+      |> Jason.decode!()
+      |> Serialization.revive()
+
+    assert revived == value
+    revived
+  end
+
+  @doc "Asserts that a webhook request becomes a typed event envelope."
+  @spec assert_webhook_event(module(), Jido.Chat.WebhookRequest.t() | map(), keyword()) ::
+          EventEnvelope.t()
+  def assert_webhook_event(adapter, request, opts \\ []) do
+    assert {:ok, %EventEnvelope{} = envelope} = Adapter.parse_event(adapter, request, opts)
+    assert envelope.adapter_name == Adapter.adapter_type(adapter)
+
+    if envelope.event_type == :message do
+      assert %Incoming{} = envelope.payload
+      assert_message_identifier(envelope.payload)
+      assert envelope.message_id == to_string(envelope.payload.external_message_id)
+    end
+
+    envelope
+  end
+
+  @doc """
+  Asserts the normalized result shape for a declared capability.
+
+  Use this in `capability_test/3` blocks after the provider operation runs.
+  """
+  @spec assert_capability_result(module(), atom(), term()) :: term()
+  def assert_capability_result(adapter, capability, result) do
+    case @operation_specs[capability] do
+      nil ->
+        flunk("unknown adapter capability #{inspect(capability)}")
+
+      %{result: result_contract} ->
+        status = Adapter.capabilities(adapter)[capability]
+        assert status in [:native, :fallback], "expected #{inspect(capability)} to be supported"
+        assert_supported_result(result_contract, result)
+    end
+
+    result
+  end
+
+  defp assert_supported_result(:response, result) do
+    assert_normalized_response(result)
+  end
+
+  defp assert_supported_result(:ok, result), do: assert(result == :ok)
+
+  defp assert_supported_result(:media, result) do
+    assert {:ok, bytes} = result
+    assert is_binary(bytes)
+  end
+
+  defp assert_supported_result(:message, result) do
+    assert {:ok, %Message{} = message} = result
+    assert_message_identifier(message)
+  end
+
+  defp assert_supported_result(:message_page, result) do
+    assert {:ok, %MessagePage{messages: messages}} = result
+    Enum.each(messages, &assert_message_identifier/1)
+  end
+
+  defp assert_supported_result(:channel_info, result),
+    do: assert({:ok, %ChannelInfo{}} = result)
+
+  defp assert_supported_result(:thread_page, result), do: assert({:ok, %ThreadPage{}} = result)
+  defp assert_supported_result(:thread, result), do: assert({:ok, %Thread{}} = result)
+
+  defp assert_supported_result(:ephemeral_message, result),
+    do: assert({:ok, %EphemeralMessage{}} = result)
+
+  defp assert_supported_result(:room_id, result) do
+    assert {:ok, room_id} = result
+    assert is_binary(room_id) or is_integer(room_id)
+  end
+
+  defp assert_supported_result(:modal_result, result),
+    do: assert({:ok, %ModalResult{}} = result)
+
+  defp assert_supported_result(:event, {:ok, :noop}), do: :ok
+  defp assert_supported_result(:event, result), do: assert({:ok, %EventEnvelope{}} = result)
+
+  defp assert_supported_result(:webhook_response, result),
+    do: assert({:ok, %WebhookResponse{}} = result)
+
+  defp assert_supported_result(:webhook, result),
+    do: assert({:ok, %Jido.Chat{}, %Incoming{}} = result)
+
+  defp call_unsupported_operation(adapter, :send_file),
+    do: Adapter.send_file(adapter, "room-1", "/tmp/jido-chat-test-kit.txt", [])
+
+  defp call_unsupported_operation(adapter, :edit_message),
+    do: Adapter.edit_message(adapter, "room-1", "message-1", "updated", [])
+
+  defp call_unsupported_operation(adapter, :delete_message),
+    do: Adapter.delete_message(adapter, "room-1", "message-1", [])
+
+  defp call_unsupported_operation(adapter, :start_typing),
+    do: Adapter.start_typing(adapter, "room-1", [])
+
+  defp call_unsupported_operation(adapter, :fetch_message),
+    do: Adapter.fetch_message(adapter, "room-1", "message-1", [])
+
+  defp call_unsupported_operation(adapter, :fetch_media),
+    do: Adapter.fetch_media(adapter, "media://test", [])
+
+  defp call_unsupported_operation(adapter, :add_reaction),
+    do: Adapter.add_reaction(adapter, "room-1", "message-1", "thumbs_up", [])
+
+  defp call_unsupported_operation(adapter, :remove_reaction),
+    do: Adapter.remove_reaction(adapter, "room-1", "message-1", "thumbs_up", [])
+
+  defp call_unsupported_operation(adapter, :post_ephemeral),
+    do: Adapter.post_ephemeral(adapter, "room-1", "user-1", "test", [])
+
+  defp call_unsupported_operation(adapter, :open_modal),
+    do: Adapter.open_modal(adapter, "room-1", %{custom_id: "test-modal"}, [])
+
+  defp call_unsupported_operation(adapter, :fetch_messages),
+    do: Adapter.fetch_messages(adapter, "room-1", [])
+
+  defp call_unsupported_operation(adapter, :fetch_channel_messages),
+    do: Adapter.fetch_channel_messages(adapter, "room-1", [])
+
+  defp call_unsupported_operation(adapter, :list_threads),
+    do: Adapter.list_threads(adapter, "room-1", [])
+
+  defp call_unsupported_operation(adapter, :open_thread),
+    do: Adapter.open_thread(adapter, "room-1", "message-1", [])
+
+  defp message_identifier(%Response{} = response), do: response.external_message_id
+  defp message_identifier(%Message{} = message), do: message.external_message_id || message.id
+  defp message_identifier(%Incoming{} = incoming), do: incoming.external_message_id
+
+  defp assert_required_callbacks(adapter) do
+    assert Code.ensure_loaded?(adapter), "expected #{inspect(adapter)} to be available"
+
+    Enum.each([channel_type: 0, transform_incoming: 1, send_message: 3], fn {name, arity} ->
+      assert function_exported?(adapter, name, arity),
+             "expected #{inspect(adapter)} to export required callback #{name}/#{arity}"
+    end)
+  end
+
+  defp assert_raw_capability_declaration(adapter) do
+    if function_exported?(adapter, :capabilities, 0) do
+      declaration = adapter.capabilities()
+
+      assert is_map(declaration), "expected capabilities/0 to return a map"
+
+      assert Enum.all?(declaration, fn {_capability, status} -> status in @stable_statuses end),
+             "expected raw capability statuses to be :native, :fallback, or :unsupported"
+    end
+  end
+end

--- a/lib/jido/chat/adapter_test_kit/factories.ex
+++ b/lib/jido/chat/adapter_test_kit/factories.ex
@@ -1,0 +1,210 @@
+defmodule Jido.Chat.AdapterTestKit.Factories do
+  @moduledoc """
+  Deterministic factories for adapter contract tests.
+
+  Each factory returns a public `Jido.Chat` type. Factories accept a map or a
+  keyword list of shallow field overrides.
+  """
+
+  alias Jido.Chat.{
+    Author,
+    EventEnvelope,
+    Incoming,
+    Media,
+    Message,
+    PostPayload,
+    Response,
+    WebhookRequest
+  }
+
+  @doc "Builds a canonical author."
+  @spec author(map() | keyword()) :: Author.t()
+  def author(overrides \\ %{}) do
+    %{
+      user_id: "user-1",
+      user_name: "test-user",
+      full_name: "Test User",
+      is_bot: false,
+      is_me: false,
+      metadata: %{"source" => "adapter-test-kit"}
+    }
+    |> merge(overrides)
+    |> Author.new()
+  end
+
+  @doc "Builds canonical media."
+  @spec media(map() | keyword()) :: Media.t()
+  def media(overrides \\ %{}) do
+    overrides = to_map(overrides)
+    kind = Map.get(overrides, :kind, Map.get(overrides, "kind", :image))
+
+    kind
+    |> media_defaults()
+    |> Map.merge(overrides)
+    |> Media.new()
+  end
+
+  @doc "Builds a canonical incoming message."
+  @spec incoming(map() | keyword()) :: Incoming.t()
+  def incoming(overrides \\ %{}) do
+    %{
+      external_room_id: "room-1",
+      external_user_id: "user-1",
+      external_message_id: "external-message-1",
+      external_thread_id: "provider-thread-1",
+      text: "Hello from the test kit",
+      author: author(),
+      username: "test-user",
+      display_name: "Test User",
+      timestamp: "2026-01-02T03:04:05Z",
+      chat_type: :channel,
+      was_mentioned: false,
+      media: [media()],
+      raw: %{"provider" => "fixture"},
+      metadata: %{"source" => "adapter-test-kit"}
+    }
+    |> merge(overrides)
+    |> Incoming.new()
+  end
+
+  @doc "Builds a canonical normalized message."
+  @spec message(map() | keyword()) :: Message.t()
+  def message(overrides \\ %{}) do
+    %{
+      id: "message-1",
+      thread_id: "test:room-1:provider-thread-1",
+      channel_id: "room-1",
+      text: "Hello from the test kit",
+      formatted: "Hello from the test kit",
+      author: author(),
+      attachments: [media()],
+      created_at: "2026-01-02T03:04:05Z",
+      external_message_id: "external-message-1",
+      external_room_id: "room-1",
+      metadata: %{"source" => "adapter-test-kit"},
+      raw: %{"provider" => "fixture"}
+    }
+    |> merge(overrides)
+    |> Message.new()
+  end
+
+  @doc "Builds a canonical message event envelope."
+  @spec event(map() | keyword()) :: EventEnvelope.t()
+  def event(overrides \\ %{}) do
+    %{
+      id: "event-1",
+      adapter_name: :test,
+      event_type: :message,
+      thread_id: "test:room-1:provider-thread-1",
+      channel_id: "room-1",
+      message_id: "external-message-1",
+      payload: incoming(),
+      raw: %{"provider" => "fixture"},
+      metadata: %{"source" => "adapter-test-kit"}
+    }
+    |> merge(overrides)
+    |> EventEnvelope.new()
+  end
+
+  @doc "Builds a canonical webhook request."
+  @spec webhook_request(map() | keyword()) :: WebhookRequest.t()
+  def webhook_request(overrides \\ %{}) do
+    %{
+      adapter_name: :test,
+      method: "POST",
+      path: "/webhooks/test",
+      headers: %{"content-type" => "application/json", "x-test-signature" => "valid"},
+      payload: %{
+        "external_room_id" => "room-1",
+        "external_user_id" => "user-1",
+        "external_message_id" => "external-message-1",
+        "external_thread_id" => "provider-thread-1",
+        "text" => "Hello from the test kit"
+      },
+      metadata: %{"source" => "adapter-test-kit"}
+    }
+    |> merge(overrides)
+    |> WebhookRequest.new()
+  end
+
+  @doc "Builds a canonical adapter response."
+  @spec response(map() | keyword()) :: Response.t()
+  def response(overrides \\ %{}) do
+    %{
+      external_message_id: "external-message-1",
+      external_room_id: "room-1",
+      timestamp: "2026-01-02T03:04:05Z",
+      channel_type: :test,
+      status: :sent,
+      raw: %{"provider" => "fixture"},
+      metadata: %{"source" => "adapter-test-kit"}
+    }
+    |> merge(overrides)
+    |> Response.new()
+  end
+
+  @doc "Builds a canonical outbound post payload."
+  @spec post_payload(map() | keyword()) :: PostPayload.t()
+  def post_payload(overrides \\ %{}) do
+    %{
+      text: "Hello from the test kit",
+      metadata: %{"source" => "adapter-test-kit"}
+    }
+    |> merge(overrides)
+    |> PostPayload.new()
+  end
+
+  defp media_defaults(kind) when kind in [:image, "image"] do
+    %{
+      kind: :image,
+      url: "https://example.test/sample.png",
+      media_type: "image/png",
+      filename: "sample.png",
+      size_bytes: 128,
+      width: 16,
+      height: 16,
+      metadata: %{"source" => "adapter-test-kit"}
+    }
+  end
+
+  defp media_defaults(kind) when kind in [:audio, "audio"] do
+    %{
+      kind: :audio,
+      url: "https://example.test/sample.mp3",
+      media_type: "audio/mpeg",
+      filename: "sample.mp3",
+      size_bytes: 128,
+      duration: 1,
+      metadata: %{"source" => "adapter-test-kit"}
+    }
+  end
+
+  defp media_defaults(kind) when kind in [:video, "video"] do
+    %{
+      kind: :video,
+      url: "https://example.test/sample.mp4",
+      media_type: "video/mp4",
+      filename: "sample.mp4",
+      size_bytes: 128,
+      width: 16,
+      height: 16,
+      duration: 1,
+      metadata: %{"source" => "adapter-test-kit"}
+    }
+  end
+
+  defp media_defaults(_kind) do
+    %{
+      kind: :file,
+      url: "https://example.test/sample.txt",
+      media_type: "text/plain",
+      filename: "sample.txt",
+      size_bytes: 128,
+      metadata: %{"source" => "adapter-test-kit"}
+    }
+  end
+
+  defp merge(defaults, overrides), do: Map.merge(defaults, to_map(overrides))
+  defp to_map(overrides) when is_map(overrides), do: overrides
+  defp to_map(overrides) when is_list(overrides), do: Map.new(overrides)
+end

--- a/lib/jido/chat/adapter_test_kit/mock_adapter.ex
+++ b/lib/jido/chat/adapter_test_kit/mock_adapter.ex
@@ -1,0 +1,232 @@
+defmodule Jido.Chat.AdapterTestKit.MockAdapter do
+  @moduledoc """
+  A deterministic adapter for contract and adapter-extension tests.
+
+  Pass a `Jido.Chat.AdapterTestKit.MockTransport` process as `:transport` in
+  operation options to record calls or supply queued provider responses.
+  """
+
+  use Jido.Chat.Adapter
+
+  alias Jido.Chat.{AdapterTestKit.Factories, Incoming, PostPayload}
+  alias Jido.Chat.AdapterTestKit.MockTransport
+
+  @impl true
+  def channel_type, do: :test
+
+  @impl true
+  def transform_incoming(payload) do
+    {:ok,
+     Incoming.new(%{
+       external_room_id: value(payload, :external_room_id, "room-1"),
+       external_user_id: value(payload, :external_user_id, "user-1"),
+       external_message_id: value(payload, :external_message_id, "external-message-1"),
+       external_thread_id: value(payload, :external_thread_id, "provider-thread-1"),
+       text: value(payload, :text, "Hello from the test kit"),
+       username: value(payload, :username, "test-user"),
+       display_name: value(payload, :display_name, "Test User"),
+       media: value(payload, :media, []),
+       raw: payload
+     })}
+  end
+
+  @impl true
+  def send_message(room_id, text, opts) do
+    dispatch(:send_message, %{room_id: room_id, text: text, opts: public_opts(opts)}, opts, fn ->
+      {:ok, response_map(room_id, "mock-message-1", %{text: text})}
+    end)
+  end
+
+  @impl true
+  def send_file(room_id, file, opts) do
+    dispatch(:send_file, %{room_id: room_id, file: file, opts: public_opts(opts)}, opts, fn ->
+      {:ok, response_map(room_id, "mock-file-1")}
+    end)
+  end
+
+  @impl true
+  def post_message(room_id, %PostPayload{} = payload, opts) do
+    dispatch(:post_message, %{room_id: room_id, payload: payload, opts: public_opts(opts)}, opts, fn ->
+      {:ok, response_map(room_id, "mock-post-1")}
+    end)
+  end
+
+  @impl true
+  def edit_message(room_id, message_id, text, opts) do
+    dispatch(
+      :edit_message,
+      %{room_id: room_id, message_id: message_id, text: text, opts: public_opts(opts)},
+      opts,
+      fn -> {:ok, response_map(room_id, message_id, %{text: text})} end
+    )
+  end
+
+  @impl true
+  def delete_message(room_id, message_id, opts) do
+    dispatch(
+      :delete_message,
+      %{room_id: room_id, message_id: message_id, opts: public_opts(opts)},
+      opts,
+      fn -> :ok end
+    )
+  end
+
+  @impl true
+  def start_typing(room_id, opts) do
+    dispatch(:start_typing, %{room_id: room_id, opts: public_opts(opts)}, opts, fn -> :ok end)
+  end
+
+  @impl true
+  def fetch_message(room_id, message_id, opts) do
+    dispatch(
+      :fetch_message,
+      %{room_id: room_id, message_id: message_id, opts: public_opts(opts)},
+      opts,
+      fn ->
+        {:ok,
+         message_for_room(room_id, %{
+           id: to_string(message_id),
+           external_message_id: to_string(message_id)
+         })}
+      end
+    )
+  end
+
+  @impl true
+  def fetch_media(reference, opts) do
+    dispatch(:fetch_media, %{reference: reference, opts: public_opts(opts)}, opts, fn ->
+      {:ok, "mock-media-bytes"}
+    end)
+  end
+
+  @impl true
+  def add_reaction(room_id, message_id, emoji, opts) do
+    dispatch(
+      :add_reaction,
+      %{room_id: room_id, message_id: message_id, emoji: emoji, opts: public_opts(opts)},
+      opts,
+      fn -> :ok end
+    )
+  end
+
+  @impl true
+  def remove_reaction(room_id, message_id, emoji, opts) do
+    dispatch(
+      :remove_reaction,
+      %{room_id: room_id, message_id: message_id, emoji: emoji, opts: public_opts(opts)},
+      opts,
+      fn -> :ok end
+    )
+  end
+
+  @impl true
+  def fetch_messages(room_id, opts), do: message_page(:fetch_messages, room_id, opts)
+
+  @impl true
+  def fetch_channel_messages(room_id, opts),
+    do: message_page(:fetch_channel_messages, room_id, opts)
+
+  @impl true
+  def list_threads(room_id, opts) do
+    dispatch(:list_threads, %{room_id: room_id, opts: public_opts(opts)}, opts, fn ->
+      {:ok,
+       %{
+         threads: [
+           %{
+             id: "test:#{room_id}:provider-thread-1",
+             root_message: message_for_room(room_id)
+           }
+         ],
+         next_cursor: nil
+       }}
+    end)
+  end
+
+  @impl true
+  def open_thread(room_id, message_id, opts) do
+    dispatch(
+      :open_thread,
+      %{room_id: room_id, message_id: message_id, opts: public_opts(opts)},
+      opts,
+      fn ->
+        {:ok,
+         %{
+           id: "test:#{room_id}:#{message_id}",
+           adapter_name: :test,
+           adapter: __MODULE__,
+           external_room_id: room_id,
+           external_thread_id: to_string(message_id)
+         }}
+      end
+    )
+  end
+
+  @impl true
+  def capabilities do
+    %{
+      send_message: :native,
+      send_file: :native,
+      post_message: :native,
+      edit_message: :native,
+      delete_message: :native,
+      start_typing: :native,
+      fetch_message: :native,
+      fetch_media: :native,
+      add_reaction: :native,
+      remove_reaction: :native,
+      fetch_messages: :native,
+      fetch_channel_messages: :native,
+      list_threads: :native,
+      open_thread: :native,
+      verify_webhook: :fallback,
+      parse_event: :fallback,
+      format_webhook_response: :fallback
+    }
+  end
+
+  defp message_page(operation, room_id, opts) do
+    dispatch(operation, %{room_id: room_id, opts: public_opts(opts)}, opts, fn ->
+      {:ok,
+       %{
+         messages: [message_for_room(room_id)],
+         next_cursor: nil,
+         direction: :backward
+       }}
+    end)
+  end
+
+  defp response_map(room_id, message_id, metadata \\ %{}) do
+    %{
+      external_room_id: room_id,
+      external_message_id: message_id,
+      channel_type: :test,
+      metadata: metadata
+    }
+  end
+
+  defp message_for_room(room_id, overrides \\ %{}) do
+    Factories.message(
+      Map.merge(
+        %{
+          external_room_id: room_id,
+          channel_id: to_string(room_id),
+          thread_id: "test:#{room_id}:provider-thread-1"
+        },
+        overrides
+      )
+    )
+  end
+
+  defp dispatch(operation, payload, opts, default_fun) do
+    case Keyword.get(opts, :transport) do
+      nil -> default_fun.()
+      transport -> MockTransport.request(transport, operation, payload, default_fun)
+    end
+  end
+
+  defp public_opts(opts), do: Keyword.delete(opts, :transport)
+
+  defp value(map, key, default) do
+    Map.get(map, key, Map.get(map, Atom.to_string(key), default))
+  end
+end

--- a/lib/jido/chat/adapter_test_kit/mock_state.ex
+++ b/lib/jido/chat/adapter_test_kit/mock_state.ex
@@ -1,0 +1,59 @@
+defmodule Jido.Chat.AdapterTestKit.MockState do
+  @moduledoc """
+  A small deterministic state process for adapter tests.
+
+  Each process keeps its initial snapshot so a test can reset it without global
+  application state.
+  """
+
+  use GenServer
+
+  @type server :: GenServer.server()
+
+  @doc "Starts a mock state process."
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    initial = Keyword.get(opts, :initial, %{})
+    GenServer.start_link(__MODULE__, initial, Keyword.take(opts, [:name]))
+  end
+
+  @doc "Gets one key from the current state."
+  @spec get(server(), term(), term()) :: term()
+  def get(server, key, default \\ nil), do: GenServer.call(server, {:get, key, default})
+
+  @doc "Puts one key in the current state."
+  @spec put(server(), term(), term()) :: :ok
+  def put(server, key, value), do: GenServer.call(server, {:put, key, value})
+
+  @doc "Updates the current state and returns the new snapshot."
+  @spec update(server(), (map() -> map())) :: map()
+  def update(server, fun) when is_function(fun, 1), do: GenServer.call(server, {:update, fun})
+
+  @doc "Returns the current state snapshot."
+  @spec snapshot(server()) :: map()
+  def snapshot(server), do: GenServer.call(server, :snapshot)
+
+  @doc "Restores the initial state snapshot."
+  @spec reset(server()) :: :ok
+  def reset(server), do: GenServer.call(server, :reset)
+
+  @impl true
+  def init(initial) when is_map(initial), do: {:ok, %{initial: initial, current: initial}}
+
+  @impl true
+  def handle_call({:get, key, default}, _from, state) do
+    {:reply, Map.get(state.current, key, default), state}
+  end
+
+  def handle_call({:put, key, value}, _from, state) do
+    {:reply, :ok, %{state | current: Map.put(state.current, key, value)}}
+  end
+
+  def handle_call({:update, fun}, _from, state) do
+    current = fun.(state.current)
+    {:reply, current, %{state | current: current}}
+  end
+
+  def handle_call(:snapshot, _from, state), do: {:reply, state.current, state}
+  def handle_call(:reset, _from, state), do: {:reply, :ok, %{state | current: state.initial}}
+end

--- a/lib/jido/chat/adapter_test_kit/mock_transport.ex
+++ b/lib/jido/chat/adapter_test_kit/mock_transport.ex
@@ -1,0 +1,89 @@
+defmodule Jido.Chat.AdapterTestKit.MockTransport do
+  @moduledoc """
+  A deterministic provider-free transport for adapter tests.
+
+  The transport records calls in order. A response queue can be set for each
+  operation. When a queue is empty, `request/4` returns its supplied default.
+  """
+
+  use GenServer
+
+  @type operation :: atom()
+  @type call :: %{operation: operation(), payload: term(), sequence: pos_integer()}
+  @type server :: GenServer.server()
+
+  @doc "Starts a mock transport."
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    responses = opts |> Keyword.get(:responses, %{}) |> normalize_responses()
+    GenServer.start_link(__MODULE__, responses, Keyword.take(opts, [:name]))
+  end
+
+  @doc "Records a request and returns the next queued response or the default."
+  @spec request(server(), operation(), term(), term()) :: term()
+  def request(server, operation, payload, default \\ {:error, :unstubbed}) do
+    GenServer.call(server, {:request, operation, payload, default})
+  end
+
+  @doc "Replaces the response queue for an operation."
+  @spec stub(server(), operation(), term() | [term()]) :: :ok
+  def stub(server, operation, responses) do
+    GenServer.call(server, {:stub, operation, List.wrap(responses)})
+  end
+
+  @doc "Returns all calls, or only calls for one operation."
+  @spec calls(server(), operation() | nil) :: [call()]
+  def calls(server, operation \\ nil), do: GenServer.call(server, {:calls, operation})
+
+  @doc "Clears recorded calls and queued responses."
+  @spec reset(server()) :: :ok
+  def reset(server), do: GenServer.call(server, :reset)
+
+  @impl true
+  def init(responses), do: {:ok, %{calls: [], responses: responses, sequence: 0}}
+
+  @impl true
+  def handle_call({:request, operation, payload, default}, _from, state) do
+    sequence = state.sequence + 1
+    call = %{operation: operation, payload: payload, sequence: sequence}
+    {response, responses} = pop_response(state.responses, operation, default, payload)
+
+    {:reply, response, %{state | calls: [call | state.calls], responses: responses, sequence: sequence}}
+  end
+
+  def handle_call({:stub, operation, responses}, _from, state) do
+    {:reply, :ok, %{state | responses: Map.put(state.responses, operation, responses)}}
+  end
+
+  def handle_call({:calls, operation}, _from, state) do
+    calls =
+      if is_nil(operation) do
+        Enum.reverse(state.calls)
+      else
+        state.calls
+        |> Enum.filter(&(&1.operation == operation))
+        |> Enum.reverse()
+      end
+
+    {:reply, calls, state}
+  end
+
+  def handle_call(:reset, _from, _state) do
+    {:reply, :ok, %{calls: [], responses: %{}, sequence: 0}}
+  end
+
+  defp pop_response(responses, operation, default, payload) do
+    case Map.get(responses, operation, []) do
+      [response | rest] -> {resolve(response, payload), Map.put(responses, operation, rest)}
+      [] -> {resolve(default, payload), responses}
+    end
+  end
+
+  defp resolve(fun, payload) when is_function(fun, 1), do: fun.(payload)
+  defp resolve(fun, _payload) when is_function(fun, 0), do: fun.()
+  defp resolve(response, _payload), do: response
+
+  defp normalize_responses(responses) do
+    Map.new(responses, fn {operation, values} -> {operation, List.wrap(values)} end)
+  end
+end

--- a/lib/jido/chat/capabilities.ex
+++ b/lib/jido/chat/capabilities.ex
@@ -162,17 +162,19 @@ defmodule Jido.Chat.Capabilities do
   end
 
   defp normalize_adapter_capabilities(capabilities) when is_map(capabilities) do
+    native_post_message? = capabilities[:post_message] == :native
+
     media_supported? =
       supported_status?(capabilities[:image]) or
         supported_status?(capabilities[:audio]) or
         supported_status?(capabilities[:video]) or
         supported_status?(capabilities[:file]) or
         supported_status?(capabilities[:send_file]) or
-        supported_status?(capabilities[:post_message])
+        native_post_message?
 
     multi_file_supported? =
       supported_status?(capabilities[:multi_file]) or
-        supported_status?(capabilities[:post_message])
+        native_post_message?
 
     [:text]
     |> maybe_add_capability(:image, media_supported?)

--- a/lib/jido/chat/event_envelope.ex
+++ b/lib/jido/chat/event_envelope.ex
@@ -66,6 +66,7 @@ defmodule Jido.Chat.EventEnvelope do
   def new(attrs) when is_map(attrs) do
     attrs
     |> Map.put_new(:id, Jido.Chat.ID.generate!())
+    |> maybe_normalize_adapter_name()
     |> maybe_normalize_event_type()
     |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
   end
@@ -98,9 +99,28 @@ defmodule Jido.Chat.EventEnvelope do
         attrs
 
       event_type when is_binary(event_type) ->
-        Map.put(attrs, :event_type, event_type |> String.trim() |> String.to_existing_atom())
+        attrs
+        |> Map.delete("event_type")
+        |> Map.put(:event_type, event_type |> String.trim() |> String.to_existing_atom())
 
       _ ->
+        attrs
+    end
+  rescue
+    ArgumentError -> attrs
+  end
+
+  defp maybe_normalize_adapter_name(attrs) do
+    case attrs[:adapter_name] || attrs["adapter_name"] do
+      adapter_name when is_atom(adapter_name) ->
+        attrs
+
+      adapter_name when is_binary(adapter_name) ->
+        attrs
+        |> Map.delete("adapter_name")
+        |> Map.put(:adapter_name, adapter_name |> String.trim() |> String.to_existing_atom())
+
+      _other ->
         attrs
     end
   rescue

--- a/lib/jido/chat/incoming.ex
+++ b/lib/jido/chat/incoming.ex
@@ -42,10 +42,12 @@ defmodule Jido.Chat.Incoming do
   def schema, do: @schema
 
   @doc "Creates a normalized incoming payload."
+  @spec new(map()) :: t()
   def new(attrs) when is_map(attrs) do
     attrs
     |> maybe_attach_author()
     |> maybe_normalize_reply_context()
+    |> maybe_normalize_chat_type()
     |> maybe_normalize_mentions()
     |> maybe_normalize_media()
     |> maybe_normalize_channel_meta()
@@ -84,10 +86,17 @@ defmodule Jido.Chat.Incoming do
   defp maybe_attach_author(%{author: author} = attrs) when is_map(author),
     do: Map.put(attrs, :author, Author.new(author))
 
-  defp maybe_attach_author(%{"author" => %Author{}} = attrs), do: attrs
+  defp maybe_attach_author(%{"author" => %Author{} = author} = attrs) do
+    attrs
+    |> Map.delete("author")
+    |> Map.put(:author, author)
+  end
 
-  defp maybe_attach_author(%{"author" => author} = attrs) when is_map(author),
-    do: attrs |> Map.delete("author") |> Map.put(:author, Author.new(author))
+  defp maybe_attach_author(%{"author" => author} = attrs) when is_map(author) do
+    attrs
+    |> Map.delete("author")
+    |> Map.put(:author, Author.new(author))
+  end
 
   defp maybe_attach_author(attrs) do
     user_id = attrs[:external_user_id] || attrs["external_user_id"]
@@ -142,6 +151,23 @@ defmodule Jido.Chat.Incoming do
       _other ->
         attrs
     end
+  end
+
+  defp maybe_normalize_chat_type(attrs) do
+    case attrs[:chat_type] || attrs["chat_type"] do
+      chat_type when is_atom(chat_type) ->
+        attrs
+
+      chat_type when is_binary(chat_type) ->
+        attrs
+        |> Map.delete("chat_type")
+        |> Map.put(:chat_type, chat_type |> String.trim() |> String.to_existing_atom())
+
+      _other ->
+        attrs
+    end
+  rescue
+    ArgumentError -> attrs
   end
 
   defp normalize_mention(%Mention{} = mention), do: mention

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Jido.Chat.MixProject do
       dialyzer: [
         plt_local_path: "priv/plts/project.plt",
         plt_core_path: "priv/plts/core.plt",
-        plt_add_apps: [:mix]
+        plt_add_apps: [:mix, :ex_unit]
       ]
     ]
   end
@@ -88,7 +88,15 @@ defmodule Jido.Chat.MixProject do
 
   defp package do
     [
-      files: ["lib", "mix.exs", "README.md", "LICENSE", "CHANGELOG.md", "usage-rules.md"],
+      files: [
+        "lib",
+        "guides",
+        "mix.exs",
+        "README.md",
+        "LICENSE",
+        "CHANGELOG.md",
+        "usage-rules.md"
+      ],
       maintainers: ["Mike Hostetler"],
       licenses: ["Apache-2.0"],
       links: %{
@@ -108,7 +116,8 @@ defmodule Jido.Chat.MixProject do
       extras: [
         "README.md",
         "CHANGELOG.md",
-        "CONTRIBUTING.md"
+        "CONTRIBUTING.md",
+        "guides/adapter_test_kit.md"
       ]
     ]
   end

--- a/test/jido/chat/adapter_conformance_test.exs
+++ b/test/jido/chat/adapter_conformance_test.exs
@@ -70,6 +70,42 @@ defmodule Jido.Chat.AdapterConformanceTest do
     end
   end
 
+  defmodule InvalidCapabilityStatusAdapter do
+    use Adapter
+
+    @impl true
+    def channel_type, do: :invalid_capability_status
+
+    @impl true
+    def transform_incoming(payload), do: {:ok, Incoming.new(payload)}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok, Response.new(%{external_message_id: "m1", external_room_id: room_id})}
+    end
+
+    @impl true
+    def capabilities, do: %{send_message: :sometimes}
+  end
+
+  defmodule InvalidCapabilityMapAdapter do
+    use Adapter
+
+    @impl true
+    def channel_type, do: :invalid_capability_map
+
+    @impl true
+    def transform_incoming(payload), do: {:ok, Incoming.new(payload)}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok, Response.new(%{external_message_id: "m1", external_room_id: room_id})}
+    end
+
+    @impl true
+    def capabilities, do: [:send_message]
+  end
+
   defmodule FallbackAdapter do
     use Adapter
 
@@ -188,6 +224,28 @@ defmodule Jido.Chat.AdapterConformanceTest do
     end
   end
 
+  defmodule MalformedMediaAdapter do
+    use Adapter
+
+    @impl true
+    def channel_type, do: :malformed_media
+
+    @impl true
+    def transform_incoming(payload), do: {:ok, Incoming.new(payload)}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok, Response.new(%{external_message_id: "m1", external_room_id: room_id})}
+    end
+
+    @impl true
+    def fetch_media(:wrapped, _opts), do: {:ok, %{bytes: "not-binary"}}
+    def fetch_media(:invalid, _opts), do: :invalid
+
+    @impl true
+    def capabilities, do: %{send_message: :native, fetch_media: :native}
+  end
+
   test "capability matrix struct normalizes statuses" do
     matrix = Adapter.capability_matrix(GoodAdapter)
 
@@ -205,13 +263,29 @@ defmodule Jido.Chat.AdapterConformanceTest do
     assert {:edit_message, :missing_callback} in mismatches
   end
 
+  test "capability validation rejects an invalid raw status before normalization" do
+    assert {:error, {:invalid_capability_matrix, [send_message: :invalid_status]}} =
+             Adapter.validate_capabilities(InvalidCapabilityStatusAdapter)
+  end
+
+  test "capability validation rejects a raw declaration that is not a map" do
+    assert {:error, {:invalid_capability_matrix, [capabilities: :invalid_map]}} =
+             Adapter.validate_capabilities(InvalidCapabilityMapAdapter)
+  end
+
   test "fetch_media is optional and surfaces through the capability matrix" do
     assert Adapter.capability_matrix(MediaAdapter).capabilities.fetch_media == :native
     assert Adapter.capability_matrix(GoodAdapter).capabilities.fetch_media == :unsupported
 
     assert :ok = Adapter.validate_capabilities(MediaAdapter)
-    assert {:ok, "bytes-42"} = MediaAdapter.fetch_media("media://42", [])
-    assert {:error, :invalid_reference} = MediaAdapter.fetch_media("nope", [])
+    assert {:ok, "bytes-42"} = Adapter.fetch_media(MediaAdapter, "media://42", [])
+    assert {:error, :invalid_reference} = Adapter.fetch_media(MediaAdapter, "nope", [])
+    assert {:error, :unsupported} = Adapter.fetch_media(GoodAdapter, "media://42", [])
+  end
+
+  test "fetch_media rejects malformed provider results" do
+    assert {:error, :invalid_media_result} = Adapter.fetch_media(MalformedMediaAdapter, :wrapped, [])
+    assert {:error, :invalid_media_result} = Adapter.fetch_media(MalformedMediaAdapter, :invalid, [])
   end
 
   test "unsupported callbacks return deterministic unsupported error" do

--- a/test/jido/chat/adapter_test_kit_test.exs
+++ b/test/jido/chat/adapter_test_kit_test.exs
@@ -1,0 +1,501 @@
+defmodule Jido.Chat.AdapterTestKitTest do
+  use ExUnit.Case, async: true
+
+  import Jido.Chat.AdapterTestKit.Assertions
+
+  alias Jido.Chat.{Adapter, EventEnvelope, Incoming, Media, Message, Response, WebhookRequest}
+
+  alias Jido.Chat.AdapterTestKit.{
+    Factories,
+    MockAdapter,
+    MockState,
+    MockTransport
+  }
+
+  defmodule MissingCallbackAdapter do
+    use Adapter
+
+    @impl true
+    def transform_incoming(payload), do: {:ok, payload}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok, %{external_message_id: "message-1", external_room_id: room_id}}
+    end
+
+    @impl true
+    def capabilities, do: %{send_message: :native, edit_message: :native}
+  end
+
+  defmodule MissingCoreCallbackAdapter do
+    use Adapter
+
+    @impl true
+    def transform_incoming(payload), do: {:ok, payload}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok, %{external_message_id: "message-1", external_room_id: room_id}}
+    end
+
+    @impl true
+    def capabilities, do: %{send_message: :native, post_message: :native}
+  end
+
+  defmodule UnsupportedCallbackAdapter do
+    use Adapter
+
+    @impl true
+    def transform_incoming(payload), do: {:ok, payload}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok, %{external_message_id: "message-1", external_room_id: room_id}}
+    end
+
+    @impl true
+    def edit_message(room_id, message_id, _text, _opts) do
+      send(self(), :unsupported_edit_message_called)
+      {:ok, %{external_message_id: message_id, external_room_id: room_id}}
+    end
+
+    @impl true
+    def capabilities, do: %{send_message: :native, edit_message: :unsupported}
+  end
+
+  defmodule UnsupportedSendMessageAdapter do
+    use Adapter
+
+    @impl true
+    def transform_incoming(payload), do: {:ok, payload}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      send(self(), :unsupported_send_message_called)
+      {:ok, %{external_message_id: "message-1", external_room_id: room_id}}
+    end
+
+    @impl true
+    def capabilities, do: %{send_message: :unsupported}
+  end
+
+  defmodule InvalidStatusAdapter do
+    use Adapter
+
+    @impl true
+    def transform_incoming(payload), do: {:ok, payload}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok, %{external_message_id: "message-1", external_room_id: room_id}}
+    end
+
+    @impl true
+    def capabilities, do: %{send_message: :sometimes}
+  end
+
+  defmodule MissingIncomingAdapter do
+    def channel_type, do: :missing_incoming
+
+    def send_message(room_id, _text, _opts) do
+      {:ok, %{external_message_id: "message-1", external_room_id: room_id}}
+    end
+
+    def capabilities, do: %{send_message: :native}
+  end
+
+  defmodule FalseFallbackAdapter do
+    use Adapter
+
+    @impl true
+    def transform_incoming(payload), do: {:ok, payload}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok, %{external_message_id: "message-1", external_room_id: room_id}}
+    end
+
+    @impl true
+    def capabilities, do: %{send_message: :native, edit_message: :fallback}
+  end
+
+  defmodule MinimalAdapter do
+    use Adapter
+
+    @impl true
+    def transform_incoming(payload), do: {:ok, payload}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok, %{external_message_id: "message-1", external_room_id: room_id}}
+    end
+  end
+
+  defmodule ContradictoryCoreFallbackAdapter do
+    use Adapter
+
+    @impl true
+    def transform_incoming(payload), do: {:ok, payload}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok, %{external_message_id: "message-1", external_room_id: room_id}}
+    end
+
+    @impl true
+    def capabilities do
+      %{
+        send_message: :native,
+        initialize: :unsupported,
+        shutdown: :unsupported,
+        post_message: :unsupported,
+        fetch_metadata: :unsupported,
+        fetch_thread: :unsupported,
+        post_channel_message: :unsupported,
+        stream: :unsupported,
+        webhook: :unsupported,
+        verify_webhook: :unsupported,
+        parse_event: :unsupported,
+        format_webhook_response: :unsupported
+      }
+    end
+  end
+
+  describe "canonical factories" do
+    test "build deterministic typed adapter values and accept overrides" do
+      assert Factories.author() == Factories.author()
+      assert Factories.message() == Factories.message()
+      assert Factories.event() == Factories.event()
+
+      assert %{user_name: "override"} = Factories.author(user_name: "override")
+      assert %Media{kind: :video, filename: "sample.mp4"} = Factories.media(kind: :video)
+
+      assert %Incoming{external_message_id: "external-message-1"} = Factories.incoming()
+
+      assert %Message{id: "message-1", external_message_id: "external-message-1"} =
+               Factories.message()
+
+      assert %EventEnvelope{event_type: :message, payload: %Incoming{}} = Factories.event()
+
+      assert %WebhookRequest{payload: %{"text" => "Hello from the test kit"}} =
+               Factories.webhook_request()
+
+      assert %Response{external_message_id: "external-message-1"} = Factories.response()
+    end
+  end
+
+  describe "shared assertions" do
+    test "checks capability coherence and reports a missing native callback" do
+      assert_capability_coherence(MockAdapter)
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_capability_coherence(MissingCallbackAdapter)
+        end
+
+      assert Exception.message(error) =~ "edit_message"
+      assert Exception.message(error) =~ "missing_callback"
+    end
+
+    test "does not hide a missing native callback behind a core fallback" do
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_capability_coherence(MissingCoreCallbackAdapter)
+        end
+
+      assert Exception.message(error) =~ "post_message"
+      assert Exception.message(error) =~ "missing_callback"
+    end
+
+    test "rejects invalid raw statuses before capability normalization" do
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_capability_coherence(InvalidStatusAdapter)
+        end
+
+      assert Exception.message(error) =~ "raw capability statuses"
+    end
+
+    test "requires the inbound transform callback" do
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_capability_coherence(MissingIncomingAdapter)
+        end
+
+      assert Exception.message(error) =~ "transform_incoming/1"
+    end
+
+    test "rejects fallback declarations without a callback or core fallback" do
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_capability_coherence(FalseFallbackAdapter)
+        end
+
+      assert Exception.message(error) =~ "edit_message"
+      assert Exception.message(error) =~ "missing_fallback"
+    end
+
+    test "missing optional callbacks return exact unsupported results through public wrappers" do
+      refute Jido.Chat.AdapterTestKit.supported?(MinimalAdapter, :fetch_message)
+
+      unsupported_results = [
+        Adapter.send_file(MinimalAdapter, "room-1", "/tmp/test.txt", []),
+        Adapter.edit_message(MinimalAdapter, "room-1", "message-1", "updated", []),
+        Adapter.delete_message(MinimalAdapter, "room-1", "message-1", []),
+        Adapter.start_typing(MinimalAdapter, "room-1", []),
+        Adapter.fetch_message(MinimalAdapter, "room-1", "message-1", []),
+        Adapter.fetch_media(MinimalAdapter, "media://test", []),
+        Adapter.add_reaction(MinimalAdapter, "room-1", "message-1", "thumbs_up", []),
+        Adapter.remove_reaction(MinimalAdapter, "room-1", "message-1", "thumbs_up", []),
+        Adapter.post_ephemeral(MinimalAdapter, "room-1", "user-1", "test", []),
+        Adapter.open_modal(MinimalAdapter, "room-1", %{custom_id: "test-modal"}, []),
+        Adapter.fetch_messages(MinimalAdapter, "room-1", []),
+        Adapter.fetch_channel_messages(MinimalAdapter, "room-1", []),
+        Adapter.list_threads(MinimalAdapter, "room-1", []),
+        Adapter.open_thread(MinimalAdapter, "room-1", "message-1", [])
+      ]
+
+      assert Enum.all?(unsupported_results, &(&1 == {:error, :unsupported}))
+      assert_unsupported_operations(MinimalAdapter)
+    end
+
+    test "reports and exercises every unconditional core fallback" do
+      capabilities = Adapter.capabilities(MinimalAdapter)
+
+      Enum.each(Adapter.core_fallback_capabilities(), fn capability ->
+        assert capabilities[capability] == :fallback
+        assert Jido.Chat.AdapterTestKit.supported?(MinimalAdapter, capability)
+      end)
+
+      assert {:ok, %Response{external_room_id: "room-1"}} =
+               Adapter.post_message(MinimalAdapter, "room-1", Factories.post_payload(), [])
+
+      assert {:ok, %Jido.Chat.ChannelInfo{id: "room-1"}} =
+               Adapter.fetch_metadata(MinimalAdapter, "room-1", [])
+
+      assert {:ok, %Jido.Chat.Thread{external_room_id: "room-1"}} =
+               Adapter.fetch_thread(MinimalAdapter, "room-1", [])
+
+      assert_unsupported_operations(MinimalAdapter)
+    end
+
+    test "canonicalizes unsupported declarations for unconditional core fallbacks" do
+      capabilities = Adapter.capabilities(ContradictoryCoreFallbackAdapter)
+
+      Enum.each(Adapter.core_fallback_capabilities(), fn capability ->
+        assert capabilities[capability] == :fallback
+      end)
+
+      assert_capability_coherence(ContradictoryCoreFallbackAdapter)
+      assert_unsupported_operations(ContradictoryCoreFallbackAdapter)
+    end
+
+    test "rejects a false unsupported declaration without calling the provider" do
+      assert_unsupported_operations(MinimalAdapter)
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_unsupported_operations(UnsupportedCallbackAdapter)
+        end
+
+      assert Exception.message(error) =~ "edit_message"
+      refute_received :unsupported_edit_message_called
+    end
+
+    test "rejects an unsupported declaration for required message sending" do
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_unsupported_operations(UnsupportedSendMessageAdapter)
+        end
+
+      assert Exception.message(error) =~ "send_message"
+      refute_received :unsupported_send_message_called
+    end
+
+    test "checks normalized results, message identifiers, media, and serialization" do
+      response = Factories.response()
+      message = Factories.message()
+      media = Factories.media()
+      event = Factories.event()
+
+      assert ^response = assert_normalized_response({:ok, response})
+      assert "external-message-1" = assert_message_identifier(response)
+      assert "external-message-1" = assert_message_identifier(message)
+      assert ^media = assert_media(media, kind: :image, media_type: "image/png")
+      assert %EventEnvelope{} = assert_json_round_trip(event)
+    end
+
+    test "checks webhook normalization through the public adapter API" do
+      assert %EventEnvelope{event_type: :message, message_id: "external-message-1"} =
+               assert_webhook_event(MockAdapter, Factories.webhook_request())
+    end
+
+    test "checks capability-gated posting, file, edit, delete, reaction, media, and thread results" do
+      assert {:ok, response} = Adapter.send_message(MockAdapter, "room-1", "hello", [])
+
+      assert {:ok, %Response{}} =
+               assert_capability_result(
+                 MockAdapter,
+                 :send_file,
+                 Adapter.send_file(MockAdapter, "room-1", "/tmp/sample.txt", [])
+               )
+
+      assert {:ok, %Response{status: :edited}} =
+               assert_capability_result(
+                 MockAdapter,
+                 :edit_message,
+                 Adapter.edit_message(
+                   MockAdapter,
+                   "room-1",
+                   response.external_message_id,
+                   "updated",
+                   []
+                 )
+               )
+
+      assert :ok =
+               assert_capability_result(
+                 MockAdapter,
+                 :add_reaction,
+                 Adapter.add_reaction(
+                   MockAdapter,
+                   "room-1",
+                   response.external_message_id,
+                   "👍",
+                   []
+                 )
+               )
+
+      assert {:ok, "mock-media-bytes"} =
+               assert_capability_result(
+                 MockAdapter,
+                 :fetch_media,
+                 Adapter.fetch_media(MockAdapter, "media://sample", [])
+               )
+
+      assert {:ok, %Jido.Chat.Thread{}} =
+               assert_capability_result(
+                 MockAdapter,
+                 :open_thread,
+                 Adapter.open_thread(
+                   MockAdapter,
+                   "room-1",
+                   response.external_message_id,
+                   []
+                 )
+               )
+
+      assert :ok =
+               assert_capability_result(
+                 MockAdapter,
+                 :delete_message,
+                 Adapter.delete_message(MockAdapter, "room-1", response.external_message_id, [])
+               )
+    end
+
+    test "rejects malformed and unknown capability results" do
+      assert_raise ExUnit.AssertionError, fn ->
+        assert_capability_result(MockAdapter, :verify_webhook, :invalid)
+      end
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_capability_result(MockAdapter, :provider_extension, :ok)
+        end
+
+      assert Exception.message(error) =~ "unknown adapter capability"
+    end
+  end
+
+  describe "deterministic support" do
+    test "mock state snapshots and resets without shared global state" do
+      start_supervised!({MockState, initial: %{count: 1}, name: :state})
+
+      assert %{count: 1} = MockState.snapshot(:state)
+      assert :ok = MockState.put(:state, :count, 2)
+      assert 2 = MockState.get(:state, :count)
+      assert %{count: 3} = MockState.update(:state, &Map.update!(&1, :count, fn n -> n + 1 end))
+      assert :ok = MockState.reset(:state)
+      assert %{count: 1} = MockState.snapshot(:state)
+    end
+
+    test "mock transport records calls and consumes queued responses in order" do
+      transport =
+        start_supervised!({MockTransport, responses: %{send_message: [{:ok, %{id: "one"}}]}})
+
+      assert {:ok, %{id: "one"}} =
+               MockTransport.request(transport, :send_message, %{text: "first"}, :default)
+
+      assert :default =
+               MockTransport.request(transport, :send_message, %{text: "second"}, :default)
+
+      assert [
+               %{operation: :send_message, payload: %{text: "first"}, sequence: 1},
+               %{operation: :send_message, payload: %{text: "second"}, sequence: 2}
+             ] = MockTransport.calls(transport)
+    end
+
+    test "mock adapter records and normalizes capability-gated operations" do
+      transport = start_supervised!(MockTransport)
+      opts = [transport: transport]
+
+      assert {:ok, %Response{} = posted} =
+               Adapter.send_message(MockAdapter, "room-1", "hello", opts)
+
+      assert posted.external_message_id == "mock-message-1"
+
+      assert {:ok, %Response{status: :edited}} =
+               Adapter.edit_message(MockAdapter, "room-1", posted.external_message_id, "edit", opts)
+
+      assert :ok =
+               Adapter.add_reaction(MockAdapter, "room-1", posted.external_message_id, "👍", opts)
+
+      assert :ok = Adapter.delete_message(MockAdapter, "room-1", posted.external_message_id, opts)
+
+      assert Enum.map(MockTransport.calls(transport), & &1.operation) == [
+               :send_message,
+               :edit_message,
+               :add_reaction,
+               :delete_message
+             ]
+    end
+
+    test "mock history routes every message field to the requested room" do
+      assert {:ok, %Message{} = fetched} =
+               Adapter.fetch_message(MockAdapter, "room-9", "message-9", [])
+
+      assert fetched.external_room_id == "room-9"
+      assert fetched.channel_id == "room-9"
+      assert fetched.thread_id == "test:room-9:provider-thread-1"
+
+      assert {:ok, %{messages: [history_message]}} =
+               Adapter.fetch_messages(MockAdapter, "room-9", [])
+
+      assert history_message.external_room_id == "room-9"
+      assert history_message.channel_id == "room-9"
+      assert history_message.thread_id == "test:room-9:provider-thread-1"
+
+      assert {:ok, %{threads: [%{root_message: root_message}]}} =
+               Adapter.list_threads(MockAdapter, "room-9", [])
+
+      assert root_message.external_room_id == "room-9"
+      assert root_message.channel_id == "room-9"
+      assert root_message.thread_id == "test:room-9:provider-thread-1"
+    end
+  end
+end
+
+defmodule Jido.Chat.AdapterTestKitGeneratedConformanceTest do
+  use Jido.Chat.AdapterTestKit, adapter: Jido.Chat.AdapterTestKit.MockAdapter, async: true
+
+  capability_test :edit_message, "provider extension runs only for a supported capability" do
+    assert {:ok, %Jido.Chat.Response{status: :edited}} =
+             Jido.Chat.Adapter.edit_message(
+               @adapter,
+               "room-1",
+               "external-message-1",
+               "updated",
+               []
+             )
+  end
+end


### PR DESCRIPTION
## Summary

This pull request adds the core, provider-independent adapter conformance kit for the cross-repository adapter quality program. Adapter packages can now test capability declarations, normalized data, serialization, stable unsupported results, and transport behavior without provider credentials or SDK dependencies.

## What changed

- Add public ExUnit factories, assertions, mock state, mock transport, and mock adapter helpers.
- Add strict capability declaration validation, including raw status and callback coherence checks.
- Add the public `fetch_media/3` adapter wrapper and capability contract.
- Normalize incoming chat types and event-envelope inputs for portable fixtures.
- Add the adapter test-kit guide and README entry.
- Add full core tests for supported results, unsupported wrappers, fallbacks, malformed provider results, serialization, and mock behavior.

This is the core contribution for the multi-repository issue. The GitHub and Telegram adapter pull requests adopt this kit after a core release is available.

## Related

Related: agentjido/jido_chat#35

- GitHub adapter adopter: agentjido/jido_chat_github#11
- Telegram adapter adopter: agentjido/jido_chat_telegram#37

## Validation

- `mix test` — 156 passed
- `mix quality` — Credo clean, Dialyzer 0 errors, Doctor 0 failed modules
- `git diff --check`
- Completed structured code review; all three validated findings were fixed

## Post-Deploy Monitoring & Validation

No production monitoring is required because this change adds development and test APIs. After the core release, run the adopter repositories against the released package and check Hex documentation and package builds. Adapter compile failures or capability-contract mismatches are failure signals. If they occur, hold the adopter merge or core release update until the contract is corrected. The maintainer owns this check during the first release CI run.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
