### PR TITLE
feat(concurrency): add bounded burst handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ upload hook used by the core fallback path for single-upload posts.
 
 1. Implement the required `Jido.Chat.Adapter` callbacks for your transport.
 2. Declare explicit surface support through `capabilities/0` instead of relying on callback inference.
-3. If you build directly on the lightweight `Jido.Chat` facade and ship a custom `Jido.Chat.StateAdapter`, implement `lock/5`, `release_lock/3`, and `force_release_lock/2`, and persist `locks` plus `pending_locks` in snapshots.
+3. If you build directly on the lightweight `Jido.Chat` facade and ship a custom `Jido.Chat.StateAdapter`, implement `lock/5`, `release_lock/3`, and `force_release_lock/2`, and persist `locks` plus `pending_locks` in snapshots. To support bounded queue and burst controls, also implement the optional `lock_with_options/6` and `drain_lock/5` callbacks. Existing adapters can continue to use the original callbacks.
 4. Treat `Jido.Chat.PostPayload` as the canonical outbound contract. It can now carry text, markdown, raw payloads, cards, streams, attachments, and `FileUpload` values.
 5. Preserve compatibility with legacy inbound payloads. Existing messages, wire maps, and adapter payloads do not need `author` or reply fields; normalization keeps their useful values and leaves the enriched fields unset.
 6. Treat `Author.id` as trusted, framework-neutral stable identity. Only pass it through when an application/runtime resolver supplied it. Never derive it from a provider ID, display name, username, or email, and do not make provider profile calls to resolve it for this contract.
@@ -119,6 +119,7 @@ payload =
 ## Scope Notes
 
 - `Jido.Chat` includes lightweight subscription/state/concurrency hooks today so the core facade can run locally without a larger runtime.
+- Burst and debounce timing is caller-driven. The core stores bounded pending state and exposes `drain_lock/4`; it does not start a timer or a supervised process.
 - Production ingress, retries, room/session state, and supervised delivery orchestration belong in `jido_messaging`, not this package.
 - The AI conversion helpers are structurally compatible with Chat SDK / AI SDK message shapes, but they keep Elixir-native naming and callback conventions.
 

--- a/lib/jido/chat/concurrency.ex
+++ b/lib/jido/chat/concurrency.ex
@@ -1,22 +1,49 @@
 defmodule Jido.Chat.Concurrency do
   @moduledoc """
   Chat-level overlapping-message concurrency configuration.
+
+  The model is a pure state protocol. It does not start timers or processes.
+  Callers supply `now_ms` when they need deterministic timing and call
+  `Jido.Chat.drain_lock/4` after the configured idle window.
+
+  Queue and burst entries default to a size of 10 and a lifetime of 90 seconds.
+  Burst and debounce idle windows default to 1.5 seconds. Concurrent handlers
+  are unbounded unless `max_concurrent` is set.
   """
 
-  @strategies [:reject, :queue, :debounce, :concurrent]
+  @strategies [:reject, :queue, :debounce, :burst, :concurrent]
+  @overflow_policies [:drop_oldest, :drop_newest]
+  @lock_scopes [:thread, :channel]
 
   @schema Zoi.struct(
             __MODULE__,
             %{
               strategy: Zoi.enum(@strategies) |> Zoi.default(:reject),
+              debounce_ms: Zoi.integer() |> Zoi.min(0) |> Zoi.default(1_500),
+              max_queue_size: Zoi.integer() |> Zoi.min(1) |> Zoi.default(10),
+              queue_entry_ttl_ms: Zoi.integer() |> Zoi.min(1) |> Zoi.default(90_000),
+              overflow_policy: Zoi.enum(@overflow_policies) |> Zoi.default(:drop_oldest),
+              lock_scope: Zoi.enum(@lock_scopes) |> Zoi.default(:thread),
+              max_concurrent: Zoi.integer() |> Zoi.min(1) |> Zoi.nullish(),
               metadata: Zoi.map() |> Zoi.default(%{})
             },
             coerce: true
           )
 
-  @type strategy :: :reject | :queue | :debounce | :concurrent
+  @type strategy :: :reject | :queue | :debounce | :burst | :concurrent
+  @type overflow_policy :: :drop_oldest | :drop_newest
+  @type lock_scope :: :thread | :channel
   @type t :: unquote(Zoi.type_spec(@schema))
-  @type pending_entry :: %{owner: String.t(), strategy: strategy(), metadata: map()}
+
+  @type pending_entry :: %{
+          owner: String.t(),
+          strategy: strategy(),
+          metadata: map(),
+          enqueued_at: non_neg_integer(),
+          expires_at: pos_integer(),
+          ready_at: non_neg_integer(),
+          conversation_key: String.t()
+        }
 
   @enforce_keys Zoi.Struct.enforce_keys(@schema)
   defstruct Zoi.Struct.struct_fields(@schema)
@@ -28,5 +55,75 @@ defmodule Jido.Chat.Concurrency do
   @spec new(t() | map() | keyword()) :: t()
   def new(%__MODULE__{} = config), do: config
   def new(opts) when is_list(opts), do: opts |> Map.new() |> new()
-  def new(opts) when is_map(opts), do: Jido.Chat.Schema.parse!(__MODULE__, @schema, opts)
+
+  def new(opts) when is_map(opts) do
+    normalized = normalize_aliases(opts)
+    Jido.Chat.Schema.parse!(__MODULE__, @schema, normalized)
+  end
+
+  @doc "Returns the lock key for the configured thread or channel scope."
+  @spec lock_key(t() | map() | keyword(), String.t(), String.t() | nil) :: String.t()
+  def lock_key(config, thread_id, channel_id \\ nil) when is_binary(thread_id) do
+    case new(config).lock_scope do
+      :channel when is_binary(channel_id) and channel_id != "" -> channel_id
+      _ -> thread_id
+    end
+  end
+
+  @doc "Returns a deterministic message context for drained pending entries."
+  @spec message_context([map()]) :: Jido.Chat.MessageContext.t()
+  def message_context(entries) when is_list(entries) do
+    Jido.Chat.MessageContext.new(
+      skipped: Enum.map(entries, &message_from_entry/1),
+      total_count: length(entries) + 1
+    )
+  end
+
+  defp normalize_aliases(opts) do
+    %{
+      strategy: value(opts, [:strategy, "strategy"], :reject) |> normalize_enum(),
+      debounce_ms: value(opts, [:debounce_ms, "debounce_ms", "debounceMs", :idle_ms, "idle_ms"]),
+      max_queue_size: value(opts, [:max_queue_size, "max_queue_size", "maxQueueSize"]),
+      queue_entry_ttl_ms: value(opts, [:queue_entry_ttl_ms, "queue_entry_ttl_ms", "queueEntryTtlMs"]),
+      overflow_policy:
+        value(opts, [
+          :overflow_policy,
+          "overflow_policy",
+          :on_queue_full,
+          "on_queue_full",
+          "onQueueFull"
+        ])
+        |> normalize_enum(),
+      lock_scope: value(opts, [:lock_scope, "lock_scope", "lockScope"]) |> normalize_enum(),
+      max_concurrent: value(opts, [:max_concurrent, "max_concurrent", "maxConcurrent"]),
+      metadata: value(opts, [:metadata, "metadata"], %{})
+    }
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+
+  defp value(opts, keys, default \\ nil) do
+    Enum.find_value(keys, default, fn key ->
+      if Map.has_key?(opts, key), do: {:found, Map.get(opts, key)}
+    end)
+    |> case do
+      {:found, value} -> value
+      value -> value
+    end
+  end
+
+  defp normalize_enum(value) when is_binary(value) do
+    value
+    |> String.replace("-", "_")
+    |> String.to_existing_atom()
+  rescue
+    ArgumentError -> value
+  end
+
+  defp normalize_enum(value), do: value
+
+  defp message_from_entry(entry) do
+    metadata = entry[:metadata] || entry["metadata"] || %{}
+    metadata[:message] || metadata["message"] || metadata[:incoming] || metadata["incoming"] || metadata
+  end
 end

--- a/lib/jido/chat/event_router.ex
+++ b/lib/jido/chat/event_router.ex
@@ -3,11 +3,17 @@ defmodule Jido.Chat.EventRouter do
 
   alias Jido.Chat.{EventEnvelope, EventNormalizer, HandlerDispatch, Incoming, Thread}
 
-  @spec process_message(map(), atom(), String.t(), Incoming.t() | map(), (map(), Incoming.t(), String.t() ->
-                                                                            Thread.t())) ::
+  @spec process_message(
+          map(),
+          atom(),
+          String.t(),
+          Incoming.t() | map(),
+          (map(), Incoming.t(), String.t() -> Thread.t()),
+          Jido.Chat.MessageContext.t() | nil
+        ) ::
           {:ok, map(), Incoming.t()} | {:error, term()}
-  def process_message(chat, adapter_name, thread_id, incoming, build_thread) do
-    HandlerDispatch.process_message(chat, adapter_name, thread_id, incoming, build_thread)
+  def process_message(chat, adapter_name, thread_id, incoming, build_thread, context \\ nil) do
+    HandlerDispatch.process_message(chat, adapter_name, thread_id, incoming, build_thread, context)
   end
 
   @spec run_event_handlers(map(), list(), term()) :: map()

--- a/lib/jido/chat/handler_dispatch.ex
+++ b/lib/jido/chat/handler_dispatch.ex
@@ -9,13 +9,20 @@ defmodule Jido.Chat.HandlerDispatch do
     ModalSubmitEvent,
     ReactionEvent,
     SlashCommandEvent,
+    MessageContext,
     Thread
   }
 
-  @spec process_message(map(), atom(), String.t(), Incoming.t() | map(), (map(), Incoming.t(), String.t() ->
-                                                                            Thread.t())) ::
+  @spec process_message(
+          map(),
+          atom(),
+          String.t(),
+          Incoming.t() | map(),
+          (map(), Incoming.t(), String.t() -> Thread.t()),
+          MessageContext.t() | nil
+        ) ::
           {:ok, map(), Incoming.t()} | {:error, term()}
