### PR TITLE
feat(adapter): add resource and receipt contracts

### DIFF
--- a/lib/jido/chat/adapter.ex
+++ b/lib/jido/chat/adapter.ex
@@ -14,28 +14,32 @@ defmodule Jido.Chat.Adapter do
   """
 
   alias Jido.Chat.{
-    Card,
+    Author,
     CapabilityMatrix,
+    Card,
     ChannelInfo,
-    EventEnvelope,
     EphemeralMessage,
-    FileUpload,
+    EventEnvelope,
     FetchOptions,
+    FileUpload,
     Incoming,
     Markdown,
     Media,
-    Modal,
-    ModalResult,
     Message,
     MessagePage,
-    PostPayload,
+    MessageSubject,
+    Modal,
+    ModalResult,
+    Participant,
     Postable,
+    PostPayload,
     Response,
-    WebhookRequest,
-    WebhookResponse,
     StreamChunk,
     Thread,
-    ThreadPage
+    ThreadPage,
+    UserInfo,
+    WebhookRequest,
+    WebhookResponse
   }
 
   @type raw_payload :: map()
@@ -63,6 +67,10 @@ defmodule Jido.Chat.Adapter do
   @type ephemeral_result :: {:ok, EphemeralMessage.t()} | {:error, term()}
   @type modal_result :: {:ok, ModalResult.t()} | {:error, term()}
   @type media_result :: {:ok, binary()} | {:error, term()}
+  @type user_result :: {:ok, UserInfo.t()} | {:error, term()}
+  @type subject_result :: {:ok, MessageSubject.t()} | {:error, term()}
+  @type participants_result :: {:ok, [Participant.t()]} | {:error, term()}
+  @type read_result :: :ok | {:error, term()}
   @type file_input :: FileUpload.input()
   @type media_reference :: String.t() | Media.t() | map()
 
@@ -121,6 +129,25 @@ defmodule Jido.Chat.Adapter do
 
   @callback fetch_message(external_room_id(), external_message_id(), opts :: keyword()) ::
               {:ok, Message.t() | Incoming.t() | map()} | {:error, term()}
+
+  @doc "Returns normalized information for one provider user."
+  @callback get_user(external_user_id(), opts :: keyword()) ::
+              {:ok, UserInfo.t() | map()} | {:error, term()}
+
+  @doc "Returns the resource subject for a room or thread."
+  @callback fetch_subject(external_room_id(), opts :: keyword()) ::
+              {:ok, MessageSubject.t() | map()} | {:error, term()}
+
+  @doc "Returns the canonical participants for a room or thread."
+  @callback get_thread_participants(external_room_id(), opts :: keyword()) ::
+              {:ok, [Participant.t() | UserInfo.t() | Author.t() | map()]} | {:error, term()}
+
+  @doc "Marks a provider message as read. Repeated calls must be safe."
+  @callback mark_as_read(
+              external_room_id(),
+              external_message_id(),
+              opts :: keyword()
+            ) :: :ok | {:ok, term()} | {:error, term()}
 
   @doc """
   Fetches the bytes behind an inbound media reference.
@@ -220,6 +247,10 @@ defmodule Jido.Chat.Adapter do
                       fetch_metadata: 2,
                       fetch_thread: 2,
                       fetch_message: 3,
+                      get_user: 2,
+                      fetch_subject: 2,
+                      get_thread_participants: 2,
+                      mark_as_read: 3,
                       fetch_media: 2,
                       add_reaction: 4,
                       remove_reaction: 4,
@@ -490,8 +521,10 @@ defmodule Jido.Chat.Adapter do
   @spec fetch_thread(module(), external_room_id(), keyword()) :: thread_result()
   def fetch_thread(adapter_module, external_room_id, opts \\ []) do
     if callback_exported?(adapter_module, :fetch_thread, 2) do
-      with {:ok, thread} <- adapter_module.fetch_thread(external_room_id, opts) do
-        {:ok, normalize_thread(adapter_module, thread, external_room_id, opts)}
+      case adapter_module.fetch_thread(external_room_id, opts) do
+        {:ok, thread} -> normalize_thread_result(adapter_module, thread, external_room_id, opts)
+        {:error, _reason} = error -> error
+        _other -> {:error, :invalid_thread_result}
       end
     else
       {:ok,
@@ -514,6 +547,78 @@ defmodule Jido.Chat.Adapter do
       with {:ok, message} <-
              adapter_module.fetch_message(external_room_id, external_message_id, opts) do
         {:ok, normalize_message(adapter_module, message, opts)}
+      end
+    else
+      {:error, :unsupported}
+    end
+  end
+
+  @doc "Gets normalized provider user information when supported."
+  @spec get_user(module(), external_user_id(), keyword()) :: user_result()
+  def get_user(adapter_module, external_user_id, opts \\ []) do
+    if callback_exported?(adapter_module, :get_user, 2) do
+      case adapter_module.get_user(external_user_id, opts) do
+        {:ok, user} -> normalize_user_result(user)
+        {:error, _reason} = error -> error
+        _other -> {:error, :invalid_user_info_result}
+      end
+    else
+      {:error, :unsupported}
+    end
+  end
+
+  @doc "Fetches the normalized resource subject for a room or thread."
+  @spec fetch_subject(module(), external_room_id(), keyword()) :: subject_result()
+  def fetch_subject(adapter_module, external_room_id, opts \\ []) do
+    cond do
+      callback_exported?(adapter_module, :fetch_subject, 2) ->
+        case adapter_module.fetch_subject(external_room_id, opts) do
+          {:ok, subject} -> normalize_subject_result(subject)
+          {:error, _reason} = error -> error
+          _other -> {:error, :invalid_subject_result}
+        end
+
+      callback_exported?(adapter_module, :fetch_thread, 2) ->
+        with {:ok, thread} <- fetch_thread(adapter_module, external_room_id, opts),
+             {:ok, subject} <- explicit_thread_subject(thread) do
+          normalize_subject_result(subject)
+        end
+
+      true ->
+        {:error, :unsupported}
+    end
+  end
+
+  @doc "Gets normalized canonical participants for a room or thread."
+  @spec get_thread_participants(module(), external_room_id(), keyword()) ::
+          participants_result()
+  def get_thread_participants(adapter_module, external_room_id, opts \\ []) do
+    if callback_exported?(adapter_module, :get_thread_participants, 2) do
+      case adapter_module.get_thread_participants(external_room_id, opts) do
+        {:ok, participants} when is_list(participants) ->
+          normalize_participants_result(adapter_module, participants)
+
+        {:error, _reason} = error ->
+          error
+
+        _other ->
+          {:error, :invalid_thread_participants_result}
+      end
+    else
+      {:error, :unsupported}
+    end
+  end
+
+  @doc "Marks a provider message as read when supported."
+  @spec mark_as_read(module(), external_room_id(), external_message_id(), keyword()) ::
+          read_result()
+  def mark_as_read(adapter_module, external_room_id, external_message_id, opts \\ []) do
+    if callback_exported?(adapter_module, :mark_as_read, 3) do
+      case adapter_module.mark_as_read(external_room_id, external_message_id, opts) do
+        :ok -> :ok
+        {:ok, _receipt} -> :ok
+        {:error, _reason} = error -> error
+        _other -> {:error, :invalid_mark_as_read_result}
       end
     else
       {:error, :unsupported}
@@ -1000,6 +1105,12 @@ defmodule Jido.Chat.Adapter do
     })
   end
 
