### PR TITLE
feat(events): add message lifecycle events

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ See the [Adapter Test Kit](guides/adapter_test_kit.md) guide for the reusable
 conformance case, deterministic factories and mocks, and provider-extension
 tests.
 
+### Message lifecycle events
+
+Adapter `parse_event/2` implementations must map provider edit and delete
+deliveries to `:message_updated` and `:message_deleted` envelopes. Their typed
+payloads are `Jido.Chat.MessageUpdatedEvent` and
+`Jido.Chat.MessageDeletedEvent`. Each payload must include the provider
+`message_id`. It should also include adapter, channel, thread, author,
+timestamp, metadata, and raw provider context when these values are available.
+
+An update should put the new content in `message`. A delete uses `message: nil`
+when the provider does not send the deleted content. Core does not fetch or
+recover that content. Lifecycle handlers use `on_message_updated/2` and
+`on_message_deleted/2`. They are separate from `on_new_message/3`, so provider
+edit deliveries, including bot streaming edits, do not start a new-message
+handler loop.
+
+Core normalizes and routes each lifecycle delivery. Duplicate-delivery policy,
+persisted-message lookup, and the result for an unknown persisted message ID
+belong to the consuming runtime or persistence layer.
+
 ## Usage (Core Loop)
 
 ```elixir

--- a/lib/jido/chat/adapter.ex
+++ b/lib/jido/chat/adapter.ex
@@ -3,6 +3,14 @@ defmodule Jido.Chat.Adapter do
   Canonical adapter behavior for Chat SDK style integrations.
 
   Thread-aware channel contract for Chat SDK integrations.
+
+  Adapters return message edits and deletes from `c:parse_event/2` as
+  `Jido.Chat.EventEnvelope` values with event type `:message_updated` or
+  `:message_deleted`. The payload must include the provider `message_id` and
+  should include channel, thread, author, timestamp, metadata, and raw provider
+  context when available. An update should include the changed `message` when
+  available. A delete must leave `message` as `nil` when the provider omits the
+  deleted content. Core does not fetch missing deleted content.
   """
 
   alias Jido.Chat.{

--- a/lib/jido/chat/event_envelope.ex
+++ b/lib/jido/chat/event_envelope.ex
@@ -8,6 +8,8 @@ defmodule Jido.Chat.EventEnvelope do
     AssistantContextChangedEvent,
     AssistantThreadStartedEvent,
     Incoming,
+    MessageDeletedEvent,
+    MessageUpdatedEvent,
     ModalCloseEvent,
     ModalSubmitEvent,
     ReactionEvent,
@@ -18,6 +20,8 @@ defmodule Jido.Chat.EventEnvelope do
 
   @event_types [
     :message,
+    :message_updated,
+    :message_deleted,
     :reaction,
     :action,
     :modal_submit,
@@ -45,6 +49,8 @@ defmodule Jido.Chat.EventEnvelope do
 
   @type event_type ::
           :message
+          | :message_updated
+          | :message_deleted
           | :reaction
           | :action
           | :modal_submit
@@ -129,6 +135,8 @@ defmodule Jido.Chat.EventEnvelope do
 
   defp serialize_payload(%Incoming{} = payload), do: Incoming.to_map(payload)
   defp serialize_payload(%Message{} = payload), do: Message.to_map(payload)
+  defp serialize_payload(%MessageUpdatedEvent{} = payload), do: MessageUpdatedEvent.to_map(payload)
+  defp serialize_payload(%MessageDeletedEvent{} = payload), do: MessageDeletedEvent.to_map(payload)
   defp serialize_payload(%ReactionEvent{} = payload), do: ReactionEvent.to_map(payload)
   defp serialize_payload(%ActionEvent{} = payload), do: ActionEvent.to_map(payload)
   defp serialize_payload(%ModalSubmitEvent{} = payload), do: ModalSubmitEvent.to_map(payload)
@@ -145,6 +153,12 @@ defmodule Jido.Chat.EventEnvelope do
 
   defp deserialize_payload(%{"__type__" => "incoming"} = payload), do: Incoming.from_map(payload)
   defp deserialize_payload(%{"__type__" => "message"} = payload), do: Message.from_map(payload)
+
+  defp deserialize_payload(%{"__type__" => "message_updated_event"} = payload),
+    do: MessageUpdatedEvent.from_map(payload)
+
+  defp deserialize_payload(%{"__type__" => "message_deleted_event"} = payload),
+    do: MessageDeletedEvent.from_map(payload)
 
   defp deserialize_payload(%{"__type__" => "reaction_event"} = payload),
     do: ReactionEvent.from_map(payload)

--- a/lib/jido/chat/event_normalizer.ex
+++ b/lib/jido/chat/event_normalizer.ex
@@ -8,6 +8,8 @@ defmodule Jido.Chat.EventNormalizer do
     AssistantThreadStartedEvent,
     EventEnvelope,
     Incoming,
+    MessageDeletedEvent,
+    MessageUpdatedEvent,
     ModalCloseEvent,
     ModalSubmitEvent,
     ReactionEvent,
@@ -18,6 +20,38 @@ defmodule Jido.Chat.EventNormalizer do
   def ensure_incoming(%Incoming{} = incoming), do: {:ok, incoming}
   def ensure_incoming(map) when is_map(map), do: {:ok, Incoming.new(map)}
   def ensure_incoming(other), do: {:error, {:invalid_incoming, other}}
+
+  @spec ensure_message_updated_event(MessageUpdatedEvent.t() | map() | term(), atom()) ::
+          {:ok, MessageUpdatedEvent.t()} | {:error, term()}
+  def ensure_message_updated_event(%MessageUpdatedEvent{} = event, _adapter_name), do: {:ok, event}
+
+  def ensure_message_updated_event(map, adapter_name) when is_map(map),
+    do:
+      ensure_lifecycle_event_struct(
+        map,
+        adapter_name,
+        MessageUpdatedEvent,
+        :invalid_message_updated_event
+      )
+
+  def ensure_message_updated_event(other, _adapter_name),
+    do: {:error, {:invalid_message_updated_event, other}}
+
+  @spec ensure_message_deleted_event(MessageDeletedEvent.t() | map() | term(), atom()) ::
+          {:ok, MessageDeletedEvent.t()} | {:error, term()}
+  def ensure_message_deleted_event(%MessageDeletedEvent{} = event, _adapter_name), do: {:ok, event}
+
+  def ensure_message_deleted_event(map, adapter_name) when is_map(map),
+    do:
+      ensure_lifecycle_event_struct(
+        map,
+        adapter_name,
+        MessageDeletedEvent,
+        :invalid_message_deleted_event
+      )
+
+  def ensure_message_deleted_event(other, _adapter_name),
+    do: {:error, {:invalid_message_deleted_event, other}}
 
   @spec ensure_reaction_event(ReactionEvent.t() | map() | term(), atom()) ::
           {:ok, ReactionEvent.t()} | {:error, term()}
@@ -162,6 +196,12 @@ defmodule Jido.Chat.EventNormalizer do
     _ -> {:error, {error_tag, map}}
   end
 
+  defp ensure_lifecycle_event_struct(map, adapter_name, mod, error_tag) when is_map(map) do
+    {:ok, map |> Map.put_new(:adapter_name, adapter_name) |> mod.new()}
+  rescue
+    _ -> {:error, {error_tag, map}}
+  end
+
   defp normalize_event_user(map) when is_map(map) do
     case map[:user] || map["user"] do
       %Author{} ->
@@ -200,6 +240,8 @@ defmodule Jido.Chat.EventNormalizer do
   end
 
   defp infer_event_type(nil), do: nil
+  defp infer_event_type(%MessageUpdatedEvent{}), do: :message_updated
+  defp infer_event_type(%MessageDeletedEvent{}), do: :message_deleted
 
   defp infer_event_type(payload) when is_map(payload) do
     cond do
@@ -235,6 +277,8 @@ defmodule Jido.Chat.EventNormalizer do
   end
 
   defp payload_thread_id(_adapter_name, %ReactionEvent{} = payload), do: payload.thread_id
+  defp payload_thread_id(_adapter_name, %MessageUpdatedEvent{} = payload), do: payload.thread_id
+  defp payload_thread_id(_adapter_name, %MessageDeletedEvent{} = payload), do: payload.thread_id
   defp payload_thread_id(_adapter_name, %ActionEvent{} = payload), do: payload.thread_id
   defp payload_thread_id(_adapter_name, %ModalSubmitEvent{} = payload), do: payload.thread_id
   defp payload_thread_id(_adapter_name, %ModalCloseEvent{} = payload), do: payload.thread_id
@@ -250,6 +294,8 @@ defmodule Jido.Chat.EventNormalizer do
 
   defp payload_channel_id(%Incoming{} = incoming), do: stringify(incoming.external_room_id)
   defp payload_channel_id(%ReactionEvent{} = payload), do: payload.channel_id
+  defp payload_channel_id(%MessageUpdatedEvent{} = payload), do: payload.channel_id
+  defp payload_channel_id(%MessageDeletedEvent{} = payload), do: payload.channel_id
   defp payload_channel_id(%ActionEvent{} = payload), do: payload.channel_id
   defp payload_channel_id(%ModalSubmitEvent{} = payload), do: payload.channel_id
   defp payload_channel_id(%ModalCloseEvent{} = payload), do: payload.channel_id
@@ -260,6 +306,8 @@ defmodule Jido.Chat.EventNormalizer do
 
   defp payload_message_id(%Incoming{} = incoming), do: stringify(incoming.external_message_id)
   defp payload_message_id(%ReactionEvent{} = payload), do: payload.message_id
+  defp payload_message_id(%MessageUpdatedEvent{} = payload), do: payload.message_id
+  defp payload_message_id(%MessageDeletedEvent{} = payload), do: payload.message_id
   defp payload_message_id(%ActionEvent{} = payload), do: payload.message_id
   defp payload_message_id(%ModalSubmitEvent{} = payload), do: payload.message_id
   defp payload_message_id(%ModalCloseEvent{} = payload), do: payload.message_id

--- a/lib/jido/chat/event_router.ex
+++ b/lib/jido/chat/event_router.ex
@@ -17,6 +17,14 @@ defmodule Jido.Chat.EventRouter do
   @spec ensure_incoming(Incoming.t() | map() | term()) :: {:ok, Incoming.t()} | {:error, term()}
   def ensure_incoming(input), do: EventNormalizer.ensure_incoming(input)
 
+  @spec ensure_message_updated_event(term(), atom()) :: {:ok, term()} | {:error, term()}
+  def ensure_message_updated_event(event, adapter_name),
+    do: EventNormalizer.ensure_message_updated_event(event, adapter_name)
+
+  @spec ensure_message_deleted_event(term(), atom()) :: {:ok, term()} | {:error, term()}
+  def ensure_message_deleted_event(event, adapter_name),
+    do: EventNormalizer.ensure_message_deleted_event(event, adapter_name)
+
   @spec ensure_reaction_event(term(), atom()) :: {:ok, term()} | {:error, term()}
   def ensure_reaction_event(event, adapter_name),
     do: EventNormalizer.ensure_reaction_event(event, adapter_name)
@@ -81,6 +89,36 @@ defmodule Jido.Chat.EventRouter do
       chat,
       adapter_name,
       envelope.payload || envelope.raw || %{},
+      opts
+    )
+  end
+
+  def route_event(
+        chat,
+        adapter_name,
+        %EventEnvelope{event_type: :message_updated} = envelope,
+        opts,
+        dispatchers
+      ) do
+    dispatchers.process_message_updated.(
+      chat,
+      adapter_name,
+      lifecycle_payload(envelope),
+      opts
+    )
+  end
+
+  def route_event(
+        chat,
+        adapter_name,
+        %EventEnvelope{event_type: :message_deleted} = envelope,
+        opts,
+        dispatchers
+      ) do
+    dispatchers.process_message_deleted.(
+      chat,
+      adapter_name,
+      lifecycle_payload(envelope),
       opts
     )
   end
@@ -170,6 +208,57 @@ defmodule Jido.Chat.EventRouter do
 
   def route_event(_chat, _adapter_name, %EventEnvelope{} = envelope, _opts, _dispatchers),
     do: {:error, {:unsupported_event_type, envelope.event_type}}
+
+  defp lifecycle_payload(%EventEnvelope{} = envelope) do
+    case envelope.payload || %{} do
+      payload when is_map(payload) ->
+        payload
+        |> put_context_if_missing(:thread_id, envelope.thread_id)
+        |> put_context_if_missing(:channel_id, envelope.channel_id)
+        |> put_context_if_missing(:message_id, envelope.message_id)
+        |> merge_context(:metadata, envelope.metadata)
+        |> merge_context(:raw, envelope.raw)
+
+      payload ->
+        payload
+    end
+  end
+
+  defp put_context_if_missing(payload, _key, nil), do: payload
+
+  defp put_context_if_missing(payload, key, value) do
+    if Map.get(payload, key) || Map.get(payload, Atom.to_string(key)) do
+      payload
+    else
+      payload |> Map.delete(Atom.to_string(key)) |> Map.put(key, value)
+    end
+  end
+
+  defp merge_context(payload, key, envelope_context) do
+    string_key = Atom.to_string(key)
+
+    if envelope_context in [nil, %{}] and is_map(Map.get(payload, key)) and
+         not Map.has_key?(payload, string_key) do
+      payload
+    else
+      merge_context_maps(payload, key, string_key, envelope_context)
+    end
+  end
+
+  defp merge_context_maps(payload, key, string_key, envelope_context) do
+    payload_context = Map.get(payload, key) || Map.get(payload, string_key)
+
+    merged_context =
+      if is_map(payload_context) do
+        Map.merge(envelope_context || %{}, payload_context)
+      else
+        payload_context || envelope_context || %{}
+      end
+
+    payload
+    |> Map.delete(string_key)
+    |> Map.put(key, merged_context)
+  end
 
   @spec with_envelope_payload(EventEnvelope.t(), term()) :: EventEnvelope.t()
   def with_envelope_payload(%EventEnvelope{} = envelope, payload),

--- a/lib/jido/chat/message_deleted_event.ex
+++ b/lib/jido/chat/message_deleted_event.ex
@@ -1,0 +1,55 @@
+defmodule Jido.Chat.MessageDeletedEvent do
+  @moduledoc """
+  A normalized event for deletion of an existing message.
+
+  `message_id` always identifies the deleted provider message. If the provider
+  does not supply deleted content, `message` is `nil`. Core does not fetch or
+  recover the missing content.
+  """
+
+  alias Jido.Chat.{Author, ChannelRef, Message, MessageLifecycleEvent, Thread}
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              adapter: Zoi.any() |> Zoi.nullish(),
+              adapter_name: Zoi.atom() |> Zoi.nullish(),
+              thread_id: Zoi.string() |> Zoi.nullish(),
+              channel_id: Zoi.string() |> Zoi.nullish(),
+              message_id: Zoi.string(),
+              author: Zoi.struct(Author) |> Zoi.nullish(),
+              timestamp: Zoi.any() |> Zoi.nullish(),
+              thread: Zoi.struct(Thread) |> Zoi.nullish(),
+              channel: Zoi.struct(ChannelRef) |> Zoi.nullish(),
+              message: Zoi.struct(Message) |> Zoi.nullish(),
+              metadata: Zoi.map() |> Zoi.default(%{}),
+              raw: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the Zoi schema for MessageDeletedEvent."
+  def schema, do: @schema
+
+  @doc "Creates a normalized message-deleted event."
+  @spec new(map()) :: t()
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> MessageLifecycleEvent.normalize()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Serializes the event into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = event),
+    do: MessageLifecycleEvent.to_map(event, "message_deleted_event")
+
+  @doc "Builds the event from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+end

--- a/lib/jido/chat/message_lifecycle_event.ex
+++ b/lib/jido/chat/message_lifecycle_event.ex
@@ -1,0 +1,94 @@
+defmodule Jido.Chat.MessageLifecycleEvent do
+  @moduledoc false
+
+  alias Jido.Chat.{Author, ChannelRef, Message, Thread, Wire}
+
+  @doc "Normalizes common fields for a typed message lifecycle event."
+  @spec normalize(map()) :: map()
+  def normalize(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_adapter()
+    |> normalize_author()
+    |> normalize_handle(:thread, Thread)
+    |> normalize_handle(:channel, ChannelRef)
+    |> attach_message_id()
+    |> normalize_handle(:message, Message)
+  end
+
+  @doc "Serializes a message lifecycle event with the specified type marker."
+  @spec to_map(struct(), String.t()) :: map()
+  def to_map(event, type) when is_struct(event) and is_binary(type) do
+    event
+    |> Map.from_struct()
+    |> Map.update!(:adapter, &Wire.encode_module/1)
+    |> Map.update!(:thread, &serialize_handle(&1, Thread))
+    |> Map.update!(:channel, &serialize_handle(&1, ChannelRef))
+    |> Map.update!(:message, &serialize_handle(&1, Message))
+    |> Wire.to_plain()
+    |> Map.put("__type__", type)
+  end
+
+  defp normalize_adapter(attrs) do
+    case attrs[:adapter] || attrs["adapter"] do
+      adapter when is_binary(adapter) ->
+        attrs |> Map.delete("adapter") |> Map.put(:adapter, Wire.decode_module(adapter))
+
+      _ ->
+        attrs
+    end
+  end
+
+  defp normalize_author(attrs) do
+    author = attrs[:author] || attrs["author"] || attrs[:user] || attrs["user"]
+
+    case author do
+      %Author{} = value ->
+        attrs
+        |> Map.drop(["author", :user, "user"])
+        |> Map.put(:author, value)
+
+      %{} = value ->
+        attrs
+        |> Map.drop(["author", :user, "user"])
+        |> Map.put(:author, Author.new(value))
+
+      _ ->
+        attrs
+    end
+  end
+
+  defp normalize_handle(attrs, key, mod) do
+    case attrs[key] || attrs[Atom.to_string(key)] do
+      %{__struct__: ^mod} = value ->
+        attrs |> Map.delete(Atom.to_string(key)) |> Map.put(key, value)
+
+      %{} = value ->
+        attrs |> Map.delete(Atom.to_string(key)) |> Map.put(key, mod.from_map(value))
+
+      _ ->
+        attrs
+    end
+  end
+
+  defp attach_message_id(attrs) do
+    message = attrs[:message] || attrs["message"]
+
+    message_target_id =
+      if is_map(message) do
+        Map.get(message, :external_message_id) || Map.get(message, "external_message_id") ||
+          Map.get(message, :id) || Map.get(message, "id")
+      end
+
+    message_id =
+      attrs[:message_id] || attrs["message_id"] || message_target_id
+
+    if is_nil(message_id) do
+      attrs
+    else
+      attrs |> Map.delete("message_id") |> Map.put(:message_id, to_string(message_id))
+    end
+  end
+
+  defp serialize_handle(nil, _mod), do: nil
+  defp serialize_handle(value, mod), do: mod.to_map(value)
+end

--- a/lib/jido/chat/message_updated_event.ex
+++ b/lib/jido/chat/message_updated_event.ex
@@ -1,0 +1,54 @@
+defmodule Jido.Chat.MessageUpdatedEvent do
+  @moduledoc """
+  A normalized event for content or metadata changes to an existing message.
+
+  `message_id` identifies the provider message. `message` contains the updated
+  content when the provider supplies it.
+  """
+
+  alias Jido.Chat.{Author, ChannelRef, Message, MessageLifecycleEvent, Thread}
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              adapter: Zoi.any() |> Zoi.nullish(),
+              adapter_name: Zoi.atom() |> Zoi.nullish(),
+              thread_id: Zoi.string() |> Zoi.nullish(),
+              channel_id: Zoi.string() |> Zoi.nullish(),
+              message_id: Zoi.string(),
+              author: Zoi.struct(Author) |> Zoi.nullish(),
+              timestamp: Zoi.any() |> Zoi.nullish(),
+              thread: Zoi.struct(Thread) |> Zoi.nullish(),
+              channel: Zoi.struct(ChannelRef) |> Zoi.nullish(),
+              message: Zoi.struct(Message) |> Zoi.nullish(),
+              metadata: Zoi.map() |> Zoi.default(%{}),
+              raw: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the Zoi schema for MessageUpdatedEvent."
+  def schema, do: @schema
+
+  @doc "Creates a normalized message-updated event."
+  @spec new(map()) :: t()
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> MessageLifecycleEvent.normalize()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Serializes the event into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = event),
+    do: MessageLifecycleEvent.to_map(event, "message_updated_event")
+
+  @doc "Builds the event from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+end

--- a/lib/jido/chat/serialization.ex
+++ b/lib/jido/chat/serialization.ex
@@ -14,6 +14,8 @@ defmodule Jido.Chat.Serialization do
     IngressResult,
     Markdown,
     Message,
+    MessageDeletedEvent,
+    MessageUpdatedEvent,
     Modal,
     ModalCloseEvent,
     ModalResult,
@@ -88,6 +90,8 @@ defmodule Jido.Chat.Serialization do
   def revive(%{"__type__" => "thread"} = map), do: Thread.from_map(map)
   def revive(%{"__type__" => "channel"} = map), do: ChannelRef.from_map(map)
   def revive(%{"__type__" => "incoming"} = map), do: Incoming.from_map(map)
+  def revive(%{"__type__" => "message_updated_event"} = map), do: MessageUpdatedEvent.from_map(map)
+  def revive(%{"__type__" => "message_deleted_event"} = map), do: MessageDeletedEvent.from_map(map)
   def revive(%{"__type__" => "reaction_event"} = map), do: ReactionEvent.from_map(map)
   def revive(%{"__type__" => "action_event"} = map), do: ActionEvent.from_map(map)
   def revive(%{"__type__" => "modal_submit_event"} = map), do: ModalSubmitEvent.from_map(map)

--- a/lib/jido_chat.ex
+++ b/lib/jido_chat.ex
@@ -25,6 +25,8 @@ defmodule Jido.Chat do
     IngressResult,
     Incoming,
     Message,
+    MessageDeletedEvent,
+    MessageUpdatedEvent,
     ModalCloseEvent,
     ModalSubmitEvent,
     Participant,
@@ -54,6 +56,14 @@ defmodule Jido.Chat do
   @type message_handler :: mention_handler()
   @typedoc "Subscribed-thread handler callback."
   @type subscribed_handler :: mention_handler()
+
+  @typedoc "Message-updated lifecycle handler callback."
+  @type message_updated_handler ::
+          (MessageUpdatedEvent.t() -> term()) | (t(), MessageUpdatedEvent.t() -> t() | term())
+
+  @typedoc "Message-deleted lifecycle handler callback."
+  @type message_deleted_handler ::
+          (MessageDeletedEvent.t() -> term()) | (t(), MessageDeletedEvent.t() -> t() | term())
 
   @typedoc "Reaction event handler callback."
   @type reaction_handler ::
@@ -87,6 +97,8 @@ defmodule Jido.Chat do
           mention: [mention_handler()],
           message: [{Regex.t(), message_handler()}],
           subscribed: [subscribed_handler()],
+          message_updated: [message_updated_handler()],
+          message_deleted: [message_deleted_handler()],
           reaction: [reaction_handler()],
           action: [action_handler()],
           modal_submit: [modal_submit_handler()],
@@ -131,6 +143,8 @@ defmodule Jido.Chat do
     mention: [],
     message: [],
     subscribed: [],
+    message_updated: [],
+    message_deleted: [],
     reaction: [],
     action: [],
     modal_submit: [],
@@ -262,6 +276,18 @@ defmodule Jido.Chat do
   @spec on_subscribed_message(t(), subscribed_handler()) :: t()
   def on_subscribed_message(%__MODULE__{} = chat, handler) when is_function(handler) do
     update_in(chat.handlers.subscribed, &(&1 ++ [handler]))
+  end
+
+  @doc "Registers a message-updated lifecycle handler."
+  @spec on_message_updated(t(), message_updated_handler()) :: t()
+  def on_message_updated(%__MODULE__{} = chat, handler) when is_function(handler) do
+    register_event_handler(chat, :message_updated, handler)
+  end
+
+  @doc "Registers a message-deleted lifecycle handler."
+  @spec on_message_deleted(t(), message_deleted_handler()) :: t()
+  def on_message_deleted(%__MODULE__{} = chat, handler) when is_function(handler) do
+    register_event_handler(chat, :message_deleted, handler)
   end
 
   @doc "Registers a reaction-event handler."
@@ -616,6 +642,40 @@ defmodule Jido.Chat do
     end
   end
 
+  @doc "Processes normalized message-updated events and dispatches lifecycle handlers."
+  @spec process_message_updated(t(), atom(), MessageUpdatedEvent.t() | map(), keyword()) ::
+          {:ok, t(), MessageUpdatedEvent.t()} | {:error, term()}
+  def process_message_updated(%__MODULE__{} = chat, adapter_name, event, opts \\ [])
+      when is_atom(adapter_name) and is_list(opts) do
+    with {:ok, message_updated} <- EventRouter.ensure_message_updated_event(event, adapter_name) do
+      message_updated = enrich_lifecycle_event_context(chat, adapter_name, message_updated)
+
+      {:ok,
+       EventRouter.run_event_handlers(
+         chat,
+         Map.get(chat.handlers, :message_updated, []),
+         message_updated
+       ), message_updated}
+    end
+  end
+
+  @doc "Processes normalized message-deleted events and dispatches lifecycle handlers."
+  @spec process_message_deleted(t(), atom(), MessageDeletedEvent.t() | map(), keyword()) ::
+          {:ok, t(), MessageDeletedEvent.t()} | {:error, term()}
+  def process_message_deleted(%__MODULE__{} = chat, adapter_name, event, opts \\ [])
+      when is_atom(adapter_name) and is_list(opts) do
+    with {:ok, message_deleted} <- EventRouter.ensure_message_deleted_event(event, adapter_name) do
+      message_deleted = enrich_lifecycle_event_context(chat, adapter_name, message_deleted)
+
+      {:ok,
+       EventRouter.run_event_handlers(
+         chat,
+         Map.get(chat.handlers, :message_deleted, []),
+         message_deleted
+       ), message_deleted}
+    end
+  end
+
   @doc "Processes normalized action events and dispatches handlers."
   @spec process_action(t(), atom(), ActionEvent.t() | map(), keyword()) ::
           {:ok, t(), ActionEvent.t()} | {:error, term()}
@@ -672,6 +732,8 @@ defmodule Jido.Chat do
       when is_atom(adapter_name) and is_list(opts) do
     dispatchers = %{
       process_message: &process_message/5,
+      process_message_updated: &process_message_updated/4,
+      process_message_deleted: &process_message_deleted/4,
       process_reaction: &process_reaction/4,
       process_action: &process_action/4,
       process_modal_submit: &process_modal_submit/4,
@@ -913,6 +975,11 @@ defmodule Jido.Chat do
     update_in(chat.handlers[key], &(&1 ++ [{normalized, handler}]))
   end
 
+  defp register_event_handler(%__MODULE__{} = chat, key, handler) do
+    handlers = Map.update(chat.handlers, key, [handler], &(&1 ++ [handler]))
+    %{chat | handlers: handlers}
+  end
+
   defp normalize_handler_selector(selectors) when is_list(selectors),
     do: Enum.map(selectors, &normalize_handler_selector/1)
 
@@ -1027,6 +1094,21 @@ defmodule Jido.Chat do
       thread_id: Map.get(event, :thread_id) || (thread && thread.id),
       channel_id: Map.get(event, :channel_id) || (channel && channel.id),
       message_id: Map.get(event, :message_id) || (message && message.id)
+    )
+  end
+
+  defp enrich_lifecycle_event_context(%__MODULE__{} = chat, adapter_name, event) do
+    adapter = Map.get(chat.adapters, adapter_name)
+    channel = Map.get(event, :channel) || build_channel_handle(chat, adapter_name, event)
+    thread = Map.get(event, :thread) || build_thread_handle(chat, adapter_name, event, channel)
+
+    struct(event,
+      adapter: adapter,
+      adapter_name: adapter_name,
+      thread: thread,
+      channel: channel,
+      thread_id: Map.get(event, :thread_id) || (thread && thread.id),
+      channel_id: Map.get(event, :channel_id) || (channel && channel.id)
     )
   end
 

--- a/test/jido/chat/message_lifecycle_event_test.exs
+++ b/test/jido/chat/message_lifecycle_event_test.exs
@@ -1,0 +1,407 @@
+defmodule Jido.Chat.MessageLifecycleEventTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Chat
+
+  alias Jido.Chat.{
+    Author,
+    ChannelRef,
+    EventEnvelope,
+    EventNormalizer,
+    Message,
+    MessageDeletedEvent,
+    MessageUpdatedEvent,
+    Thread
+  }
+
+  defmodule TestAdapter do
+    use Jido.Chat.Adapter
+
+    @impl true
+    def transform_incoming(payload), do: {:ok, Jido.Chat.Incoming.new(payload)}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok,
+       Jido.Chat.Response.new(%{
+         external_message_id: "sent-1",
+         external_room_id: room_id,
+         channel_type: :test
+       })}
+    end
+  end
+
+  defmodule LifecycleRequestAdapter do
+    use Jido.Chat.Adapter
+
+    @impl true
+    def transform_incoming(payload), do: {:ok, Jido.Chat.Incoming.new(payload)}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok,
+       Jido.Chat.Response.new(%{
+         external_message_id: "sent-1",
+         external_room_id: room_id,
+         channel_type: :test
+       })}
+    end
+
+    @impl true
+    def parse_event(%Jido.Chat.WebhookRequest{payload: payload}, _opts) do
+      {:ok,
+       Jido.Chat.EventEnvelope.new(%{
+         event_type: :message_updated,
+         channel_id: "request:C1",
+         thread_id: "request:C1:T1",
+         message_id: payload["message_id"],
+         payload: %{
+           message_id: payload["message_id"],
+           message: %{
+             id: payload["message_id"],
+             external_message_id: payload["message_id"],
+             text: payload["text"]
+           }
+         }
+       })}
+    end
+  end
+
+  test "typed lifecycle events keep provider context and optional content" do
+    author = Author.new(%{user_id: "U1", user_name: "casey"})
+
+    message =
+      Message.new(%{
+        id: "M1",
+        external_message_id: "M1",
+        external_room_id: "C1",
+        text: "corrected text"
+      })
+
+    updated =
+      MessageUpdatedEvent.new(%{
+        adapter_name: :slack,
+        channel_id: "slack:C1",
+        thread_id: "slack:C1:T1",
+        message_id: "M1",
+        message: message,
+        author: author,
+        timestamp: "2026-08-20T12:00:00Z",
+        metadata: %{delivery_id: "D1"},
+        raw: %{"type" => "message_changed"}
+      })
+
+    assert updated.message.text == "corrected text"
+    assert updated.author == author
+    assert updated.timestamp == "2026-08-20T12:00:00Z"
+    assert updated.metadata == %{delivery_id: "D1"}
+    assert updated.raw == %{"type" => "message_changed"}
+
+    deleted =
+      MessageDeletedEvent.new(%{
+        adapter_name: :slack,
+        channel_id: "slack:C1",
+        thread_id: "slack:C1:T1",
+        message_id: "M1",
+        author: author,
+        timestamp: "2026-08-20T12:01:00Z",
+        raw: %{"type" => "message_deleted"}
+      })
+
+    assert deleted.message_id == "M1"
+    assert deleted.message == nil
+    assert deleted.author == author
+  end
+
+  test "normalizer creates lifecycle structs from adapter maps" do
+    assert {:ok, %MessageUpdatedEvent{} = updated} =
+             EventNormalizer.ensure_message_updated_event(
+               %{
+                 "channel_id" => "slack:C1",
+                 "thread_id" => "slack:C1:T1",
+                 "message_id" => "M1",
+                 "message" => %{
+                   "id" => "M1",
+                   "external_message_id" => "M1",
+                   "text" => "edited"
+                 },
+                 "author" => %{"user_id" => "U1", "user_name" => "casey"},
+                 "timestamp" => "2026-08-20T12:00:00Z",
+                 "metadata" => %{"delivery_id" => "D1"},
+                 "raw" => %{"provider" => "slack"}
+               },
+               :slack
+             )
+
+    assert updated.adapter_name == :slack
+    assert updated.message.text == "edited"
+    assert updated.author.user_id == "U1"
+
+    assert {:ok, %MessageDeletedEvent{} = deleted} =
+             EventNormalizer.ensure_message_deleted_event(
+               %{
+                 message_id: "M1",
+                 channel_id: "discord:C1",
+                 thread_id: "discord:C1:T1",
+                 raw: %{"provider" => "discord"}
+               },
+               :discord
+             )
+
+    assert deleted.adapter_name == :discord
+    assert deleted.message == nil
+
+    assert {:error, {:invalid_message_updated_event, :bad}} =
+             EventNormalizer.ensure_message_updated_event(:bad, :slack)
+
+    assert {:error, {:invalid_message_deleted_event, :bad}} =
+             EventNormalizer.ensure_message_deleted_event(:bad, :slack)
+
+    assert {:error, {:invalid_message_updated_event, %{}}} =
+             EventNormalizer.ensure_message_updated_event(%{}, :slack)
+
+    assert {:error, {:invalid_message_deleted_event, %{}}} =
+             EventNormalizer.ensure_message_deleted_event(%{}, :slack)
+
+    assert {:ok, %EventEnvelope{event_type: :message_updated}} =
+             EventNormalizer.ensure_event_envelope(%{payload: updated}, :slack)
+  end
+
+  test "lifecycle envelopes and top-level reviver restore typed payloads" do
+    thread =
+      Thread.new(%{
+        id: "test:C1:T1",
+        adapter_name: :test,
+        adapter: TestAdapter,
+        external_room_id: "C1",
+        external_thread_id: "T1"
+      })
+
+    channel =
+      ChannelRef.new(%{
+        id: "test:C1",
+        adapter_name: :test,
+        adapter: TestAdapter,
+        external_id: "C1"
+      })
+
+    events = [
+      {:message_updated,
+       MessageUpdatedEvent.new(%{
+         message_id: "M1",
+         channel_id: "test:C1",
+         thread_id: "test:C1:T1",
+         thread: thread,
+         channel: channel,
+         message: %{id: "M1", external_message_id: "M1", text: "edited"}
+       })},
+      {:message_deleted,
+       MessageDeletedEvent.new(%{
+         message_id: "M2",
+         channel_id: "test:C1",
+         thread_id: "test:C1:T1",
+         thread: thread,
+         channel: channel
+       })}
+    ]
+
+    for {event_type, payload} <- events do
+      envelope =
+        EventEnvelope.new(%{
+          adapter_name: :test,
+          event_type: event_type,
+          payload: payload,
+          raw: %{"delivery" => "D1"}
+        })
+
+      assert %EventEnvelope{event_type: ^event_type, payload: revived_payload} =
+               envelope |> EventEnvelope.to_map() |> EventEnvelope.from_map()
+
+      assert revived_payload.__struct__ == payload.__struct__
+      assert revived_payload.message_id == payload.message_id
+      assert %Thread{adapter: TestAdapter} = revived_payload.thread
+      assert %ChannelRef{adapter: TestAdapter} = revived_payload.channel
+      assert {:ok, %Jido.Chat.SentMessage{}} = Thread.post(revived_payload.thread, "thread reply")
+      assert {:ok, %Jido.Chat.SentMessage{}} = ChannelRef.post(revived_payload.channel, "channel reply")
+
+      assert Chat.reviver().(payload.__struct__.to_map(payload)).__struct__ == payload.__struct__
+    end
+  end
+
+  test "lifecycle events preserve explicit and nested provider message ids" do
+    nested_id_event =
+      MessageUpdatedEvent.new(%{
+        message: %{id: "M-from-message", text: "edited"}
+      })
+
+    assert nested_id_event.message_id == "M-from-message"
+    assert nested_id_event.message.external_message_id == "M-from-message"
+
+    nested_external_id_event =
+      MessageUpdatedEvent.new(%{
+        message: %{external_message_id: "M-from-provider", text: "edited"}
+      })
+
+    assert nested_external_id_event.message_id == "M-from-provider"
+
+    explicit_id_event =
+      MessageUpdatedEvent.new(%{
+        message_id: "M-explicit",
+        message: %{text: "edited"}
+      })
+
+    assert explicit_id_event.message_id == "M-explicit"
+  end
+
+  test "message update rejects nested content without a provider message id" do
+    assert_missing_provider_id_rejected(:message_updated, :invalid_message_updated_event)
+  end
+
+  test "message delete rejects nested content without a provider message id" do
+    assert_missing_provider_id_rejected(:message_deleted, :invalid_message_deleted_event)
+  end
+
+  test "lifecycle handlers route separately from normal message handlers" do
+    chat =
+      Chat.new(adapters: %{test: TestAdapter})
+      |> Chat.on_new_message(~r/.*/, fn _thread, _incoming -> send(self(), :normal_message) end)
+      |> Chat.on_message_updated(fn chat, event ->
+        send(self(), {:updated, event})
+        %{chat | metadata: Map.put(chat.metadata, :updated, true)}
+      end)
+      |> Chat.on_message_deleted(fn event -> send(self(), {:deleted, event}) end)
+
+    update_envelope =
+      EventEnvelope.new(%{
+        adapter_name: :test,
+        event_type: :message_updated,
+        channel_id: "test:C1",
+        thread_id: "test:C1:T1",
+        message_id: "M1",
+        payload: %{
+          message: %{id: "M1", external_message_id: "M1", text: "edited"}
+        },
+        metadata: %{delivery_id: "D1"},
+        raw: %{"provider_event" => "changed"}
+      })
+
+    assert {:ok, updated_chat, %EventEnvelope{payload: %MessageUpdatedEvent{} = updated}} =
+             Chat.process_event(chat, :test, update_envelope, [])
+
+    assert updated_chat.metadata.updated
+    assert %ChannelRef{id: "test:C1"} = updated.channel
+    assert %Thread{id: "test:C1:T1"} = updated.thread
+    assert updated.adapter == TestAdapter
+    assert updated.metadata == %{delivery_id: "D1"}
+    assert updated.raw == %{"provider_event" => "changed"}
+    assert_received {:updated, ^updated}
+    refute_received :normal_message
+
+    delete_envelope =
+      EventEnvelope.new(%{
+        adapter_name: :test,
+        event_type: :message_deleted,
+        payload: %{
+          channel_id: "test:C1",
+          thread_id: "test:C1:T1",
+          message_id: "M1"
+        }
+      })
+
+    assert {:ok, _chat, %EventEnvelope{payload: %MessageDeletedEvent{} = deleted}} =
+             Chat.process_event(updated_chat, :test, delete_envelope, [])
+
+    assert deleted.message == nil
+    assert %ChannelRef{} = deleted.channel
+    assert %Thread{} = deleted.thread
+    assert_received {:deleted, ^deleted}
+    refute_received :normal_message
+  end
+
+  test "lifecycle payload context overrides duplicate envelope metadata and raw values" do
+    chat =
+      Chat.new(adapters: %{test: TestAdapter})
+      |> Chat.on_message_updated(fn event -> send(self(), {:merged, event}) end)
+
+    envelope =
+      EventEnvelope.new(%{
+        adapter_name: :test,
+        event_type: :message_updated,
+        channel_id: "test:C1",
+        thread_id: "test:C1:T1",
+        message_id: "M1",
+        payload: %{
+          message: %{id: "M1", text: "edited"},
+          metadata: %{payload_only: true, shared: :payload},
+          raw: %{"payload_only" => true, "shared" => "payload"}
+        },
+        metadata: %{envelope_only: true, shared: :envelope},
+        raw: %{"envelope_only" => true, "shared" => "envelope"}
+      })
+
+    assert {:ok, _chat, %EventEnvelope{payload: %MessageUpdatedEvent{} = updated}} =
+             Chat.process_event(chat, :test, envelope, [])
+
+    assert updated.metadata == %{envelope_only: true, payload_only: true, shared: :payload}
+
+    assert updated.raw == %{
+             "envelope_only" => true,
+             "payload_only" => true,
+             "shared" => "payload"
+           }
+
+    assert_received {:merged, ^updated}
+  end
+
+  test "request ingress dispatches parsed lifecycle events without normal message handlers" do
+    chat =
+      Chat.new(adapters: %{request: LifecycleRequestAdapter})
+      |> Chat.on_new_message(~r/.*/, fn _thread, _incoming -> send(self(), :normal_message) end)
+      |> Chat.on_message_updated(fn event -> send(self(), {:request_updated, event}) end)
+
+    assert {:ok, _chat, %EventEnvelope{payload: %MessageUpdatedEvent{} = updated}, response} =
+             Chat.handle_webhook_request(
+               chat,
+               :request,
+               %{"message_id" => "M-request", "text" => "edited through request ingress"},
+               []
+             )
+
+    assert updated.message_id == "M-request"
+    assert updated.message.text == "edited through request ingress"
+    assert response.status == 200
+    assert_received {:request_updated, ^updated}
+    refute_received :normal_message
+  end
+
+  test "lifecycle registration accepts chat values with the legacy handler map" do
+    chat = Chat.new(adapters: %{test: TestAdapter})
+
+    legacy_chat =
+      %{chat | handlers: Map.drop(chat.handlers, [:message_updated, :message_deleted])}
+
+    registered =
+      legacy_chat
+      |> Chat.on_message_updated(fn _event -> :ok end)
+      |> Chat.on_message_deleted(fn _event -> :ok end)
+
+    assert length(registered.handlers.message_updated) == 1
+    assert length(registered.handlers.message_deleted) == 1
+  end
+
+  defp assert_missing_provider_id_rejected(event_type, error_tag) do
+    chat = Chat.new(adapters: %{test: TestAdapter})
+
+    envelope =
+      EventEnvelope.new(%{
+        adapter_name: :test,
+        event_type: event_type,
+        payload: %{message: %{text: "content without a provider id"}}
+      })
+
+    assert {:error, {^error_tag, rejected_payload}} =
+             Chat.process_event(chat, :test, envelope, [])
+
+    assert rejected_payload.message == %{text: "content without a provider id"}
+  end
+end


### PR DESCRIPTION
## Summary

This pull request adds the core message lifecycle contract for cross-platform message updates and deletes. Adapters and the messaging runtime can now exchange typed lifecycle events without sending edits through the new-message path.

## What changed

- Add typed `MessageUpdatedEvent` and `MessageDeletedEvent` payloads.
- Add shared lifecycle normalization, validation, serialization, envelope support, and router support.
- Preserve provider message IDs from the top-level or nested payload and reject payloads that do not contain a provider ID.
- Add public lifecycle helpers and adapter event capability entries.
- Document the lifecycle contract and add focused coverage for updates, deletes, raw payloads, and invalid inputs.

This is the core contribution for the multi-repository lifecycle program. Slack, Discord, and `jido_messaging` use these types in separate pull requests.

## Related

Related: agentjido/jido_chat#37

## Validation

- `mix test` — 141 passed
- `mix quality` — Credo clean, Dialyzer 0 errors, Doctor passed
- `git diff --check`
- Completed structured code review; the validated provider-ID finding was fixed

## Post-Deploy Monitoring & Validation

No direct production monitoring is required for the core type package. After release, run the Slack, Discord, and messaging-runtime branches against the released version. Failure signals are adapter compile errors, rejected valid lifecycle payloads, or lifecycle events entering the new-message route. Hold downstream merges or the core version update if these signals occur. The maintainers own validation during the first release CI cycle.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