-  def process_message(chat, adapter_name, thread_id, incoming, build_thread)
+  def process_message(chat, adapter_name, thread_id, incoming, build_thread, context \\ nil)
       when is_map(chat) and is_atom(adapter_name) and is_binary(thread_id) and
              is_function(build_thread, 3) do
     with {:ok, incoming} <- EventNormalizer.ensure_incoming(incoming) do
@@ -26,7 +33,7 @@ defmodule Jido.Chat.HandlerDispatch do
       else
         chat = mark_dedupe(chat, dedupe_key)
         thread = build_thread.(chat, incoming, thread_id)
-        routed_chat = route_handlers(chat, thread, incoming)
+        routed_chat = route_handlers(chat, thread, incoming, context)
         {:ok, routed_chat, incoming}
       end
     end
@@ -55,37 +62,56 @@ defmodule Jido.Chat.HandlerDispatch do
 
   defp mark_dedupe(chat, key), do: Jido.Chat.mark_dedupe(chat, key)
 
-  defp route_handlers(chat, %Thread{} = thread, %Incoming{} = incoming) do
+  defp route_handlers(chat, %Thread{} = thread, %Incoming{} = incoming, context) do
     cond do
       subscribed?(chat, thread.id) ->
-        run_handlers(chat, chat.handlers.subscribed, thread, incoming)
+        run_handlers(chat, chat.handlers.subscribed, thread, incoming, context)
 
       mentioned?(chat, incoming) ->
-        run_handlers(chat, chat.handlers.mention, thread, incoming)
+        run_handlers(chat, chat.handlers.mention, thread, incoming, context)
 
       true ->
-        run_message_handlers(chat, thread, incoming)
+        run_message_handlers(chat, thread, incoming, context)
     end
   end
 
-  defp run_message_handlers(chat, %Thread{} = thread, %Incoming{} = incoming) do
+  defp run_message_handlers(chat, %Thread{} = thread, %Incoming{} = incoming, context) do
     text = incoming.text || ""
 
     Enum.reduce(chat.handlers.message, chat, fn {pattern, handler}, acc ->
       if Regex.match?(pattern, text) do
-        run_handler(acc, handler, thread, incoming)
+        run_handler(acc, handler, thread, incoming, context)
       else
         acc
       end
     end)
   end
 
-  defp run_handlers(chat, handlers, %Thread{} = thread, %Incoming{} = incoming) do
-    Enum.reduce(handlers, chat, fn handler, acc -> run_handler(acc, handler, thread, incoming) end)
+  defp run_handlers(chat, handlers, %Thread{} = thread, %Incoming{} = incoming, context) do
+    Enum.reduce(handlers, chat, fn handler, acc ->
+      run_handler(acc, handler, thread, incoming, context)
+    end)
   end
 
-  defp run_handler(chat, handler, %Thread{} = thread, %Incoming{} = incoming) do
+  defp run_handler(chat, handler, %Thread{} = thread, %Incoming{} = incoming, nil) do
     case :erlang.fun_info(handler, :arity) do
+      {:arity, 4} ->
+        context = MessageContext.new(skipped: [], total_count: 1)
+        coerce_handler_result(chat, handler.(chat, thread, incoming, context))
+
+      {:arity, 3} ->
+        coerce_handler_result(chat, handler.(chat, thread, incoming))
+
+      _ ->
+        coerce_handler_result(chat, handler.(thread, incoming))
+    end
+  end
+
+  defp run_handler(chat, handler, %Thread{} = thread, %Incoming{} = incoming, context) do
+    case :erlang.fun_info(handler, :arity) do
+      {:arity, 4} ->
+        coerce_handler_result(chat, handler.(chat, thread, incoming, context))
+
       {:arity, 3} ->
         coerce_handler_result(chat, handler.(chat, thread, incoming))
 

--- a/lib/jido/chat/message_context.ex
+++ b/lib/jido/chat/message_context.ex
@@ -1,0 +1,48 @@
+defmodule Jido.Chat.MessageContext do
+  @moduledoc """
+  Ordered message context for a collapsed queue or burst dispatch.
+
+  `skipped` contains the earlier messages from the same conversation. The
+  current message is not in this list. `total_since_last_handler` and
+  `total_count` have the same value. The second field gives callers a short,
+  transport-neutral name while the first field matches the Chat SDK contract.
+  """
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              skipped: Zoi.list(Zoi.any()) |> Zoi.default([]),
+              total_since_last_handler: Zoi.integer() |> Zoi.min(1) |> Zoi.default(1),
+              total_count: Zoi.integer() |> Zoi.min(1) |> Zoi.default(1)
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the schema for message context."
+  @spec schema() :: Zoi.schema()
+  def schema, do: @schema
+
+  @doc "Creates normalized ordered message context."
+  @spec new(t() | map() | keyword()) :: t()
+  def new(%__MODULE__{} = context), do: context
+  def new(opts) when is_list(opts), do: opts |> Map.new() |> new()
+
+  def new(opts) when is_map(opts) do
+    skipped = opts[:skipped] || opts["skipped"] || []
+
+    total =
+      opts[:total_count] || opts["total_count"] || opts[:total_since_last_handler] ||
+        opts["total_since_last_handler"] || length(skipped) + 1
+
+    Jido.Chat.Schema.parse!(__MODULE__, @schema, %{
+      skipped: skipped,
+      total_since_last_handler: total,
+      total_count: total
+    })
+  end
+end

--- a/lib/jido/chat/serialization.ex
+++ b/lib/jido/chat/serialization.ex
@@ -53,6 +53,7 @@ defmodule Jido.Chat.Serialization do
       channel_state: Wire.to_plain(chat.channel_state),
       locks: Wire.to_plain(snapshot.locks),
       pending_locks: Wire.to_plain(snapshot.pending_locks),
+      concurrency_events: Wire.to_plain(snapshot.concurrency_events),
       initialized: chat.initialized
     }
     |> Wire.to_plain()
@@ -74,7 +75,8 @@ defmodule Jido.Chat.Serialization do
         thread_state: map[:thread_state] || map["thread_state"] || %{},
         channel_state: map[:channel_state] || map["channel_state"] || %{},
         locks: map[:locks] || map["locks"] || %{},
-        pending_locks: map[:pending_locks] || map["pending_locks"] || %{}
+        pending_locks: map[:pending_locks] || map["pending_locks"] || %{},
+        concurrency_events: map[:concurrency_events] || map["concurrency_events"] || []
       })
 
     %{

--- a/lib/jido/chat/state_adapter.ex
+++ b/lib/jido/chat/state_adapter.ex
@@ -16,12 +16,17 @@ defmodule Jido.Chat.StateAdapter do
           thread_state: %{optional(String.t()) => map()},
           channel_state: %{optional(String.t()) => map()},
           locks: %{optional(String.t()) => map()},
-          pending_locks: %{optional(String.t()) => [map()]}
+          pending_locks: %{optional(String.t()) => [map()]},
+          concurrency_events: [map()]
         }
 
   @type state :: term()
-  @type lock_result :: :acquired | :queued | :debounced | :busy
+  @type lock_result :: :acquired | :queued | :debounced | :bursting | :dropped | :busy
   @type release_result :: {:released, [map()]} | {:error, :not_owner}
+  @type drain_result ::
+          {:drained, map() | nil}
+          | {:waiting, %{remaining_ms: non_neg_integer()}}
+          | {:error, :not_owner}
 
   @callback init(snapshot(), keyword()) :: state()
   @callback snapshot(state()) :: snapshot() | map()
@@ -35,8 +40,16 @@ defmodule Jido.Chat.StateAdapter do
   @callback duplicate?(state(), dedupe_key()) :: boolean()
   @callback mark_dedupe(state(), dedupe_key(), pos_integer()) :: state()
   @callback lock(state(), String.t(), String.t(), atom(), map()) :: {lock_result(), state()}
+  @callback lock_with_options(state(), String.t(), String.t(), atom(), map(), map()) ::
+              {lock_result(), state()}
   @callback release_lock(state(), String.t(), String.t()) :: {release_result(), state()}
+  @callback release_lock_with_options(state(), String.t(), String.t(), non_neg_integer()) ::
+              {release_result(), state()}
   @callback force_release_lock(state(), String.t()) :: {{:released, [map()]}, state()}
+  @callback drain_lock(state(), String.t(), String.t(), non_neg_integer(), String.t()) ::
+              {drain_result(), state()}
+
+  @optional_callbacks drain_lock: 5, lock_with_options: 6, release_lock_with_options: 4
 
   @dialyzer {:nowarn_function, default_snapshot: 0}
 
@@ -124,6 +137,19 @@ defmodule Jido.Chat.StateAdapter do
     adapter_module.lock(state, key, owner, strategy, metadata)
   end
 
+  @doc "Attempts to acquire a lock with optional bounded-concurrency controls."
+  @spec lock(module(), state(), String.t(), String.t(), atom(), map(), map()) ::
+          {lock_result(), state()}
+  def lock(adapter_module, state, key, owner, strategy, metadata, options)
+      when is_atom(adapter_module) and is_binary(key) and is_binary(owner) and is_atom(strategy) and
+             is_map(metadata) and is_map(options) do
+    if function_exported?(adapter_module, :lock_with_options, 6) do
+      adapter_module.lock_with_options(state, key, owner, strategy, metadata, options)
+    else
+      adapter_module.lock(state, key, owner, strategy, metadata)
+    end
+  end
+
   @doc "Releases a held lock and returns any queued/debounced pending entries."
   @spec release_lock(module(), state(), String.t(), String.t()) :: {release_result(), state()}
   def release_lock(adapter_module, state, key, owner)