+  defp normalize_thread_result(adapter_module, thread, external_room_id, opts) do
+    {:ok, normalize_thread(adapter_module, thread, external_room_id, opts)}
+  rescue
+    _error -> {:error, :invalid_thread_result}
+  end
+
   defp normalize_message(_adapter_module, %Message{} = message, _opts), do: message
 
   defp normalize_message(adapter_module, %Incoming{} = incoming, opts),
@@ -1023,6 +1134,124 @@ defmodule Jido.Chat.Adapter do
       |> Message.new()
     end
   end
+
+  defp normalize_user_result(%UserInfo{} = user), do: {:ok, user}
+
+  defp normalize_user_result(user) when is_map(user) do
+    {:ok, UserInfo.new(user)}
+  rescue
+    _error -> {:error, :invalid_user_info_result}
+  end
+
+  defp normalize_user_result(_user), do: {:error, :invalid_user_info_result}
+
+  defp normalize_subject_result(%MessageSubject{} = subject), do: {:ok, subject}
+
+  defp normalize_subject_result(subject) when is_map(subject) do
+    {:ok, MessageSubject.new(subject)}
+  rescue
+    _error -> {:error, :invalid_subject_result}
+  end
+
+  defp normalize_subject_result(_subject), do: {:error, :invalid_subject_result}
+
+  defp explicit_thread_subject(%Thread{metadata: metadata}) when is_map(metadata) do
+    case metadata[:subject] || metadata["subject"] do
+      nil -> {:error, :unsupported}
+      subject -> {:ok, subject}
+    end
+  end
+
+  defp normalize_participants_result(adapter_module, participants) do
+    participants
+    |> Enum.reduce_while({:ok, []}, fn participant, {:ok, acc} ->
+      case normalize_participant(adapter_module, participant) do
+        {:ok, normalized} -> {:cont, {:ok, [normalized | acc]}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, normalized} -> {:ok, Enum.reverse(normalized)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp normalize_participant(_adapter_module, %Participant{} = participant),
+    do: {:ok, participant}
+
+  defp normalize_participant(adapter_module, %UserInfo{} = user) do
+    {:ok, participant_from_user(adapter_module, user)}
+  end
+
+  defp normalize_participant(adapter_module, %Author{} = author) do
+    user =
+      UserInfo.new(%{
+        id: author.user_id,
+        username: author.user_name,
+        display_name: author.full_name,
+        is_bot: author.is_bot,
+        metadata: author.metadata
+      })
+
+    {:ok, participant_from_user(adapter_module, user)}
+  rescue
+    _error -> {:error, :invalid_thread_participants_result}
+  end
+
+  defp normalize_participant(adapter_module, participant) when is_map(participant) do
+    if participant_input?(participant) do
+      {:ok, participant |> normalize_participant_attrs() |> Participant.new()}
+    else
+      {:ok, participant_from_user(adapter_module, UserInfo.new(participant))}
+    end
+  rescue
+    _error -> {:error, :invalid_thread_participants_result}
+  end
+
+  defp normalize_participant(_adapter_module, _participant),
+    do: {:error, :invalid_thread_participants_result}
+
+  defp participant_from_user(adapter_module, %UserInfo{} = user) do
+    identity =
+      %{
+        username: user.username,
+        display_name: user.display_name,
+        email: user.email,
+        avatar_url: user.avatar_url
+      }
+      |> Map.filter(fn {_key, value} -> not is_nil(value) end)
+
+    Participant.new(%{
+      id: user.id,
+      type: if(user.is_bot, do: :agent, else: :human),
+      identity: identity,
+      external_ids: %{adapter_type(adapter_module) => user.id},
+      metadata: user.metadata
+    })
+  end
+
+  defp participant_input?(participant) do
+    id = participant[:id] || participant["id"]
+    type = participant[:type] || participant["type"]
+
+    not is_nil(id) and canonical_participant_type?(type)
+  end
+
+  defp canonical_participant_type?(type), do: type in [:human, :agent, :system, "human", "agent", "system"]
+
+  defp normalize_participant_attrs(participant) do
+    type = participant[:type] || participant["type"]
+
+    participant
+    |> Map.delete("type")
+    |> Map.put(:type, normalize_participant_type(type))
+  end
+
+  defp normalize_participant_type(type) when type in [:human, :agent, :system], do: type
+  defp normalize_participant_type("human"), do: :human
+  defp normalize_participant_type("agent"), do: :agent
+  defp normalize_participant_type("system"), do: :system
+  defp normalize_participant_type(type), do: type
 
   defp normalize_message_page(
          _adapter_module,
@@ -1312,6 +1541,10 @@ defmodule Jido.Chat.Adapter do
       fetch_metadata: inferred_capability_status(adapter_module, :fetch_metadata),
       fetch_thread: inferred_capability_status(adapter_module, :fetch_thread),
       fetch_message: inferred_capability_status(adapter_module, :fetch_message),
+      get_user: inferred_capability_status(adapter_module, :get_user),
+      fetch_subject: subject_support_status(adapter_module),
+      get_thread_participants: inferred_capability_status(adapter_module, :get_thread_participants),
+      mark_as_read: inferred_capability_status(adapter_module, :mark_as_read),
       fetch_media: inferred_capability_status(adapter_module, :fetch_media),
       add_reaction: inferred_capability_status(adapter_module, :add_reaction),
       remove_reaction: inferred_capability_status(adapter_module, :remove_reaction),
@@ -1449,6 +1682,10 @@ defmodule Jido.Chat.Adapter do
   defp capability_callback(:fetch_metadata), do: {:fetch_metadata, 2}
   defp capability_callback(:fetch_thread), do: {:fetch_thread, 2}
   defp capability_callback(:fetch_message), do: {:fetch_message, 3}
+  defp capability_callback(:get_user), do: {:get_user, 2}
+  defp capability_callback(:fetch_subject), do: {:fetch_subject, 2}
+  defp capability_callback(:get_thread_participants), do: {:get_thread_participants, 2}
+  defp capability_callback(:mark_as_read), do: {:mark_as_read, 3}
   defp capability_callback(:fetch_media), do: {:fetch_media, 2}
   defp capability_callback(:add_reaction), do: {:add_reaction, 4}
   defp capability_callback(:remove_reaction), do: {:remove_reaction, 4}
@@ -1469,6 +1706,14 @@ defmodule Jido.Chat.Adapter do
 
   defp callback_exported?(adapter_module, callback, arity) do
     Code.ensure_loaded?(adapter_module) and function_exported?(adapter_module, callback, arity)
+  end
+
+  defp subject_support_status(adapter_module) do
+    cond do
+      callback_exported?(adapter_module, :fetch_subject, 2) -> :native
+      callback_exported?(adapter_module, :fetch_thread, 2) -> :fallback
+      true -> :unsupported
+    end
   end
 
   defp maybe_put_caption(opts, %PostPayload{} = payload) do

--- a/lib/jido/chat/adapter.ex
+++ b/lib/jido/chat/adapter.ex
@@ -956,7 +956,7 @@ defmodule Jido.Chat.Adapter do
                   [{capability, :missing_callback} | acc]
 
                 {:fallback, false} ->
-                  if core_fallback_capability?(capability) do
+                  if fallback_available?(adapter_module, capability) do
                     acc
                   else
                     [{capability, :missing_fallback} | acc]
@@ -1008,6 +1008,12 @@ defmodule Jido.Chat.Adapter do
   end
 
   defp core_fallback_capability?(capability), do: capability in @core_fallback_capabilities
+
+  defp fallback_available?(adapter_module, :fetch_subject),
+    do: callback_exported?(adapter_module, :fetch_thread, 2)
+
+  defp fallback_available?(_adapter_module, capability),
+    do: core_fallback_capability?(capability)
 
   defp supported_status?(status), do: status in [:native, :fallback]
 

--- a/lib/jido/chat/capabilities.ex
+++ b/lib/jido/chat/capabilities.ex
@@ -6,7 +6,7 @@ defmodule Jido.Chat.Capabilities do
   post payloads based on channel capabilities.
   """
 
-  alias Jido.Chat.{Adapter, Attachment, FileUpload, PostPayload, Postable}
+  alias Jido.Chat.{Adapter, Attachment, FileUpload, Postable, PostPayload}
   alias Jido.Chat.Content.{Audio, File, Image, Text, ToolResult, ToolUse, Video}
 
   @type capability ::
@@ -205,6 +205,7 @@ defmodule Jido.Chat.Capabilities do
     )
     |> maybe_add_capability(:typing, supported_status?(capabilities[:start_typing]))
     |> maybe_add_capability(:streaming, supported_status?(capabilities[:stream]))
+    |> maybe_add_capability(:read_receipts, supported_status?(capabilities[:mark_as_read]))
     |> maybe_add_capability(:assistant_events, supported_status?(capabilities[:assistant_events]))
   end
 

--- a/lib/jido/chat/channel_ref.ex
+++ b/lib/jido/chat/channel_ref.ex
@@ -11,11 +11,12 @@ defmodule Jido.Chat.ChannelRef do
     MessagePage,
     Modal,
     ModalResult,
-    PostPayload,
     Postable,
+    PostPayload,
     SentMessage,
-    ThreadPage,
     Thread,
+    ThreadPage,
+    UserInfo,
     Wire
   }
 
@@ -191,6 +192,14 @@ defmodule Jido.Chat.ChannelRef do
   @spec fetch_metadata(t(), keyword()) :: {:ok, ChannelInfo.t()} | {:error, term()}
   def fetch_metadata(%__MODULE__{} = channel, opts \\ []) do
     Adapter.fetch_metadata(channel.adapter, channel.external_id, opts)
+  end
+
+  @doc "Gets normalized provider user information through this channel's adapter."
+  @spec get_user(t(), String.t() | integer(), keyword()) ::
+          {:ok, UserInfo.t()} | {:error, term()}
+  def get_user(%__MODULE__{} = channel, user_id, opts \\ []) do
+    opts = Keyword.put_new(opts, :external_room_id, channel.external_id)
+    Adapter.get_user(channel.adapter, user_id, opts)
   end
 
   @doc "Fetches a page of channel-level messages when supported."

--- a/lib/jido/chat/message_subject.ex
+++ b/lib/jido/chat/message_subject.ex
@@ -1,0 +1,76 @@
+defmodule Jido.Chat.MessageSubject do
+  @moduledoc """
+  Normalized subject for a resource-backed conversation.
+
+  Examples include an issue, a pull request, or a discussion. The adapter
+  supplies the provider resource type and identifier. Core does not infer a
+  subject from a room identifier.
+  """
+
+  alias Jido.Chat.Wire
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              type: Zoi.string(min_length: 1),
+              id: Zoi.string(min_length: 1),
+              title: Zoi.string() |> Zoi.nullish(),
+              url: Zoi.string() |> Zoi.nullish(),
+              status: Zoi.string() |> Zoi.nullish(),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the Zoi schema for MessageSubject."
+  @spec schema() :: Zoi.schema()
+  def schema, do: @schema
+
+  @doc "Creates a normalized message subject from atom-keyed or string-keyed input."
+  @spec new(map()) :: t()
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_attrs()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Serializes a message subject into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = subject) do
+    subject
+    |> Map.from_struct()
+    |> Wire.to_plain()
+    |> Map.put("__type__", "message_subject")
+  end
+
+  @doc "Builds a message subject from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_attrs(attrs) do
+    %{
+      type: attrs |> value([:type, "type"]) |> normalize_text(),
+      id: attrs |> value([:id, "id"]) |> stringify(),
+      title: value(attrs, [:title, "title"]),
+      url: value(attrs, [:url, "url"]),
+      status: attrs |> value([:status, "status"]) |> normalize_text(),
+      metadata: value(attrs, [:metadata, "metadata"]) || %{}
+    }
+  end
+
+  defp value(attrs, keys), do: Enum.find_value(keys, &Map.get(attrs, &1))
+
+  defp normalize_text(nil), do: nil
+  defp normalize_text(value) when is_atom(value), do: Atom.to_string(value)
+  defp normalize_text(value) when is_binary(value), do: String.trim(value)
+  defp normalize_text(value), do: value
+
+  defp stringify(nil), do: nil
+  defp stringify(value) when is_binary(value), do: value
+  defp stringify(value), do: to_string(value)
+end

--- a/lib/jido/chat/sent_message.ex
+++ b/lib/jido/chat/sent_message.ex
@@ -3,7 +3,7 @@ defmodule Jido.Chat.SentMessage do
   Canonical sent-message handle with follow-up lifecycle operations.
   """
 
-  alias Jido.Chat.{Adapter, Attachment, Author, Emoji, PostPayload, Postable, Response, Wire}
+  alias Jido.Chat.{Adapter, Attachment, Author, Emoji, Postable, PostPayload, Response, Wire}
 
   @schema Zoi.struct(
             __MODULE__,
@@ -100,6 +100,35 @@ defmodule Jido.Chat.SentMessage do
       emoji,
       merge_opts(sent, opts)
     )
+  end
+
+  @doc "Marks this provider message as read. Repeated calls are safe when the adapter is compliant."
+  @spec mark_as_read(t(), keyword()) :: :ok | {:error, term()}
+  def mark_as_read(%__MODULE__{} = sent, opts \\ []) do
+    case sent.response.external_message_id do
+      message_id when is_binary(message_id) ->
+        if String.trim(message_id) == "" do
+          {:error, :missing_external_message_id}
+        else
+          Adapter.mark_as_read(
+            sent.adapter,
+            sent.external_room_id,
+            message_id,
+            merge_opts(sent, opts)
+          )
+        end
+
+      message_id when is_integer(message_id) ->
+        Adapter.mark_as_read(
+          sent.adapter,
+          sent.external_room_id,
+          message_id,
+          merge_opts(sent, opts)
+        )
+
+      _ ->
+        {:error, :missing_external_message_id}
+    end
   end
 
   @doc "Serializes the sent message into a plain map with type marker."

--- a/lib/jido/chat/serialization.ex
+++ b/lib/jido/chat/serialization.ex
@@ -5,8 +5,8 @@ defmodule Jido.Chat.Serialization do
     ActionEvent,
     AssistantContextChangedEvent,
     AssistantThreadStartedEvent,
-    Card,
     CapabilityMatrix,
+    Card,
     ChannelRef,
     EventEnvelope,
     FileUpload,
@@ -16,11 +16,12 @@ defmodule Jido.Chat.Serialization do
     Message,
     MessageDeletedEvent,
     MessageUpdatedEvent,
+    MessageSubject,
     Modal,
     ModalCloseEvent,
+    ModalResponse,
     ModalResult,
     ModalSubmitEvent,
-    ModalResponse,
     PostPayload,
     ReactionEvent,
     ReplyContext,
@@ -28,6 +29,7 @@ defmodule Jido.Chat.Serialization do
     SlashCommandEvent,
     StreamChunk,
     Thread,
+    UserInfo,
     WebhookRequest,
     WebhookResponse,
     Wire
@@ -112,6 +114,8 @@ defmodule Jido.Chat.Serialization do
   def revive(%{"__type__" => "modal_element"} = map), do: Jido.Chat.Modal.Element.from_map(map)
   def revive(%{"__type__" => "message"} = map), do: Message.from_map(map)
   def revive(%{"__type__" => "reply_context"} = map), do: ReplyContext.from_map(map)
+  def revive(%{"__type__" => "user_info"} = map), do: UserInfo.from_map(map)
+  def revive(%{"__type__" => "message_subject"} = map), do: MessageSubject.from_map(map)
   def revive(%{"__type__" => "file_upload"} = map), do: FileUpload.from_map(map)
   def revive(%{"__type__" => "post_payload"} = map), do: PostPayload.from_map(map)
   def revive(%{"__type__" => "sent_message"} = map), do: SentMessage.from_map(map)

--- a/lib/jido/chat/thread.ex
+++ b/lib/jido/chat/thread.ex
@@ -11,10 +11,12 @@ defmodule Jido.Chat.Thread do
     FileUpload,
     Message,
     MessagePage,
+    MessageSubject,
     Modal,
     ModalResult,
-    PostPayload,
+    Participant,
     Postable,
+    PostPayload,
     SentMessage,
     Wire
   }
@@ -247,6 +249,26 @@ defmodule Jido.Chat.Thread do
     with {:ok, %MessagePage{} = page} <- messages(thread, opts) do
       {:ok, page.messages}
     end
+  end
+
+  @doc "Fetches the normalized resource subject for this thread."
+  @spec fetch_subject(t(), keyword()) :: {:ok, MessageSubject.t()} | {:error, term()}
+  def fetch_subject(%__MODULE__{} = thread, opts \\ []) do
+    Adapter.fetch_subject(
+      thread.adapter,
+      thread.external_room_id,
+      with_thread_opts(thread, opts)
+    )
+  end
+
+  @doc "Gets normalized canonical participants for this thread."
+  @spec participants(t(), keyword()) :: {:ok, [Participant.t()]} | {:error, term()}
+  def participants(%__MODULE__{} = thread, opts \\ []) do
+    Adapter.get_thread_participants(
+      thread.adapter,
+      thread.external_room_id,
+      with_thread_opts(thread, opts)
+    )
   end
 
   @doc "Returns a lazy stream over thread messages using cursor pagination."

--- a/lib/jido/chat/user_info.ex
+++ b/lib/jido/chat/user_info.ex
@@ -1,0 +1,73 @@
+defmodule Jido.Chat.UserInfo do
+  @moduledoc """
+  Normalized provider user information.
+
+  The `id` is the user identifier from one adapter. It is not a
+  cross-platform identity. Adapters and runtimes can cache this data, but
+  `jido_chat` does not provide a global user cache.
+  """
+
+  alias Jido.Chat.Wire
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              id: Zoi.string(min_length: 1),
+              username: Zoi.string() |> Zoi.nullish(),
+              display_name: Zoi.string() |> Zoi.nullish(),
+              email: Zoi.string() |> Zoi.nullish(),
+              avatar_url: Zoi.string() |> Zoi.nullish(),
+              is_bot: Zoi.boolean() |> Zoi.default(false),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the Zoi schema for UserInfo."
+  @spec schema() :: Zoi.schema()
+  def schema, do: @schema
+
+  @doc "Creates normalized user information from atom-keyed or string-keyed input."
+  @spec new(map()) :: t()
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_attrs()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Serializes user information into a plain map with a type marker."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = user) do
+    user
+    |> Map.from_struct()
+    |> Wire.to_plain()
+    |> Map.put("__type__", "user_info")
+  end
+
+  @doc "Builds user information from serialized map data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+
+  defp normalize_attrs(attrs) do
+    %{
+      id: attrs |> value([:id, "id", :user_id, "user_id"]) |> stringify(),
+      username: value(attrs, [:username, "username", :user_name, "user_name"]),
+      display_name: value(attrs, [:display_name, "display_name", :full_name, "full_name", :name, "name"]),
+      email: value(attrs, [:email, "email"]),
+      avatar_url: value(attrs, [:avatar_url, "avatar_url"]),
+      is_bot: value(attrs, [:is_bot, "is_bot"]) || false,
+      metadata: value(attrs, [:metadata, "metadata"]) || %{}
+    }
+  end
+
+  defp value(attrs, keys), do: Enum.find_value(keys, &Map.get(attrs, &1))
+
+  defp stringify(nil), do: nil
+  defp stringify(value) when is_binary(value), do: value
+  defp stringify(value), do: to_string(value)
+end

--- a/test/jido/chat/resource_contracts_test.exs
+++ b/test/jido/chat/resource_contracts_test.exs
@@ -1,0 +1,506 @@
+defmodule Jido.Chat.ResourceContractsTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Chat.{
+    Adapter,
+    Capabilities,
+    ChannelRef,
+    MessageSubject,
+    Participant,
+    Response,
+    SentMessage,
+    Thread,
+    UserInfo
+  }
+
+  defmodule NativeAdapter do
+    use Adapter
+
+    @impl true
+    def channel_type, do: :native_resource
+
+    @impl true
+    def transform_incoming(_payload), do: {:error, :not_implemented}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok, Response.new(%{external_message_id: "m1", external_room_id: room_id})}
+    end
+
+    @impl true
+    def get_user(user_id, opts) do
+      send(self(), {:get_user, user_id, opts})
+
+      {:ok,
+       %{
+         "id" => user_id,
+         "username" => "octocat",
+         "display_name" => "The Octocat",
+         "email" => "octocat@example.com",
+         "avatar_url" => "https://example.com/octocat.png",
+         "metadata" => %{"provider" => "github"}
+       }}
+    end
+
+    @impl true
+    def fetch_subject(room_id, opts) do
+      send(self(), {:fetch_subject, room_id, opts})
+
+      {:ok,
+       %{
+         "type" => "pull_request",
+         "id" => 38,
+         "title" => "Add resource contracts",
+         "url" => "https://github.com/agentjido/jido_chat/pull/38",
+         "status" => "open",
+         "metadata" => %{"draft" => false}
+       }}
+    end
+
+    @impl true
+    def get_thread_participants(room_id, opts) do
+      send(self(), {:get_thread_participants, room_id, opts})
+
+      {:ok,
+       [
+         %{
+           "id" => "u1",
+           "username" => "octocat",
+           "display_name" => "The Octocat"
+         },
+         Participant.new(%{
+           id: "agent-1",
+           type: :agent,
+           identity: %{display_name: "Review Bot"},
+           external_ids: %{native_resource: "bot-1"}
+         }),
+         %{
+           "id" => "system-1",
+           "type" => "system",
+           "identity" => %{"display_name" => "GitHub"},
+           "external_ids" => %{"native_resource" => "system-1"}
+         },
+         %{
+           "id" => "provider-bot-1",
+           "type" => "Bot",
+           "username" => "provider-bot",
+           "is_bot" => true
+         }
+       ]}
+    end
+
+    @impl true
+    def mark_as_read(room_id, message_id, opts) do
+      send(self(), {:mark_as_read, room_id, message_id, opts})
+      {:ok, %{receipt_id: "receipt-1"}}
+    end
+
+    @impl true
+    def capabilities do
+      %{
+        send_message: :native,
+        get_user: :native,
+        fetch_subject: :native,
+        get_thread_participants: :native,
+        mark_as_read: :native
+      }
+    end
+  end
+
+  defmodule SubjectFallbackAdapter do
+    use Adapter
+
+    @impl true
+    def channel_type, do: :subject_fallback
+
+    @impl true
+    def transform_incoming(_payload), do: {:error, :not_implemented}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok, Response.new(%{external_message_id: "m1", external_room_id: room_id})}
+    end
+
+    @impl true
+    def fetch_thread(room_id, opts) do
+      send(self(), {:fetch_thread_for_subject, room_id, opts})
+
+      {:ok,
+       %{
+         id: "subject_fallback:#{room_id}:#{opts[:external_thread_id]}",
+         external_room_id: room_id,
+         external_thread_id: opts[:external_thread_id],
+         metadata: %{
+           subject: %{
+             type: :issue,
+             id: "38",
+             title: "Add resource contracts",
+             url: "https://github.com/agentjido/jido_chat/issues/38",
+             status: :open,
+             metadata: %{labels: ["enhancement"]}
+           }
+         }
+       }}
+    end
+
+    @impl true
+    def capabilities, do: %{send_message: :native, fetch_thread: :native, fetch_subject: :fallback}
+  end
+
+  defmodule MalformedSubjectFallbackAdapter do
+    use Adapter
+
+    @impl true
+    def channel_type, do: :malformed_subject_fallback
+
+    @impl true
+    def transform_incoming(_payload), do: {:error, :not_implemented}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok, Response.new(%{external_message_id: "m1", external_room_id: room_id})}
+    end
+
+    @impl true
+    def fetch_thread(room_id, opts) do
+      send(self(), {:fetch_malformed_thread_for_subject, room_id, opts})
+      {:ok, :invalid}
+    end
+
+    @impl true
+    def capabilities, do: %{send_message: :native, fetch_thread: :native, fetch_subject: :fallback}
+  end
+
+  defmodule UnsupportedAdapter do
+    use Adapter
+
+    @impl true
+    def channel_type, do: :unsupported_resource
+
+    @impl true
+    def transform_incoming(_payload), do: {:error, :not_implemented}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok, Response.new(%{external_message_id: "m1", external_room_id: room_id})}
+    end
+  end
+
+  defmodule InvalidDeclarationAdapter do
+    use Adapter
+
+    @impl true
+    def channel_type, do: :invalid_resource
+
+    @impl true
+    def transform_incoming(_payload), do: {:error, :not_implemented}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok, Response.new(%{external_message_id: "m1", external_room_id: room_id})}
+    end
+
+    @impl true
+    def capabilities do
+      %{
+        send_message: :native,
+        get_user: :native,
+        fetch_subject: :native,
+        get_thread_participants: :native,
+        mark_as_read: :native
+      }
+    end
+  end
+
+  defmodule ProviderErrorAdapter do
+    use Adapter
+
+    @impl true
+    def channel_type, do: :provider_error
+
+    @impl true
+    def transform_incoming(_payload), do: {:error, :not_implemented}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok, Response.new(%{external_message_id: "m1", external_room_id: room_id})}
+    end
+
+    @impl true
+    def get_user(_user_id, _opts), do: {:error, {:provider_error, 404}}
+
+    @impl true
+    def fetch_subject(_room_id, _opts), do: {:error, {:provider_error, 403}}
+
+    @impl true
+    def get_thread_participants(_room_id, _opts), do: {:error, {:provider_error, 429}}
+
+    @impl true
+    def mark_as_read(_room_id, _message_id, _opts), do: {:error, {:provider_error, 503}}
+  end
+
+  defmodule InvalidResultAdapter do
+    use Adapter
+
+    @impl true
+    def channel_type, do: :invalid_result
+
+    @impl true
+    def transform_incoming(_payload), do: {:error, :not_implemented}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok, Response.new(%{external_message_id: "m1", external_room_id: room_id})}
+    end
+
+    @impl true
+    def get_user(_user_id, _opts), do: {:ok, %{}}
+
+    @impl true
+    def fetch_subject(_room_id, _opts), do: {:ok, %{}}
+
+    @impl true
+    def get_thread_participants(_room_id, _opts), do: {:ok, :not_a_list}
+
+    @impl true
+    def mark_as_read(_room_id, _message_id, _opts), do: {:ok}
+  end
+
+  test "UserInfo normalizes atom and string keyed input" do
+    assert %UserInfo{
+             id: "42",
+             username: "ada",
+             display_name: "Ada Lovelace",
+             is_bot: false
+           } =
+             UserInfo.new(%{
+               user_id: 42,
+               user_name: "ada",
+               full_name: "Ada Lovelace"
+             })
+
+    assert %UserInfo{id: "u2", username: "grace", is_bot: true} =
+             UserInfo.new(%{"id" => "u2", "username" => "grace", "is_bot" => true})
+  end
+
+  test "MessageSubject normalizes atom and string keyed input" do
+    assert %MessageSubject{
+             type: "pull_request",
+             id: "38",
+             title: "Resource contracts",
+             status: "open",
+             metadata: %{"draft" => false}
+           } =
+             MessageSubject.new(%{
+               "type" => "pull_request",
+               "id" => 38,
+               "title" => "Resource contracts",
+               "url" => "https://example.com/pull/38",
+               "status" => "open",
+               "metadata" => %{"draft" => false}
+             })
+  end
+
+  test "native callbacks return normalized public models" do
+    assert {:ok, %UserInfo{id: "u1", username: "octocat"} = user} =
+             Adapter.get_user(NativeAdapter, "u1", scope: :test)
+
+    assert user.metadata == %{"provider" => "github"}
+    assert_received {:get_user, "u1", scope: :test}
+
+    assert {:ok, %MessageSubject{type: "pull_request", id: "38", status: "open"}} =
+             Adapter.fetch_subject(NativeAdapter, "repo", external_thread_id: "38")
+
+    assert_received {:fetch_subject, "repo", external_thread_id: "38"}
+
+    assert {:ok,
+            [
+              %Participant{} = user_participant,
+              %Participant{} = agent_participant,
+              %Participant{} = system_participant,
+              %Participant{} = provider_bot_participant
+            ]} =
+             Adapter.get_thread_participants(
+               NativeAdapter,
+               "repo",
+               external_thread_id: "38"
+             )
+
+    assert user_participant.id == "u1"
+    assert user_participant.type == :human
+    assert user_participant.identity.username == "octocat"
+    assert user_participant.external_ids.native_resource == "u1"
+    assert agent_participant.id == "agent-1"
+    assert system_participant.type == :system
+    assert provider_bot_participant.type == :agent
+
+    assert_received {:get_thread_participants, "repo", external_thread_id: "38"}
+
+    assert :ok = Adapter.mark_as_read(NativeAdapter, "repo", "message-1", source: :test)
+    assert_received {:mark_as_read, "repo", "message-1", source: :test}
+    assert :read_receipts in Capabilities.channel_capabilities(NativeAdapter)
+  end
+
+  test "fetch_subject uses only an explicit subject from native thread metadata" do
+    assert Adapter.capabilities(SubjectFallbackAdapter).fetch_subject == :fallback
+    assert :ok = Adapter.validate_capabilities(SubjectFallbackAdapter)
+
+    assert {:ok, %MessageSubject{type: "issue", id: "38", status: "open"}} =
+             Adapter.fetch_subject(
+               SubjectFallbackAdapter,
+               "agentjido/jido_chat",
+               external_thread_id: "38"
+             )
+
+    assert_received {:fetch_thread_for_subject, "agentjido/jido_chat", external_thread_id: "38"}
+  end
+
+  test "fetch_subject returns a stable error when its thread fallback is malformed" do
+    assert {:error, :invalid_thread_result} =
+             Adapter.fetch_subject(
+               MalformedSubjectFallbackAdapter,
+               "agentjido/jido_chat",
+               external_thread_id: "38"
+             )
+
+    assert_received {
+      :fetch_malformed_thread_for_subject,
+      "agentjido/jido_chat",
+      external_thread_id: "38"
+    }
+  end
+
+  test "unsupported callbacks return an explicit unsupported error" do
+    assert Adapter.capabilities(UnsupportedAdapter).get_user == :unsupported
+    assert Adapter.capabilities(UnsupportedAdapter).fetch_subject == :unsupported
+    assert Adapter.capabilities(UnsupportedAdapter).get_thread_participants == :unsupported
+    assert Adapter.capabilities(UnsupportedAdapter).mark_as_read == :unsupported
+
+    assert {:error, :unsupported} = Adapter.get_user(UnsupportedAdapter, "u1")
+    assert {:error, :unsupported} = Adapter.fetch_subject(UnsupportedAdapter, "room")
+    assert {:error, :unsupported} = Adapter.get_thread_participants(UnsupportedAdapter, "room")
+    assert {:error, :unsupported} = Adapter.mark_as_read(UnsupportedAdapter, "room", "m1")
+  end
+
+  test "capability validation detects false native declarations" do
+    assert {:error, {:invalid_capability_matrix, mismatches}} =
+             Adapter.validate_capabilities(InvalidDeclarationAdapter)
+
+    assert {:get_user, :missing_callback} in mismatches
+    assert {:fetch_subject, :missing_callback} in mismatches
+    assert {:get_thread_participants, :missing_callback} in mismatches
+    assert {:mark_as_read, :missing_callback} in mismatches
+  end
+
+  test "provider errors pass through all safe wrappers" do
+    assert {:error, {:provider_error, 404}} = Adapter.get_user(ProviderErrorAdapter, "u1")
+    assert {:error, {:provider_error, 403}} = Adapter.fetch_subject(ProviderErrorAdapter, "room")
+
+    assert {:error, {:provider_error, 429}} =
+             Adapter.get_thread_participants(ProviderErrorAdapter, "room")
+
+    assert {:error, {:provider_error, 503}} =
+             Adapter.mark_as_read(ProviderErrorAdapter, "room", "m1")
+  end
+
+  test "invalid callback success values return stable contract errors" do
+    assert {:error, :invalid_user_info_result} = Adapter.get_user(InvalidResultAdapter, "u1")
+    assert {:error, :invalid_subject_result} = Adapter.fetch_subject(InvalidResultAdapter, "room")
+
+    assert {:error, :invalid_thread_participants_result} =
+             Adapter.get_thread_participants(InvalidResultAdapter, "room")
+
+    assert {:error, :invalid_mark_as_read_result} =
+             Adapter.mark_as_read(InvalidResultAdapter, "room", "m1")
+  end
+
+  test "channel, thread, and sent-message helpers route normalized operations" do
+    channel =
+      ChannelRef.new(%{
+        id: "native_resource:repo",
+        adapter_name: :native_resource,
+        adapter: NativeAdapter,
+        external_id: "repo"
+      })
+
+    thread =
+      Thread.new(%{
+        id: "native_resource:repo:38",
+        adapter_name: :native_resource,
+        adapter: NativeAdapter,
+        external_room_id: "repo",
+        external_thread_id: "38"
+      })
+
+    sent =
+      SentMessage.new(%{
+        id: "message-1",
+        thread_id: thread.id,
+        adapter: NativeAdapter,
+        external_room_id: "repo",
+        response: Response.new(%{external_message_id: "message-1", external_room_id: "repo"}),
+        default_opts: [external_thread_id: "38"]
+      })
+
+    assert {:ok, %UserInfo{id: "u1"}} = ChannelRef.get_user(channel, "u1")
+    assert_received {:get_user, "u1", external_room_id: "repo"}
+
+    assert {:ok, %MessageSubject{id: "38"}} = Thread.fetch_subject(thread)
+    assert_received {:fetch_subject, "repo", thread_id: "38"}
+
+    assert {:ok, [%Participant{}, %Participant{}, %Participant{}, %Participant{}]} =
+             Thread.participants(thread)
+
+    assert_received {:get_thread_participants, "repo", thread_id: "38"}
+
+    assert :ok = SentMessage.mark_as_read(sent)
+    assert_received {:mark_as_read, "repo", "message-1", external_thread_id: "38"}
+
+    assert :ok = SentMessage.mark_as_read(sent)
+  end
+
+  test "SentMessage.mark_as_read requires a provider external message id" do
+    missing_external_id =
+      SentMessage.new(%{
+        id: "generated-local-id",
+        thread_id: "native_resource:repo:38",
+        adapter: NativeAdapter,
+        external_room_id: "repo",
+        response: Response.new(%{external_room_id: "repo"})
+      })
+
+    blank_external_id =
+      SentMessage.new(%{
+        id: "generated-local-id",
+        thread_id: "native_resource:repo:38",
+        adapter: NativeAdapter,
+        external_room_id: "repo",
+        response: Response.new(%{external_message_id: "   ", external_room_id: "repo"})
+      })
+
+    assert {:error, :missing_external_message_id} = SentMessage.mark_as_read(missing_external_id)
+    refute_received {:mark_as_read, _, _, _}
+
+    assert {:error, :missing_external_message_id} = SentMessage.mark_as_read(blank_external_id)
+    refute_received {:mark_as_read, _, _, _}
+  end
+
+  test "UserInfo and MessageSubject serialize and revive" do
+    user = UserInfo.new(%{id: "u1", username: "octocat", metadata: %{provider: :github}})
+
+    subject =
+      MessageSubject.new(%{
+        type: :issue,
+        id: "38",
+        title: "Add resource contracts",
+        status: :open,
+        metadata: %{labels: ["enhancement"]}
+      })
+
+    assert %UserInfo{id: "u1", username: "octocat"} =
+             user |> UserInfo.to_map() |> Jido.Chat.reviver().()
+
+    assert %MessageSubject{type: "issue", id: "38", status: "open"} =
+             subject |> MessageSubject.to_map() |> Jido.Chat.reviver().()
+  end
+end


### PR DESCRIPTION
## Summary

- add normalized `UserInfo` and `MessageSubject` models
- add adapter contracts for user lookup, subject lookup, thread participants, and read receipts
- add handle helpers and capability declarations for the four operations
- preserve explicit unsupported and provider-error results

## Implementation

- normalize native and fallback adapter results into core models
- expose subject and participant helpers through channel and thread handles
- expose read-receipt handling through sent messages
- require a provider external message ID before a read receipt can be sent
- return a stable error for malformed thread fallback results
- serialize and revive the new models

## Validation

- `mix test test/jido/chat/resource_contracts_test.exs` — 12 passed
- `mix test` — 143 passed
- `mix quality` — passed
- `mix format --check-formatted` — passed
- `git diff --check` — passed

Related: agentjido/jido_chat#38

## Post-Deploy Monitoring & Validation

- update one downstream adapter to the released core version and run its direct test suite
- verify native, fallback, unsupported, and provider-error paths for all four operations
- confirm read receipts use only provider message IDs and remain idempotent
- watch for malformed provider results that raise, local `jch_*` IDs sent to providers, or capability declarations that do not match callbacks
- hold the core release if any of these signals occur

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