@@ -131,11 +157,37 @@ defmodule Jido.Chat.StateAdapter do
     adapter_module.release_lock(state, key, owner)
   end
 
+  @doc "Releases a held lock and filters expired entries at the supplied time."
+  @spec release_lock(module(), state(), String.t(), String.t(), non_neg_integer()) ::
+          {release_result(), state()}
+  def release_lock(adapter_module, state, key, owner, now_ms)
+      when is_atom(adapter_module) and is_binary(key) and is_binary(owner) and
+             is_integer(now_ms) and now_ms >= 0 do
+    if function_exported?(adapter_module, :release_lock_with_options, 4) do
+      adapter_module.release_lock_with_options(state, key, owner, now_ms)
+    else
+      filter_released_entries(adapter_module.release_lock(state, key, owner), now_ms)
+    end
+  end
+
   @doc "Force-releases a lock regardless of owner and returns pending entries."
   @spec force_release_lock(module(), state(), String.t()) :: {{:released, [map()]}, state()}
   def force_release_lock(adapter_module, state, key)
       when is_atom(adapter_module) and is_binary(key) do
     adapter_module.force_release_lock(state, key)
+  end
+
+  @doc "Drains a due lock into one dispatch entry with ordered message context."
+  @spec drain_lock(module(), state(), String.t(), String.t(), non_neg_integer(), String.t()) ::
+          {drain_result(), state()}
+  def drain_lock(adapter_module, state, key, owner, now_ms, conversation_key)
+      when is_atom(adapter_module) and is_binary(key) and is_binary(owner) and
+             is_integer(now_ms) and now_ms >= 0 and is_binary(conversation_key) do
+    if function_exported?(adapter_module, :drain_lock, 5) do
+      adapter_module.drain_lock(state, key, owner, now_ms, conversation_key)
+    else
+      fallback_drain(adapter_module, state, key, owner, now_ms, conversation_key)
+    end
   end
 
   @doc "Returns the canonical empty snapshot."
@@ -148,7 +200,8 @@ defmodule Jido.Chat.StateAdapter do
       thread_state: %{},
       channel_state: %{},
       locks: %{},
-      pending_locks: %{}
+      pending_locks: %{},
+      concurrency_events: []
     }
   end
 
@@ -164,7 +217,10 @@ defmodule Jido.Chat.StateAdapter do
       thread_state: snapshot[:thread_state] || snapshot["thread_state"] || defaults.thread_state,
       channel_state: snapshot[:channel_state] || snapshot["channel_state"] || defaults.channel_state,
       locks: snapshot[:locks] || snapshot["locks"] || defaults.locks,
-      pending_locks: snapshot[:pending_locks] || snapshot["pending_locks"] || defaults.pending_locks
+      pending_locks: snapshot[:pending_locks] || snapshot["pending_locks"] || defaults.pending_locks,
+      concurrency_events:
+        snapshot[:concurrency_events] || snapshot["concurrency_events"] ||
+          defaults.concurrency_events
     }
     |> normalize_subscriptions()
     |> normalize_dedupe()
@@ -173,6 +229,7 @@ defmodule Jido.Chat.StateAdapter do
     |> normalize_channel_state()
     |> normalize_locks()
     |> normalize_pending_locks()
+    |> normalize_concurrency_events()
   end
 
   def normalize_snapshot(_snapshot), do: default_snapshot()
@@ -278,8 +335,13 @@ defmodule Jido.Chat.StateAdapter do
   defp normalize_locks(snapshot) do
     locks =
       case snapshot.locks do
-        locks when is_map(locks) -> locks
-        _ -> %{}
+        locks when is_map(locks) ->
+          locks
+          |> Enum.map(fn {key, lock} -> {to_string(key), normalize_lock(lock)} end)
+          |> Map.new()
+
+        _ ->
+          %{}
       end
 
     %{snapshot | locks: locks}
@@ -293,7 +355,9 @@ defmodule Jido.Chat.StateAdapter do
           |> Enum.map(fn {key, entries} ->
             normalized_entries =
               if is_list(entries) do
-                Enum.filter(entries, &is_map/1)
+                entries
+                |> Enum.filter(&is_map/1)
+                |> Enum.map(&normalize_pending_entry/1)
               else
                 []
               end
@@ -307,6 +371,168 @@ defmodule Jido.Chat.StateAdapter do
       end
 
     %{snapshot | pending_locks: pending_locks}
+  end
+
+  defp normalize_concurrency_events(snapshot) do
+    events =
+      case snapshot.concurrency_events do
+        events when is_list(events) ->
+          events
+          |> Enum.filter(&is_map/1)
+          |> Enum.map(&normalize_concurrency_event/1)
+          |> Enum.take(-100)
+
+        _ ->
+          []
+      end
+
+    %{snapshot | concurrency_events: events}
+  end
+
+  defp normalize_concurrency_event(event) do
+    event
+    |> copy_known_fields([
+      :event,
+      :key,
+      :lock_key,
+      :owner,
+      :message_id,
+      :strategy,
+      :at,
+      :queue_depth,
+      :conversation_key,
+      :reason,
+      :overflow_policy,
+      :expired_at,
+      :superseded_by,
+      :skipped_count,
+      :total_count,
+      :drained_count
+    ])
+    |> normalize_event_enum(:event)
+    |> normalize_event_enum(:reason)
+    |> normalize_event_enum(:overflow_policy)
+  end
+
+  defp normalize_event_enum(event, key) do
+    case Map.get(event, key) do
+      value when is_binary(value) ->
+        try do
+          Map.put(event, key, String.to_existing_atom(value))
+        rescue
+          ArgumentError -> event
+        end
+
+      _ ->
+        event
+    end
+  end
+
+  defp normalize_lock(lock) when is_map(lock) do
+    copy_known_fields(lock, [
+      :owner,
+      :owners,
+      :strategy,
+      :metadata,
+      :ready_at,
+      :conversation_key,
+      :max_concurrent
+    ])
+  end
+
+  defp normalize_lock(_lock), do: %{}
+
+  defp normalize_pending_entry(entry) do
+    copy_known_fields(entry, [
+      :owner,
+      :strategy,
+      :metadata,
+      :enqueued_at,
+      :expires_at,
+      :ready_at,
+      :conversation_key
+    ])
+  end
+
+  defp filter_released_entries({{:released, entries}, state}, now_ms) do
+    active =
+      Enum.filter(entries, fn entry ->
+        expires_at = entry[:expires_at] || entry["expires_at"]
+        is_nil(expires_at) or expires_at >= now_ms
+      end)
+
+    {{:released, active}, state}
+  end
+
+  defp filter_released_entries(result, _now_ms), do: result
+
+  defp copy_known_fields(map, fields) do
+    Enum.reduce(fields, map, fn field, acc ->
+      string_field = Atom.to_string(field)
+
+      if Map.has_key?(acc, string_field) and not Map.has_key?(acc, field) do
+        acc |> Map.put(field, Map.get(acc, string_field)) |> Map.delete(string_field)
+      else
+        acc
+      end
+    end)
+    |> normalize_strategy()
+  end
+
+  defp normalize_strategy(%{strategy: strategy} = map) when is_binary(strategy) do
+    try do
+      %{map | strategy: String.to_existing_atom(strategy)}
+    rescue
+      ArgumentError -> map
+    end
+  end
+
+  defp normalize_strategy(map), do: map
+
+  defp fallback_drain(adapter_module, state, key, owner, now_ms, conversation_key) do
+    snapshot = snapshot(adapter_module, state)
+    lock = Map.get(snapshot.locks, key, %{})
+    ready_at = lock[:ready_at] || lock["ready_at"] || 0
+
+    cond do
+      (lock[:owner] || lock["owner"]) != owner ->
+        {{:error, :not_owner}, state}
+
+      ready_at > now_ms ->
+        {{:waiting, %{remaining_ms: ready_at - now_ms}}, state}
+
+      true ->
+        {{:released, entries}, next_state} = adapter_module.release_lock(state, key, owner)
+        dispatch = fallback_dispatch(entries, now_ms, conversation_key)
+        {{:drained, dispatch}, next_state}
+    end
+  end
+
+  defp fallback_dispatch(entries, now_ms, conversation_key) do
+    active =
+      Enum.filter(entries, fn entry ->
+        expires_at = entry[:expires_at] || entry["expires_at"]
+        is_nil(expires_at) or expires_at >= now_ms
+      end)
+
+    case List.last(active) do
+      nil ->
+        nil
+
+      latest ->
+        latest_conversation =
+          latest[:conversation_key] || latest["conversation_key"] || conversation_key
+
+        skipped =
+          active
+          |> Enum.drop(-1)
+          |> Enum.filter(fn entry ->
+            (entry[:conversation_key] || entry["conversation_key"] || conversation_key) ==
+              latest_conversation
+          end)
+
+        Map.put(latest, :context, Jido.Chat.Concurrency.message_context(skipped))
+    end
   end
 
   defp normalize_key_atom(key) when is_atom(key), do: {:ok, key}

--- a/lib/jido/chat/state_adapters/memory.ex
+++ b/lib/jido/chat/state_adapters/memory.ex
@@ -8,7 +8,9 @@ defmodule Jido.Chat.StateAdapters.Memory do
 
   @behaviour Jido.Chat.StateAdapter
 
-  alias Jido.Chat.StateAdapter
+  alias Jido.Chat.{Concurrency, StateAdapter}
+
+  @max_concurrency_events 100
 
   @enforce_keys [:subscriptions, :dedupe, :dedupe_order, :thread_state, :channel_state]
   defstruct subscriptions: MapSet.new(),
@@ -17,7 +19,8 @@ defmodule Jido.Chat.StateAdapters.Memory do
             thread_state: %{},
             channel_state: %{},
             locks: %{},
-            pending_locks: %{}
+            pending_locks: %{},
+            concurrency_events: []
 
   @type t :: %__MODULE__{
           subscriptions: MapSet.t(String.t()),
@@ -26,7 +29,8 @@ defmodule Jido.Chat.StateAdapters.Memory do
           thread_state: %{optional(String.t()) => map()},
           channel_state: %{optional(String.t()) => map()},
           locks: %{optional(String.t()) => map()},
-          pending_locks: %{optional(String.t()) => [map()]}
+          pending_locks: %{optional(String.t()) => [map()]},
+          concurrency_events: [map()]
         }
 
   @impl true
@@ -40,7 +44,8 @@ defmodule Jido.Chat.StateAdapters.Memory do
       thread_state: snapshot.thread_state,
       channel_state: snapshot.channel_state,
       locks: snapshot.locks,
-      pending_locks: snapshot.pending_locks
+      pending_locks: snapshot.pending_locks,
+      concurrency_events: snapshot.concurrency_events
     }
   end
 
@@ -53,7 +58,8 @@ defmodule Jido.Chat.StateAdapters.Memory do
       thread_state: state.thread_state,
       channel_state: state.channel_state,
       locks: state.locks,
-      pending_locks: state.pending_locks
+      pending_locks: state.pending_locks,
+      concurrency_events: state.concurrency_events
     }
   end
 
@@ -109,36 +115,33 @@ defmodule Jido.Chat.StateAdapters.Memory do
   end
 
   @impl true
-  def lock(%__MODULE__{} = state, _key, _owner, :concurrent, _metadata) do
-    {:acquired, state}
+  def lock(%__MODULE__{} = state, key, owner, strategy, metadata) do
+    lock_with_options(state, key, owner, strategy, metadata, %{})
   end
 
-  def lock(%__MODULE__{} = state, key, owner, strategy, metadata)
-      when strategy in [:reject, :queue, :debounce] do
-    case Map.get(state.locks, key) do
-      nil ->
-        next_state = put_lock(state, key, owner, strategy, metadata)
-        {:acquired, next_state}
+  @impl true
+  def lock_with_options(%__MODULE__{} = state, key, owner, strategy, metadata, options) do
+    {config, now_ms, conversation_key} = lock_input(strategy, key, options)
 
-      _lock when strategy == :reject ->
-        {:busy, state}
+    case strategy do
+      :concurrent ->
+        lock_concurrent(state, key, owner, config, metadata)
 
-      _lock when strategy == :queue ->
-        pending = Map.get(state.pending_locks, key, [])
-        entry = pending_entry(owner, strategy, metadata)
-        {:queued, %{state | pending_locks: Map.put(state.pending_locks, key, pending ++ [entry])}}
-
-      _lock when strategy == :debounce ->
-        entry = pending_entry(owner, strategy, metadata)
-        {:debounced, %{state | pending_locks: Map.put(state.pending_locks, key, [entry])}}
+      strategy when strategy in [:reject, :queue, :debounce, :burst] ->
+        lock_serial(state, key, owner, strategy, metadata, config, now_ms, conversation_key)
     end
   end
 
   @impl true
   def release_lock(%__MODULE__{} = state, key, owner) do
+    release_lock_with_options(state, key, owner, System.system_time(:millisecond))
+  end
+
+  @impl true
+  def release_lock_with_options(%__MODULE__{} = state, key, owner, now_ms) do
     case Map.get(state.locks, key) do
       %{owner: ^owner} ->
-        pending = Map.get(state.pending_locks, key, [])
+        {state, pending} = expire_pending(state, key, now_ms)
 
         next_state =
           state
@@ -146,6 +149,22 @@ defmodule Jido.Chat.StateAdapters.Memory do
           |> delete_pending(key)
 
         {{:released, pending}, next_state}
+
+      %{strategy: :concurrent, owners: owners} = lock ->
+        if owner in owners do
+          remaining = List.delete(owners, owner)
+
+          next_state =
+            if remaining == [] do
+              delete_lock(state, key)
+            else
+              %{state | locks: Map.put(state.locks, key, %{lock | owners: remaining})}
+            end
+
+          {{:released, []}, next_state}
+        else
+          {{:error, :not_owner}, state}
+        end
 
       _other ->
         {{:error, :not_owner}, state}
@@ -164,6 +183,17 @@ defmodule Jido.Chat.StateAdapters.Memory do
     {{:released, pending}, next_state}
   end
 
+  @impl true
+  def drain_lock(%__MODULE__{} = state, key, owner, now_ms, conversation_key) do
+    case Map.get(state.locks, key) do
+      %{owner: ^owner} = lock ->
+        drain_owned_lock(state, key, lock, now_ms, conversation_key)
+
+      _other ->
+        {{:error, :not_owner}, state}
+    end
+  end
+
   defp trim_dedupe_order(dedupe_order, dedupe_limit) do
     overflow_count = max(length(dedupe_order) - dedupe_limit, 0)
 
@@ -175,8 +205,8 @@ defmodule Jido.Chat.StateAdapters.Memory do
     end
   end
 
-  defp put_lock(%__MODULE__{} = state, key, owner, strategy, metadata) do
-    lock = %{owner: owner, strategy: strategy, metadata: metadata}
+  defp put_lock(%__MODULE__{} = state, key, owner, strategy, metadata, attrs) do
+    lock = Map.merge(%{owner: owner, strategy: strategy, metadata: metadata}, attrs)
     %{state | locks: Map.put(state.locks, key, lock)}
   end
 
@@ -185,7 +215,381 @@ defmodule Jido.Chat.StateAdapters.Memory do
   defp delete_pending(%__MODULE__{} = state, key),
     do: %{state | pending_locks: Map.delete(state.pending_locks, key)}
 
-  defp pending_entry(owner, strategy, metadata) do
-    %{owner: owner, strategy: strategy, metadata: metadata}
+  defp pending_entry(owner, strategy, metadata, now_ms, config, conversation_key) do
+    %{
+      owner: owner,
+      strategy: strategy,
+      metadata: metadata,
+      enqueued_at: now_ms,
+      expires_at: now_ms + config.queue_entry_ttl_ms,
+      ready_at: pending_ready_at(strategy, now_ms, config.debounce_ms),
+      conversation_key: conversation_key
+    }
   end
+
+  defp pending_ready_at(strategy, now_ms, debounce_ms) when strategy in [:burst, :debounce],
+    do: now_ms + debounce_ms
+
+  defp pending_ready_at(_strategy, now_ms, _debounce_ms), do: now_ms
+
+  defp lock_input(strategy, key, options) do
+    config = options[:config] || options["config"] || %{strategy: strategy}
+    config = if match?(%Concurrency{}, config), do: config, else: Concurrency.new(config)
+    now_ms = options[:now_ms] || options["now_ms"] || System.system_time(:millisecond)
+
+    conversation_key =
+      options[:conversation_key] || options["conversation_key"] || key
+
+    {config, now_ms, conversation_key}
+  end
+
+  defp lock_concurrent(state, _key, _owner, %Concurrency{max_concurrent: nil}, _metadata),
+    do: {:acquired, state}
+
+  defp lock_concurrent(state, key, owner, %Concurrency{max_concurrent: maximum}, metadata) do
+    case Map.get(state.locks, key) do
+      nil ->
+        lock = %{
+          owner: owner,
+          owners: [owner],
+          strategy: :concurrent,
+          max_concurrent: maximum,
+          metadata: metadata
+        }
+
+        {:acquired, %{state | locks: Map.put(state.locks, key, lock)}}
+
+      %{strategy: :concurrent, owners: owners} = lock when length(owners) < maximum ->
+        next_lock = %{lock | owners: owners ++ [owner]}
+        {:acquired, %{state | locks: Map.put(state.locks, key, next_lock)}}
+
+      _lock ->
+        {:busy, state}
+    end
+  end
+
+  defp lock_serial(state, key, owner, strategy, metadata, config, now_ms, conversation_key) do
+    case Map.get(state.locks, key) do
+      nil when strategy == :burst ->
+        state =
+          put_lock(state, key, owner, strategy, metadata, %{
+            ready_at: now_ms + config.debounce_ms,
+            conversation_key: conversation_key
+          })
+
+        enqueue_bounded(state, key, owner, strategy, metadata, config, now_ms, conversation_key, first?: true)
+
+      nil ->
+        {:acquired, put_lock(state, key, owner, strategy, metadata, %{conversation_key: conversation_key})}
+
+      _lock when strategy == :reject ->
+        event = %{
+          event: :dropped,
+          key: key,
+          lock_key: key,
+          owner: owner,
+          strategy: :reject,
+          at: now_ms,
+          reason: :lock_busy,
+          message_id: event_message_id(%{metadata: metadata}),
+          conversation_key: conversation_key
+        }
+
+        {:busy, record_event(state, event)}
+
+      _lock when strategy in [:queue, :burst] ->
+        enqueue_bounded(state, key, owner, strategy, metadata, config, now_ms, conversation_key)
+
+      lock when strategy == :debounce ->
+        debounce(state, key, lock, owner, metadata, config, now_ms, conversation_key)
+    end
+  end
+
+  defp enqueue_bounded(
+         state,
+         key,
+         owner,
+         strategy,
+         metadata,
+         config,
+         now_ms,
+         conversation_key,
+         opts \\ []
+       ) do
+    {state, pending} = expire_pending(state, key, now_ms)
+    entry = pending_entry(owner, strategy, metadata, now_ms, config, conversation_key)
+    first? = Keyword.get(opts, :first?, false)
+
+    cond do
+      length(pending) < config.max_queue_size ->
+        accepted = pending ++ [entry]
+
+        state =
+          state
+          |> put_pending(key, accepted)
+          |> refresh_active_deadline(key, entry)
+
+        state = record_event(state, queue_event(key, entry, length(pending) + 1))
+        {if(first?, do: :bursting, else: :queued), state}
+
+      config.overflow_policy == :drop_newest ->
+        state = record_event(state, dropped_event(key, entry, :drop_newest))
+        {:dropped, state}
+
+      true ->
+        [oldest | remaining] = pending
+
+        state =
+          state
+          |> put_pending(key, remaining ++ [entry])
+          |> refresh_active_deadline(key, entry)
+          |> record_event(dropped_event(key, oldest, :drop_oldest))
+          |> record_event(queue_event(key, entry, config.max_queue_size))
+
+        {if(first?, do: :bursting, else: :queued), state}
+    end
+  end
+
+  defp debounce(state, key, lock, owner, metadata, config, now_ms, conversation_key) do
+    {state, pending} = expire_pending(state, key, now_ms)
+    entry = pending_entry(owner, :debounce, metadata, now_ms, config, conversation_key)
+    {replaced, retained} = split_conversation(pending, conversation_key, key)
+
+    state =
+      Enum.reduce(replaced, state, fn superseded, acc ->
+        record_event(acc, superseded_event(key, superseded, owner, now_ms))
+      end)
+
+    next_lock =
+      if lock_conversation(lock, key) == conversation_key do
+        Map.put(lock, :ready_at, entry.ready_at)
+      else
+        lock
+      end
+
+    state =
+      state
+      |> put_pending(key, retained ++ [entry])
+      |> then(&%{&1 | locks: Map.put(&1.locks, key, next_lock)})
+      |> record_event(queue_event(key, entry, 1))
+
+    {:debounced, state}
+  end
+
+  defp drain_owned_lock(state, key, lock, now_ms, conversation_key) do
+    {state, pending} = expire_pending(state, key, now_ms)
+    {selected, retained} = split_conversation(pending, conversation_key, key)
+    ready_at = conversation_ready_at(selected, lock)
+
+    if ready_at > now_ms do
+      {{:waiting, %{remaining_ms: ready_at - now_ms}}, state}
+    else
+      drain_conversation(state, key, lock, selected, retained, now_ms, conversation_key)
+    end
+  end
+
+  defp drain_conversation(state, key, lock, selected, retained, now_ms, conversation_key) do
+    strategy = lock[:strategy] || :queue
+
+    {latest, skipped} = select_dispatch(selected, strategy)
+    dispatch = build_dispatch(latest, skipped)
+
+    drained_event = %{
+      event: :drained,
+      key: key,
+      lock_key: key,
+      owner: latest && latest.owner,
+      message_id: latest && event_message_id(latest),
+      strategy: strategy,
+      at: now_ms,
+      skipped_count: length(skipped),
+      total_count: if(latest, do: length(skipped) + 1, else: 0),
+      drained_count: length(selected),
+      conversation_key: conversation_key
+    }
+
+    next_state =
+      state
+      |> put_pending(key, retained)
+      |> promote_retained_lock(key, retained)
+      |> record_event(drained_event)
+
+    {{:drained, dispatch}, next_state}
+  end
+
+  defp select_dispatch([], _strategy), do: {nil, []}
+
+  defp select_dispatch(pending, strategy) do
+    latest = List.last(pending)
+
+    skipped =
+      if strategy == :debounce do
+        []
+      else
+        Enum.drop(pending, -1)
+      end
+
+    {latest, skipped}
+  end
+
+  defp build_dispatch(nil, _skipped), do: nil
+
+  defp build_dispatch(latest, skipped) do
+    Map.put(latest, :context, Concurrency.message_context(skipped))
+  end
+
+  defp expire_pending(state, key, now_ms) do
+    pending = Map.get(state.pending_locks, key, [])
+
+    {expired, active} =
+      Enum.split_with(pending, fn entry ->
+        expires_at = entry[:expires_at] || entry["expires_at"]
+        is_integer(expires_at) and expires_at < now_ms
+      end)
+
+    state =
+      Enum.reduce(expired, state, fn entry, acc ->
+        record_event(acc, expired_event(key, entry, now_ms))
+      end)
+
+    {put_pending(state, key, active), active}
+  end
+
+  defp split_conversation(pending, conversation_key, fallback_conversation_key) do
+    Enum.split_with(pending, fn entry ->
+      entry_conversation(entry, fallback_conversation_key) == conversation_key
+    end)
+  end
+
+  defp entry_conversation(entry, fallback),
+    do: entry[:conversation_key] || entry["conversation_key"] || fallback
+
+  defp lock_conversation(lock, fallback),
+    do: lock[:conversation_key] || lock["conversation_key"] || fallback
+
+  defp conversation_ready_at([], lock), do: lock[:ready_at] || lock["ready_at"] || 0
+
+  defp conversation_ready_at(entries, lock) do
+    latest = List.last(entries)
+    latest[:ready_at] || latest["ready_at"] || lock[:ready_at] || lock["ready_at"] || 0
+  end
+
+  defp refresh_active_deadline(state, key, %{strategy: :burst} = entry) do
+    case Map.get(state.locks, key) do
+      nil ->
+        state
+
+      lock ->
+        if lock_conversation(lock, key) == entry.conversation_key do
+          next_lock = Map.put(lock, :ready_at, entry.ready_at)
+          %{state | locks: Map.put(state.locks, key, next_lock)}
+        else
+          state
+        end
+    end
+  end
+
+  defp refresh_active_deadline(state, _key, _entry), do: state
+
+  defp promote_retained_lock(state, key, []), do: delete_lock(state, key)
+
+  defp promote_retained_lock(state, key, [first | _] = retained) do
+    conversation_key = entry_conversation(first, key)
+
+    conversation_entries =
+      Enum.filter(retained, fn entry -> entry_conversation(entry, key) == conversation_key end)
+
+    latest = List.last(conversation_entries)
+
+    lock = %{
+      owner: first[:owner] || first["owner"],
+      strategy: first[:strategy] || first["strategy"],
+      metadata: first[:metadata] || first["metadata"] || %{},
+      ready_at: latest[:ready_at] || latest["ready_at"] || 0,
+      conversation_key: conversation_key
+    }
+
+    %{state | locks: Map.put(state.locks, key, lock)}
+  end
+
+  defp put_pending(state, key, []),
+    do: %{state | pending_locks: Map.delete(state.pending_locks, key)}
+
+  defp put_pending(state, key, pending),
+    do: %{state | pending_locks: Map.put(state.pending_locks, key, pending)}
+
+  defp record_event(state, event),
+    do: %{
+      state
+      | concurrency_events: (state.concurrency_events ++ [event]) |> Enum.take(-@max_concurrency_events)
+    }
+
+  defp queue_event(key, entry, depth) do
+    %{
+      event: :queued,
+      key: key,
+      lock_key: key,
+      owner: entry.owner,
+      strategy: entry.strategy,
+      at: entry.enqueued_at,
+      message_id: event_message_id(entry),
+      queue_depth: depth,
+      conversation_key: entry.conversation_key
+    }
+  end
+
+  defp dropped_event(key, entry, policy) do
+    %{
+      event: :dropped,
+      key: key,
+      lock_key: key,
+      owner: entry.owner,
+      strategy: entry.strategy,
+      at: entry.enqueued_at,
+      message_id: event_message_id(entry),
+      reason: :queue_full,
+      overflow_policy: policy,
+      conversation_key: entry.conversation_key
+    }
+  end
+
+  defp expired_event(key, entry, now_ms) do
+    %{
+      event: :expired,
+      key: key,
+      lock_key: key,
+      owner: entry.owner,
+      strategy: entry.strategy,
+      at: now_ms,
+      message_id: event_message_id(entry),
+      expired_at: entry.expires_at,
+      conversation_key: entry.conversation_key
+    }
+  end
+
+  defp superseded_event(key, entry, replacing_owner, now_ms) do
+    %{
+      event: :superseded,
+      key: key,
+      lock_key: key,
+      owner: entry.owner,
+      superseded_by: replacing_owner,
+      strategy: :debounce,
+      at: now_ms,
+      message_id: event_message_id(entry),
+      conversation_key: entry.conversation_key
+    }
+  end
+
+  defp event_message_id(entry) do
+    metadata = entry[:metadata] || entry["metadata"] || %{}
+    message = metadata[:message] || metadata["message"] || metadata[:incoming] || metadata["incoming"]
+
+    get_value(message, :id) || get_value(message, :external_message_id) ||
+      get_value(metadata, :message_id)
+  end
+
+  defp get_value(%_{} = struct, key), do: Map.get(struct, key)
+  defp get_value(map, key) when is_map(map), do: map[key] || map[Atom.to_string(key)]
+  defp get_value(_value, _key), do: nil
 end

--- a/lib/jido_chat.ex
+++ b/lib/jido_chat.ex
@@ -51,7 +51,9 @@ defmodule Jido.Chat do
 
   @typedoc "Mention handler callback."
   @type mention_handler ::
-          (Thread.t(), Incoming.t() -> term()) | (t(), Thread.t(), Incoming.t() -> t() | term())
+          (Thread.t(), Incoming.t() -> term())
+          | (t(), Thread.t(), Incoming.t() -> t() | term())
+          | (t(), Thread.t(), Incoming.t(), Jido.Chat.MessageContext.t() -> t() | term())
   @typedoc "Regex-routed message handler callback."
   @type message_handler :: mention_handler()
   @typedoc "Subscribed-thread handler callback."
@@ -614,6 +616,12 @@ defmodule Jido.Chat do
           {:ok, t(), Incoming.t()} | {:error, term()}
   def process_message(%__MODULE__{} = chat, adapter_name, thread_id, incoming, opts \\ [])
       when is_atom(adapter_name) and is_binary(thread_id) and is_list(opts) do
+    context =
+      case opts[:message_context] || opts[:context] do
+        nil -> nil
+        context -> Jido.Chat.MessageContext.new(context)
+      end
+
     EventRouter.process_message(
       chat,
       adapter_name,
@@ -627,7 +635,8 @@ defmodule Jido.Chat do
           thread_id: normalized_incoming.external_thread_id,
           id: resolved_thread_id
         )
-      end
+      end,
+      context
     )
   end
 
@@ -841,42 +850,99 @@ defmodule Jido.Chat do
     %{locks: snapshot.locks, pending_locks: snapshot.pending_locks}
   end
 
+  @doc "Returns ordered metadata for concurrency queue lifecycle events."
+  @spec concurrency_events(t()) :: [map()]
+  def concurrency_events(%__MODULE__{} = chat) do
+    chat.state_adapter
+    |> StateAdapter.snapshot(chat.state)
+    |> Map.fetch!(:concurrency_events)
+  end
+
   @doc "Attempts to acquire a concurrency lock for a message-processing key."
   @spec acquire_lock(t(), String.t(), String.t(), keyword() | map()) ::
-          {:acquired | :queued | :debounced | :busy, t()}
+          {:acquired | :queued | :debounced | :bursting | :dropped | :busy, t()}
   def acquire_lock(%__MODULE__{} = chat, key, owner, opts \\ [])
       when is_binary(key) and is_binary(owner) do
     opts = if is_list(opts), do: Map.new(opts), else: opts
     config = opts[:concurrency] || opts["concurrency"] || concurrency(chat)
     config = Concurrency.new(config)
     metadata = opts[:metadata] || opts["metadata"] || %{}
+    thread_id = opts[:thread_id] || opts["thread_id"] || key
+    channel_id = opts[:channel_id] || opts["channel_id"]
+    lock_key = Concurrency.lock_key(config, thread_id, channel_id)
+    conversation_key = opts[:conversation_key] || opts["conversation_key"] || thread_id
+
+    concurrency_options = %{
+      config: config,
+      now_ms: concurrency_now(opts),
+      conversation_key: conversation_key
+    }
 
     {result, state} =
       StateAdapter.lock(
         chat.state_adapter,
         chat.state,
-        key,
+        lock_key,
         owner,
         config.strategy,
-        metadata
+        metadata,
+        concurrency_options
       )
 
-    {result, sync_state(state, chat)}
+    {result, sync_concurrency_state(state, chat)}
   end
 
   @doc "Releases a held concurrency lock and returns queued/debounced entries."
-  @spec release_lock(t(), String.t(), String.t()) ::
+  @spec release_lock(t(), String.t(), String.t(), keyword() | map()) ::
           {{:released, [map()]} | {:error, :not_owner}, t()}
-  def release_lock(%__MODULE__{} = chat, key, owner) when is_binary(key) and is_binary(owner) do
-    {result, state} = StateAdapter.release_lock(chat.state_adapter, chat.state, key, owner)
-    {result, sync_state(state, chat)}
+  def release_lock(%__MODULE__{} = chat, key, owner, opts \\ [])
+      when is_binary(key) and is_binary(owner) do
+    opts = if is_list(opts), do: Map.new(opts), else: opts
+    lock_key = scoped_lock_key(chat, key, opts)
+
+    {result, state} =
+      StateAdapter.release_lock(
+        chat.state_adapter,
+        chat.state,
+        lock_key,
+        owner,
+        concurrency_now(opts)
+      )
+
+    {result, sync_concurrency_state(state, chat)}
   end
 
   @doc "Force-releases a concurrency lock regardless of owner."
-  @spec force_release_lock(t(), String.t()) :: {{:released, [map()]}, t()}
-  def force_release_lock(%__MODULE__{} = chat, key) when is_binary(key) do
-    {result, state} = StateAdapter.force_release_lock(chat.state_adapter, chat.state, key)
-    {result, sync_state(state, chat)}
+  @spec force_release_lock(t(), String.t(), keyword() | map()) :: {{:released, [map()]}, t()}
+  def force_release_lock(%__MODULE__{} = chat, key, opts \\ []) when is_binary(key) do
+    lock_key = scoped_lock_key(chat, key, opts)
+    {result, state} = StateAdapter.force_release_lock(chat.state_adapter, chat.state, lock_key)
+    {result, sync_concurrency_state(state, chat)}
+  end
+
+  @doc "Drains a due queue, debounce, or burst lock into one handler dispatch entry."
+  @spec drain_lock(t(), String.t(), String.t(), keyword() | map()) ::
+          {StateAdapter.drain_result(), t()}
+  def drain_lock(%__MODULE__{} = chat, key, owner, opts \\ [])
+      when is_binary(key) and is_binary(owner) do
+    opts = if is_list(opts), do: Map.new(opts), else: opts
+    lock_key = scoped_lock_key(chat, key, opts)
+
+    conversation_key =
+      opts[:conversation_key] || opts["conversation_key"] || opts[:thread_id] ||
+        opts["thread_id"] || key
+
+    {result, state} =
+      StateAdapter.drain_lock(
+        chat.state_adapter,
+        chat.state,
+        lock_key,
+        owner,
+        concurrency_now(opts),
+        conversation_key
+      )
+
+    {result, sync_concurrency_state(state, chat)}
   end
 
   @doc "Unsubscribes a thread id."
@@ -1280,6 +1346,8 @@ defmodule Jido.Chat do
     }
   end
 
+  defp sync_concurrency_state(state, %__MODULE__{} = chat), do: %{chat | state: state}
+
   defp initial_state_snapshot(opts) do
     %{
       subscriptions: opts[:subscriptions] || opts["subscriptions"] || MapSet.new(),
@@ -1288,7 +1356,8 @@ defmodule Jido.Chat do
       thread_state: opts[:thread_state] || opts["thread_state"] || %{},
       channel_state: opts[:channel_state] || opts["channel_state"] || %{},
       locks: opts[:locks] || opts["locks"] || %{},
-      pending_locks: opts[:pending_locks] || opts["pending_locks"] || %{}
+      pending_locks: opts[:pending_locks] || opts["pending_locks"] || %{},
+      concurrency_events: opts[:concurrency_events] || opts["concurrency_events"] || []
     }
     |> StateAdapter.normalize_snapshot()
   end
@@ -1297,6 +1366,22 @@ defmodule Jido.Chat do
 
   defp maybe_replace_with_explicit_state(_snapshot, state_adapter, explicit_state) do
     StateAdapter.snapshot(state_adapter, explicit_state)
+  end
+
+  defp scoped_lock_key(%__MODULE__{} = chat, key, opts) do
+    opts = if is_list(opts), do: Map.new(opts), else: opts
+    config = opts[:concurrency] || opts["concurrency"] || concurrency(chat)
+    thread_id = opts[:thread_id] || opts["thread_id"] || key
+    channel_id = opts[:channel_id] || opts["channel_id"]
+    Concurrency.lock_key(config, thread_id, channel_id)
+  end
+
+  defp concurrency_now(opts) when is_map(opts) do
+    case opts[:now_ms] || opts["now_ms"] || opts[:now] || opts["now"] do
+      value when is_integer(value) and value >= 0 -> value
+      fun when is_function(fun, 0) -> fun.()
+      nil -> System.system_time(:millisecond)
+    end
   end
 
   defp dedupe_limit(chat) do

--- a/test/jido/chat/concurrency_test.exs
+++ b/test/jido/chat/concurrency_test.exs
@@ -2,6 +2,48 @@ defmodule Jido.Chat.ConcurrencyTest do
   use ExUnit.Case, async: true
 
   alias Jido.Chat
+  alias Jido.Chat.{Concurrency, Incoming, MessageContext, Response}
+
+  defmodule TestAdapter do
+    use Jido.Chat.Adapter
+
+    @impl true
+    def channel_type, do: :test
+
+    @impl true
+    def transform_incoming(payload), do: {:ok, Incoming.new(payload)}
+
+    @impl true
+    def send_message(room_id, _text, _opts) do
+      {:ok,
+       Response.new(%{
+         external_message_id: "sent-1",
+         external_room_id: room_id,
+         channel_type: :test
+       })}
+    end
+  end
+
+  test "normalizes bounded concurrency configuration" do
+    assert %Concurrency{
+             strategy: :burst,
+             debounce_ms: 250,
+             max_queue_size: 3,
+             queue_entry_ttl_ms: 2_000,
+             overflow_policy: :drop_newest,
+             lock_scope: :channel,
+             max_concurrent: 2
+           } =
+             Concurrency.new(%{
+               "strategy" => "burst",
+               "debounceMs" => 250,
+               "maxQueueSize" => 3,
+               "queueEntryTtlMs" => 2_000,
+               "onQueueFull" => "drop-newest",
+               "lockScope" => "channel",
+               "maxConcurrent" => 2
+             })
+  end
 
   test "reject strategy blocks overlapping owners until release" do
     chat = Chat.new()
@@ -33,6 +75,27 @@ defmodule Jido.Chat.ConcurrencyTest do
     assert {{:released, pending}, _chat} = Chat.release_lock(chat, "thread:queue", "owner-1")
     assert Enum.map(pending, & &1.owner) == ["owner-2", "owner-3"]
     assert Enum.map(pending, & &1.metadata.message_id) == ["m2", "m3"]
+  end
+
+  test "release excludes expired pending entries and records deterministic expiry events" do
+    chat =
+      Chat.new()
+      |> Chat.configure_concurrency(strategy: :queue, queue_entry_ttl_ms: 10)
+
+    assert {:acquired, chat} =
+             Chat.acquire_lock(chat, "thread:release-expiry", "owner-1", now_ms: 0)
+
+    assert {:queued, chat} =
+             Chat.acquire_lock(chat, "thread:release-expiry", "owner-2",
+               now_ms: 1,
+               metadata: %{message: %{id: "m2"}}
+             )
+
+    assert {{:released, []}, chat} =
+             Chat.release_lock(chat, "thread:release-expiry", "owner-1", now_ms: 12)
+
+    assert %{event: :expired, owner: "owner-2", at: 12, expired_at: 11} =
+             List.last(Chat.concurrency_events(chat))
   end
 
   test "debounce strategy only keeps the latest pending owner" do
@@ -85,4 +148,444 @@ defmodule Jido.Chat.ConcurrencyTest do
     assert encoded["pending_locks"] == %{}
     assert %{locks: %{}, pending_locks: %{}} = Chat.lock_snapshot(revived)
   end
+
+  test "burst drains the latest message with ordered skipped context" do
+    chat =
+      Chat.new()
+      |> Chat.configure_concurrency(
+        strategy: :burst,
+        debounce_ms: 100,
+        max_queue_size: 3,
+        queue_entry_ttl_ms: 1_000
+      )
+
+    assert {:bursting, chat} =
+             Chat.acquire_lock(chat, "thread:burst", "owner-1",
+               now_ms: 0,
+               metadata: %{message: %{id: "m1", text: "one"}}
+             )
+
+    assert {:queued, chat} =
+             Chat.acquire_lock(chat, "thread:burst", "owner-2",
+               now_ms: 10,
+               metadata: %{message: %{id: "m2", text: "two"}}
+             )
+
+    assert {:queued, chat} =
+             Chat.acquire_lock(chat, "thread:burst", "owner-3",
+               now_ms: 20,
+               metadata: %{message: %{id: "m3", text: "three"}}
+             )
+
+    assert {{:waiting, %{remaining_ms: 1}}, ^chat} =
+             Chat.drain_lock(chat, "thread:burst", "owner-1", now_ms: 119)
+
+    assert {{:drained, drained}, chat} =
+             Chat.drain_lock(chat, "thread:burst", "owner-1", now_ms: 120)
+
+    assert drained.owner == "owner-3"
+    assert drained.metadata.message.id == "m3"
+
+    assert %MessageContext{
+             skipped: [%{id: "m1"}, %{id: "m2"}],
+             total_since_last_handler: 3,
+             total_count: 3
+           } = drained.context
+
+    assert %{locks: %{}, pending_locks: %{}} = Chat.lock_snapshot(chat)
+
+    assert Enum.map(Chat.concurrency_events(chat), & &1.event) == [
+             :queued,
+             :queued,
+             :queued,
+             :drained
+           ]
+
+    assert %{event: :drained, message_id: "m3", skipped_count: 2, total_count: 3} =
+             List.last(Chat.concurrency_events(chat))
+  end
+
+  test "each accepted burst entry resets the idle deadline" do
+    chat =
+      Chat.new()
+      |> Chat.configure_concurrency(strategy: :burst, debounce_ms: 100)
+
+    assert {:bursting, chat} = burst(chat, "owner-1", "m1", 0)
+    assert {:queued, chat} = burst(chat, "owner-2", "m2", 90)
+
+    assert {{:waiting, %{remaining_ms: 90}}, ^chat} =
+             Chat.drain_lock(chat, "thread:overflow", "owner-1", now_ms: 100)
+
+    assert {{:waiting, %{remaining_ms: 1}}, ^chat} =
+             Chat.drain_lock(chat, "thread:overflow", "owner-1", now_ms: 189)
+
+    assert {{:drained, drained}, _chat} =
+             Chat.drain_lock(chat, "thread:overflow", "owner-1", now_ms: 190)
+
+    assert drained.metadata.message.id == "m2"
+    assert Enum.map(drained.context.skipped, & &1.id) == ["m1"]
+  end
+
+  test "bounded burst overflow can drop the oldest entry" do
+    chat =
+      Chat.new()
+      |> Chat.configure_concurrency(
+        strategy: :burst,
+        debounce_ms: 0,
+        max_queue_size: 2,
+        overflow_policy: :drop_oldest
+      )
+
+    assert {:bursting, chat} = burst(chat, "owner-1", "m1", 0)
+    assert {:queued, chat} = burst(chat, "owner-2", "m2", 1)
+    assert {:queued, chat} = burst(chat, "owner-3", "m3", 2)
+
+    assert {{:drained, drained}, chat} =
+             Chat.drain_lock(chat, "thread:overflow", "owner-1", now_ms: 2)
+
+    assert Enum.map(drained.context.skipped, & &1.id) == ["m2"]
+    assert drained.metadata.message.id == "m3"
+
+    assert %{event: :dropped, owner: "owner-1", message_id: "m1", reason: :queue_full} =
+             Enum.find(Chat.concurrency_events(chat), &(&1.event == :dropped))
+  end
+
+  test "bounded queue overflow can drop the newest entry" do
+    chat =
+      Chat.new()
+      |> Chat.configure_concurrency(
+        strategy: :queue,
+        max_queue_size: 1,
+        overflow_policy: :drop_newest
+      )
+
+    assert {:acquired, chat} = Chat.acquire_lock(chat, "thread:newest", "owner-1", now_ms: 0)
+
+    assert {:queued, chat} =
+             Chat.acquire_lock(chat, "thread:newest", "owner-2",
+               now_ms: 1,
+               metadata: %{message: %{id: "m2"}}
+             )
+
+    assert {:dropped, chat} =
+             Chat.acquire_lock(chat, "thread:newest", "owner-3",
+               now_ms: 2,
+               metadata: %{message: %{id: "m3"}}
+             )
+
+    assert {{:drained, drained}, _chat} =
+             Chat.drain_lock(chat, "thread:newest", "owner-1", now_ms: 2)
+
+    assert drained.owner == "owner-2"
+    assert drained.metadata.message.id == "m2"
+  end
+
+  test "drain discards expired entries with deterministic metadata" do
+    chat =
+      Chat.new()
+      |> Chat.configure_concurrency(strategy: :burst, debounce_ms: 0, queue_entry_ttl_ms: 10)
+
+    assert {:bursting, chat} = burst(chat, "owner-1", "m1", 0)
+    assert {:queued, chat} = burst(chat, "owner-2", "m2", 15)
+
+    assert {{:drained, drained}, chat} =
+             Chat.drain_lock(chat, "thread:overflow", "owner-1", now_ms: 20)
+
+    assert drained.metadata.message.id == "m2"
+    assert drained.context.total_count == 1
+
+    assert %{event: :expired, owner: "owner-1", expired_at: 10} =
+             Enum.find(Chat.concurrency_events(chat), &(&1.event == :expired))
+  end
+
+  test "debounce records superseded entries and drains only the latest" do
+    chat = Chat.new() |> Chat.configure_concurrency(strategy: :debounce, debounce_ms: 50)
+
+    assert {:acquired, chat} = Chat.acquire_lock(chat, "thread:debounce-meta", "owner-1", now_ms: 0)
+
+    assert {:debounced, chat} =
+             Chat.acquire_lock(chat, "thread:debounce-meta", "owner-2",
+               now_ms: 10,
+               metadata: %{message: %{id: "m2"}}
+             )
+
+    assert {:debounced, chat} =
+             Chat.acquire_lock(chat, "thread:debounce-meta", "owner-3",
+               now_ms: 20,
+               metadata: %{message: %{id: "m3"}}
+             )
+
+    assert {{:waiting, _}, _chat} =
+             Chat.drain_lock(chat, "thread:debounce-meta", "owner-1", now_ms: 69)
+
+    assert {{:drained, drained}, chat} =
+             Chat.drain_lock(chat, "thread:debounce-meta", "owner-1", now_ms: 70)
+
+    assert drained.owner == "owner-3"
+    assert drained.context == MessageContext.new(skipped: [], total_count: 1)
+
+    assert %{event: :superseded, owner: "owner-2", superseded_by: "owner-3"} =
+             Enum.find(Chat.concurrency_events(chat), &(&1.event == :superseded))
+  end
+
+  test "channel lock scope drains one conversation and retains the other with its deadline" do
+    chat =
+      Chat.new()
+      |> Chat.configure_concurrency(strategy: :burst, debounce_ms: 100, lock_scope: :channel)
+
+    assert {:bursting, chat} =
+             Chat.acquire_lock(chat, "thread:one", "owner-1",
+               channel_id: "channel:a",
+               now_ms: 0,
+               conversation_key: "thread:one",
+               metadata: %{message: %{id: "m1"}}
+             )
+
+    assert {:queued, chat} =
+             Chat.acquire_lock(chat, "thread:two", "owner-2",
+               channel_id: "channel:a",
+               now_ms: 10,
+               conversation_key: "thread:two",
+               metadata: %{message: %{id: "m2"}}
+             )
+
+    assert {:bursting, chat} =
+             Chat.acquire_lock(chat, "thread:three", "owner-3",
+               channel_id: "channel:b",
+               now_ms: 1,
+               metadata: %{message: %{id: "m3"}}
+             )
+
+    assert %{locks: locks} = Chat.lock_snapshot(chat)
+    assert Map.keys(locks) |> Enum.sort() == ["channel:a", "channel:b"]
+
+    assert {{:drained, first}, chat} =
+             Chat.drain_lock(chat, "thread:one", "owner-1",
+               channel_id: "channel:a",
+               conversation_key: "thread:one",
+               now_ms: 100
+             )
+
+    assert first.owner == "owner-1"
+    assert first.context.skipped == []
+
+    assert %{
+             locks: %{
+               "channel:a" => %{
+                 owner: "owner-2",
+                 conversation_key: "thread:two",
+                 ready_at: 110
+               }
+             },
+             pending_locks: %{"channel:a" => [%{owner: "owner-2"}]}
+           } = Chat.lock_snapshot(chat)
+
+    assert {{:waiting, %{remaining_ms: 1}}, ^chat} =
+             Chat.drain_lock(chat, "thread:two", "owner-2",
+               channel_id: "channel:a",
+               conversation_key: "thread:two",
+               now_ms: 109
+             )
+
+    assert {{:drained, second}, chat} =
+             Chat.drain_lock(chat, "thread:two", "owner-2",
+               channel_id: "channel:a",
+               conversation_key: "thread:two",
+               now_ms: 110
+             )
+
+    assert second.owner == "owner-2"
+    assert %{locks: %{}, pending_locks: %{}} = Chat.lock_snapshot(chat)
+
+    assert [first_event, second_event] =
+             Chat.concurrency_events(chat)
+             |> Enum.filter(&(&1.event == :drained))
+
+    assert %{owner: "owner-1", conversation_key: "thread:one", drained_count: 1} = first_event
+    assert %{owner: "owner-2", conversation_key: "thread:two", drained_count: 1} = second_event
+  end
+
+  test "channel-scoped debounce only supersedes entries in the same conversation" do
+    chat =
+      Chat.new()
+      |> Chat.configure_concurrency(strategy: :debounce, debounce_ms: 50, lock_scope: :channel)
+
+    assert {:acquired, chat} =
+             Chat.acquire_lock(chat, "thread:one", "owner-1",
+               channel_id: "channel:a",
+               conversation_key: "thread:one",
+               now_ms: 0
+             )
+
+    assert {:debounced, chat} =
+             Chat.acquire_lock(chat, "thread:one", "owner-2",
+               channel_id: "channel:a",
+               conversation_key: "thread:one",
+               now_ms: 10,
+               metadata: %{message: %{id: "m2"}}
+             )
+
+    assert {:debounced, chat} =
+             Chat.acquire_lock(chat, "thread:two", "owner-3",
+               channel_id: "channel:a",
+               conversation_key: "thread:two",
+               now_ms: 20,
+               metadata: %{message: %{id: "m3"}}
+             )
+
+    assert {:debounced, chat} =
+             Chat.acquire_lock(chat, "thread:one", "owner-4",
+               channel_id: "channel:a",
+               conversation_key: "thread:one",
+               now_ms: 30,
+               metadata: %{message: %{id: "m4"}}
+             )
+
+    assert %{pending_locks: %{"channel:a" => pending}} = Chat.lock_snapshot(chat)
+    assert Enum.map(pending, & &1.owner) == ["owner-3", "owner-4"]
+
+    assert [%{owner: "owner-2", superseded_by: "owner-4", conversation_key: "thread:one"}] =
+             Chat.concurrency_events(chat)
+             |> Enum.filter(&(&1.event == :superseded))
+  end
+
+  test "concurrent strategy can bound active handlers per key" do
+    chat =
+      Chat.new()
+      |> Chat.configure_concurrency(strategy: :concurrent, max_concurrent: 2)
+
+    assert {:acquired, chat} = Chat.acquire_lock(chat, "thread:slots", "owner-1")
+    assert {:acquired, chat} = Chat.acquire_lock(chat, "thread:slots", "owner-2")
+    assert {:busy, chat} = Chat.acquire_lock(chat, "thread:slots", "owner-3")
+
+    assert {{:released, []}, chat} = Chat.release_lock(chat, "thread:slots", "owner-1")
+    assert {:acquired, _chat} = Chat.acquire_lock(chat, "thread:slots", "owner-3")
+  end
+
+  test "pending burst state survives serialization and old snapshots still load" do
+    chat = Chat.new() |> Chat.configure_concurrency(strategy: :burst, debounce_ms: 100)
+    assert {:bursting, chat} = burst(chat, "owner-1", "m1", 10)
+
+    encoded = Chat.to_map(chat)
+    revived = encoded |> Jason.encode!() |> Jason.decode!() |> Chat.from_map()
+
+    assert encoded["concurrency_events"] != []
+
+    assert {{:drained, drained}, _chat} =
+             Chat.drain_lock(revived, "thread:overflow", "owner-1", now_ms: 110)
+
+    assert drained.metadata["message"]["id"] == "m1"
+    assert Enum.map(Chat.concurrency_events(revived), & &1.event) == [:queued]
+
+    legacy = Chat.from_map(%{"id" => "legacy", "user_name" => "bot"})
+    assert %{locks: %{}, pending_locks: %{}} = Chat.lock_snapshot(legacy)
+    assert Chat.concurrency_events(legacy) == []
+  end
+
+  test "process_message passes optional drained context to context-aware handlers" do
+    test_pid = self()
+    context = MessageContext.new(skipped: [%{id: "m1"}], total_count: 2)
+
+    chat =
+      Chat.new(adapters: %{test: TestAdapter})
+      |> Chat.on_new_mention(fn _chat, _thread, incoming, received_context ->
+        send(test_pid, {:handled, incoming.external_message_id, received_context})
+      end)
+
+    incoming =
+      Incoming.new(%{
+        external_room_id: "room-1",
+        external_message_id: "m2",
+        text: "@bot hello",
+        was_mentioned: true
+      })
+
+    assert {:ok, _chat, ^incoming} =
+             Chat.process_message(chat, :test, "test:room-1", incoming, message_context: context)
+
+    assert_received {:handled, "m2", ^context}
+  end
+
+  test "ordinary messages give context-aware mention handlers a default context" do
+    assert_default_context_for_route(:mention)
+  end
+
+  test "ordinary messages give context-aware regex handlers a default context" do
+    assert_default_context_for_route(:message)
+  end
+
+  test "ordinary messages give context-aware subscribed handlers a default context" do
+    assert_default_context_for_route(:subscribed)
+  end
+
+  test "message context does not change the legacy stateful handler arguments" do
+    test_pid = self()
+    context = MessageContext.new(skipped: [%{id: "m1"}], total_count: 2)
+
+    chat =
+      Chat.new(adapters: %{test: TestAdapter})
+      |> Chat.on_new_mention(fn received_chat, thread, incoming ->
+        send(test_pid, {:legacy_handler, received_chat.id, thread.id, incoming.external_message_id})
+      end)
+
+    incoming =
+      Incoming.new(%{
+        external_room_id: "room-1",
+        external_message_id: "m3",
+        text: "@bot hello again",
+        was_mentioned: true
+      })
+
+    assert {:ok, _chat, ^incoming} =
+             Chat.process_message(chat, :test, "test:room-1", incoming, message_context: context)
+
+    assert_received {:legacy_handler, chat_id, "test:room-1", "m3"}
+    assert chat_id == chat.id
+  end
+
+  defp burst(chat, owner, message_id, now_ms) do
+    Chat.acquire_lock(chat, "thread:overflow", owner,
+      now_ms: now_ms,
+      metadata: %{message: %{id: message_id}}
+    )
+  end
+
+  defp assert_default_context_for_route(route) do
+    test_pid = self()
+    thread_id = "test:ordinary-#{route}"
+
+    handler = fn received_chat, _thread, _incoming, context ->
+      send(test_pid, {:ordinary_context, route, context})
+      received_chat
+    end
+
+    chat =
+      Chat.new(adapters: %{test: TestAdapter})
+      |> register_route_handler(route, handler)
+      |> maybe_subscribe(route, thread_id)
+
+    incoming =
+      Incoming.new(%{
+        external_room_id: "ordinary-#{route}",
+        external_message_id: "ordinary-#{route}",
+        text: if(route == :message, do: "ping", else: "@bot hello"),
+        was_mentioned: route == :mention
+      })
+
+    assert {:ok, _chat, ^incoming} = Chat.process_message(chat, :test, thread_id, incoming)
+
+    assert_received {:ordinary_context, ^route, %MessageContext{} = context}
+    assert context == MessageContext.new(skipped: [], total_count: 1)
+  end
+
+  defp register_route_handler(chat, :mention, handler), do: Chat.on_new_mention(chat, handler)
+
+  defp register_route_handler(chat, :message, handler),
+    do: Chat.on_new_message(chat, ~r/^ping$/, handler)
+
+  defp register_route_handler(chat, :subscribed, handler),
+    do: Chat.on_subscribed_message(chat, handler)
+
+  defp maybe_subscribe(chat, :subscribed, thread_id), do: Chat.subscribe(chat, thread_id)
+  defp maybe_subscribe(chat, _route, _thread_id), do: chat
 end

--- a/test/jido/chat/serialization_test.exs
+++ b/test/jido/chat/serialization_test.exs
@@ -147,6 +147,25 @@ defmodule Jido.Chat.SerializationTest do
     assert Chat.channel_state(revived, "test:chan-1") == %{"topic" => "general"}
   end
 
+  test "custom state adapters keep the existing lock callback contract" do
+    chat =
+      Chat.new(state_adapter: WrappedStateAdapter)
+      |> Chat.configure_concurrency(strategy: :queue)
+
+    assert {:acquired, chat} = Chat.acquire_lock(chat, "thread:custom", "owner-1", now_ms: 10)
+
+    assert {:queued, chat} =
+             Chat.acquire_lock(chat, "thread:custom", "owner-2",
+               now_ms: 20,
+               metadata: %{message_id: "m2"}
+             )
+
+    assert {{:released, [entry]}, _chat} =
+             Chat.release_lock(chat, "thread:custom", "owner-1")
+
+    assert entry.metadata == %{message_id: "m2"}
+  end
+
   test "thread and channel refs round-trip with module adapters" do
     thread =
       Thread.new(%{


### PR DESCRIPTION
## Summary

- Add bounded burst, debounce, queue, and reject concurrency strategies.
- Dispatch the latest burst message with ordered skipped-message context after an idle window.
- Enforce queue size, entry TTL, overflow policy, conversation isolation, and maximum concurrency.
- Add deterministic concurrency events, snapshots, and handler dispatch for three- and four-argument handlers.
- Make release expiry-aware, retain queued work for other conversations, and reset the burst deadline when a message is accepted.

## Validation

- `mix test test/jido/chat/concurrency_test.exs` — 22 tests passed.
- `mix test` — 149 tests passed.
- `mix quality` — passed, including Credo, Dialyzer, and Doctor.
- `git diff --check` — passed.
- Structured code review run `20260821-084352-39b344f1` — all five validated findings fixed.

## Post-Deploy Monitoring & Validation

- Run burst and debounce traffic through channel and thread scopes.
- Confirm queue size and TTL bounds under sustained traffic.
- Confirm each conversation drains independently and no accepted message is lost.
- Watch for handler arity errors, split bursts, or late dispatch after the idle window.

Related: agentjido/jido_chat#39

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
