### PR TITLE
feat(markdown): harden streamed rendering

### DIFF
--- a/lib/jido/chat/adapter.ex
+++ b/lib/jido/chat/adapter.ex
@@ -34,13 +34,14 @@ defmodule Jido.Chat.Adapter do
     Postable,
     PostPayload,
     Response,
-    StreamChunk,
     Thread,
     ThreadPage,
     UserInfo,
     WebhookRequest,
     WebhookResponse
   }
+
+  alias Jido.Chat.Markdown.StreamRenderer
 
   @type raw_payload :: map()
   @type external_room_id :: String.t() | integer()
@@ -423,7 +424,14 @@ defmodule Jido.Chat.Adapter do
     end
   end
 
-  @doc "Streams chunked text using adapter stream callback or send fallback."
+  @doc """
+  Streams chunked text with the adapter's native callback or a core fallback.
+
+  Adapters with native or append-only transport receive the original enumerable and
+  can use `Jido.Chat.Markdown.StreamRenderer` to build safe snapshots. Core fallback
+  mode `:post_edit` posts once and edits safe snapshots. Mode `:final` posts the exact
+  final Markdown once.
+  """
   @spec stream(module(), external_room_id(), Enumerable.t(), keyword()) :: send_result()
   def stream(adapter_module, external_room_id, chunks, opts \\ []) do
     if callback_exported?(adapter_module, :stream, 3) do
@@ -432,33 +440,49 @@ defmodule Jido.Chat.Adapter do
       end
     else
       fallback_chunks = Enum.to_list(chunks)
-      fallback_text = stream_fallback_text(fallback_chunks)
       fallback_mode = Keyword.get(opts, :fallback_mode, default_stream_fallback(adapter_module))
       placeholder_text = Keyword.get(opts, :placeholder_text, "Working...")
       update_every = Keyword.get(opts, :update_every, 1)
       stream_opts = Keyword.drop(opts, [:fallback_mode, :placeholder_text, :update_every])
+      fallback_text = StreamRenderer.render(fallback_chunks)
+      chunk_count = length(fallback_chunks)
 
       cond do
+        is_nil(fallback_text) ->
+          {:error, :empty_stream}
+
         fallback_mode == :post_edit and callback_exported?(adapter_module, :edit_message, 4) ->
-          with {:ok, initial_response} <-
-                 send_message(adapter_module, external_room_id, placeholder_text, stream_opts),
-               {:ok, final_response} <-
-                 stream_post_edit_fallback(
-                   adapter_module,
-                   external_room_id,
-                   initial_response,
-                   fallback_chunks,
-                   stream_opts,
-                   update_every
-                 ) do
-            {:ok, final_response}
-          end
+          stream_post_edit_fallback(
+            adapter_module,
+            external_room_id,
+            fallback_chunks,
+            stream_opts,
+            %{
+              placeholder_text: placeholder_text,
+              update_every: update_every,
+              chunk_count: chunk_count,
+              final_text: fallback_text
+            }
+          )
 
         true ->
-          send_message(adapter_module, external_room_id, fallback_text, stream_opts)
+          with {:ok, response} <-
+                 send_message(adapter_module, external_room_id, fallback_text, stream_opts) do
+            {:ok,
+             with_stream_metadata(
+               response,
+               fallback_mode,
+               chunk_count,
+               fallback_text
+             )}
+          end
       end
     end
   end
+
+  @doc "Renders a finite stream with the canonical provider-independent Markdown rules."
+  @spec render_stream(Enumerable.t()) :: String.t() | nil
+  def render_stream(chunks), do: StreamRenderer.render(chunks)
 
   @doc "Normalizes adapter edit results to `Jido.Chat.Response`."
   @spec edit_message(module(), external_room_id(), external_message_id(), String.t(), keyword()) ::
@@ -1424,44 +1448,106 @@ defmodule Jido.Chat.Adapter do
   defp stream_post_edit_fallback(
          adapter_module,
          external_room_id,
-         initial_response,
          chunks,
          stream_opts,
-         update_every
+         stream_state
+       ) do
+    update_every = normalize_update_every(stream_state.update_every)
+
+    with {:ok, initial} <-
+           start_stream_edit(adapter_module, external_room_id, stream_opts, stream_state.placeholder_text),
+         {:ok, streamed} <-
+           apply_stream_chunks(
+             adapter_module,
+             external_room_id,
+             chunks,
+             stream_opts,
+             update_every,
+             initial
+           ),
+         {:ok, completed} <-
+           apply_stream_text(
+             adapter_module,
+             external_room_id,
+             stream_opts,
+             streamed,
+             stream_state.final_text
+           ) do
+      {:ok,
+       with_stream_metadata(
+         completed.response,
+         :post_edit,
+         stream_state.chunk_count,
+         stream_state.final_text
+       )}
+    end
+  end
+
+  defp start_stream_edit(adapter_module, external_room_id, stream_opts, placeholder_text) do
+    if nonblank?(placeholder_text) do
+      with {:ok, response} <-
+             send_message(adapter_module, external_room_id, placeholder_text, stream_opts) do
+        {:ok, %{renderer: StreamRenderer.new(), response: response, last_text: placeholder_text}}
+      end
+    else
+      {:ok, %{renderer: StreamRenderer.new(), response: nil, last_text: nil}}
+    end
+  end
+
+  defp apply_stream_chunks(
+         adapter_module,
+         external_room_id,
+         chunks,
+         stream_opts,
+         update_every,
+         initial
        ) do
     total = length(chunks)
-    update_every = if is_integer(update_every) and update_every > 0, do: update_every, else: 1
 
     chunks
     |> Enum.with_index(1)
-    |> Enum.reduce_while({:ok, "", initial_response}, fn {chunk, index}, {:ok, acc_text, response} ->
-      next_text = acc_text <> render_stream_chunk(chunk)
-      should_update = rem(index, update_every) == 0 or index == total
+    |> Enum.reduce_while({:ok, initial}, fn {chunk, index}, {:ok, state} ->
+      boundary? = rem(index, update_every) == 0 or index == total
 
-      if should_update do
-        case edit_message(
-               adapter_module,
-               external_room_id,
-               initial_response.external_message_id,
-               next_text,
-               stream_opts
-             ) do
-          {:ok, next_response} ->
-            {:cont, {:ok, next_text, with_stream_metadata(next_response, :post_edit, total, next_text)}}
-
-          {:error, _reason} = error ->
-            {:halt, error}
+      {renderer, text} =
+        if boundary? do
+          {renderer, _update} = StreamRenderer.push(state.renderer, chunk)
+          {renderer, StreamRenderer.snapshot(renderer)}
+        else
+          {StreamRenderer.append(state.renderer, chunk), nil}
         end
-      else
-        {:cont, {:ok, next_text, response}}
+
+      state = %{state | renderer: renderer}
+
+      case apply_stream_text(adapter_module, external_room_id, stream_opts, state, text) do
+        {:ok, next_state} -> {:cont, {:ok, next_state}}
+        {:error, _reason} = error -> {:halt, error}
       end
     end)
-    |> case do
-      {:ok, _text, response} ->
-        {:ok, response}
+  end
 
-      {:error, _reason} = error ->
-        error
+  defp apply_stream_text(_adapter_module, _external_room_id, _stream_opts, state, nil),
+    do: {:ok, state}
+
+  defp apply_stream_text(_adapter_module, _external_room_id, _stream_opts, %{last_text: text} = state, text),
+    do: {:ok, state}
+
+  defp apply_stream_text(adapter_module, external_room_id, stream_opts, %{response: nil} = state, text) do
+    with {:ok, response} <- send_message(adapter_module, external_room_id, text, stream_opts) do
+      {:ok, %{state | response: response, last_text: text}}
+    end
+  end
+
+  defp apply_stream_text(adapter_module, external_room_id, stream_opts, state, text) do
+    with {:ok, response} <-
+           edit_message(
+             adapter_module,
+             external_room_id,
+             state.response.external_message_id,
+             text,
+             stream_opts
+           ) do
+      {:ok, %{state | response: response, last_text: text}}
     end
   end
 
@@ -1475,54 +1561,11 @@ defmodule Jido.Chat.Adapter do
     %{response | metadata: metadata}
   end
 
-  defp stream_fallback_text(chunks) do
-    chunks
-    |> Enum.map(&render_stream_chunk/1)
-    |> Enum.join("")
-  end
+  defp normalize_update_every(value) when is_integer(value) and value > 0, do: value
+  defp normalize_update_every(_value), do: 1
 
-  defp render_stream_chunk(%StreamChunk{} = chunk) do
-    case chunk.kind do
-      :text -> chunk.text || ""
-      :markdown -> chunk.text || ""
-      :status -> bracketed_chunk(chunk)
-      :plan -> plan_chunk(chunk)
-      :step_start -> step_chunk(chunk)
-      :step_finish -> "\n"
-      :data -> ""
-    end
-  end
-
-  defp render_stream_chunk(chunk) when is_map(chunk),
-    do: chunk |> StreamChunk.new() |> render_stream_chunk()
-
-  defp render_stream_chunk(chunk), do: to_string(chunk)
-
-  defp bracketed_chunk(%StreamChunk{} = chunk) do
-    case StreamChunk.fallback_text(chunk) do
-      "" -> ""
-      text -> "\n[#{text}]\n"
-    end
-  end
-
-  defp plan_chunk(%StreamChunk{} = chunk) do
-    case chunk.payload do
-      items when is_list(items) ->
-        "\n" <>
-          (items
-           |> Enum.map_join("\n", fn item -> "- " <> to_string(item) end)) <> "\n"
-
-      _other ->
-        bracketed_chunk(chunk)
-    end
-  end
-
-  defp step_chunk(%StreamChunk{} = chunk) do
-    case StreamChunk.fallback_text(chunk) do
-      "" -> ""
-      text -> "\n\n#{text}\n"
-    end
-  end
+  defp nonblank?(text) when is_binary(text), do: String.trim(text) != ""
+  defp nonblank?(_text), do: false
 
   defp normalize_markdown_payload(%Markdown{} = markdown), do: markdown
   defp normalize_markdown_payload(%{} = markdown), do: Markdown.new(markdown)

--- a/lib/jido/chat/markdown/stream_renderer.ex
+++ b/lib/jido/chat/markdown/stream_renderer.ex
@@ -1,0 +1,429 @@
+defmodule Jido.Chat.Markdown.StreamRenderer do
+  @moduledoc """
+  Builds safe Markdown snapshots from an incremental, provider-independent stream.
+
+  The renderer keeps the original text. `push/2` can return a repaired snapshot for
+  an in-progress edit. `flush/1` returns stable final Markdown and keeps complete,
+  supported Markdown exact. Possible table headers and partial table rows are held
+  until their structure is known.
+  """
+
+  alias Jido.Chat.StreamChunk
+
+  @type t :: %__MODULE__{
+          parts: [iodata()],
+          snapshot: String.t() | nil,
+          exact_snapshot?: boolean()
+        }
+
+  defstruct parts: [],
+            snapshot: nil,
+            exact_snapshot?: true
+
+  @doc "Creates an empty streaming Markdown renderer."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc "Adds one text or structured stream chunk and returns a changed safe snapshot."
+  @spec push(t(), term()) :: {t(), String.t() | nil}
+  def push(%__MODULE__{} = renderer, chunk) do
+    text = StreamChunk.markdown_fallback(chunk)
+
+    if incremental_exact_append?(renderer, text) do
+      push_exact_text(renderer, text)
+    else
+      push_with_full_scan(renderer, text)
+    end
+  end
+
+  @doc "Adds one chunk without calculating a partial snapshot."
+  @spec append(t(), term()) :: t()
+  def append(%__MODULE__{} = renderer, chunk) do
+    %{
+      renderer
+      | parts: [StreamChunk.markdown_fallback(chunk) | renderer.parts],
+        exact_snapshot?: false
+    }
+  end
+
+  @doc "Returns the current safe replacement snapshot without changing state."
+  @spec snapshot(t()) :: String.t() | nil
+  def snapshot(%__MODULE__{snapshot: snapshot}), do: snapshot
+
+  @doc "Returns stable final Markdown, or nil when there is no visible text."
+  @spec flush(t()) :: String.t() | nil
+  def flush(%__MODULE__{} = renderer), do: renderer |> source() |> render_snapshot(:final)
+
+  @doc "Renders a finite stream to its exact final Markdown fallback."
+  @spec render(Enumerable.t()) :: String.t() | nil
+  def render(chunks) do
+    chunks
+    |> Enum.reduce(new(), &append(&2, &1))
+    |> flush()
+  end
+
+  defp incremental_exact_append?(%__MODULE__{} = renderer, text) do
+    renderer.exact_snapshot? and plain_text_chunk?(text)
+  end
+
+  defp plain_text_chunk?(text) do
+    not String.contains?(text, ["\\", "`", "~", "*", "_", "[", "]", "(", ")", "|", "\n", "\r"])
+  end
+
+  defp push_exact_text(%__MODULE__{} = renderer, text) do
+    snapshot = exact_snapshot(renderer.snapshot, text)
+    update = if snapshot == renderer.snapshot, do: nil, else: snapshot
+
+    next = %{
+      renderer
+      | parts: [text | renderer.parts],
+        snapshot: snapshot,
+        exact_snapshot?: is_binary(snapshot) or text == ""
+    }
+
+    {next, update}
+  end
+
+  defp exact_snapshot(nil, text), do: visible_text(text)
+  defp exact_snapshot(snapshot, text), do: snapshot <> text
+
+  defp push_with_full_scan(%__MODULE__{} = renderer, text) do
+    renderer = %{renderer | parts: [text | renderer.parts]}
+    source = source(renderer)
+    snapshot = render_snapshot(source, :partial)
+    update = if snapshot == renderer.snapshot, do: nil, else: snapshot
+
+    next = %{
+      renderer
+      | snapshot: snapshot,
+        exact_snapshot?: snapshot == source or (is_nil(snapshot) and source == "")
+    }
+
+    {next, update}
+  end
+
+  defp source(%__MODULE__{parts: parts}) do
+    parts |> Enum.reverse() |> IO.iodata_to_binary()
+  end
+
+  defp render_snapshot(source, :partial) do
+    source
+    |> buffer_partial_table()
+    |> visible_text()
+    |> repair_markdown(:partial)
+  end
+
+  defp render_snapshot(source, :final), do: source |> visible_text() |> repair_markdown(:final)
+
+  defp visible_text(text) when is_binary(text) do
+    if String.trim(text) == "", do: nil, else: text
+  end
+
+  defp repair_markdown(nil, _phase), do: nil
+
+  defp repair_markdown(text, phase) do
+    text = buffer_trailing_emphasis_delimiter(text, phase)
+
+    case visible_text(text) do
+      nil ->
+        nil
+
+      text ->
+        case open_fence(text) do
+          nil -> repair_inline_markdown(text)
+          fence -> text <> newline_before_closer(text) <> fence
+        end
+    end
+  end
+
+  defp buffer_trailing_emphasis_delimiter(text, phase) do
+    cond do
+      String.ends_with?(text, "\\*") or String.ends_with?(text, "\\_") ->
+        text
+
+      String.ends_with?(text, "**") ->
+        maybe_buffer_delimiter(text, "**", phase)
+
+      String.ends_with?(text, "__") ->
+        maybe_buffer_delimiter(text, "__", phase)
+
+      String.ends_with?(text, "*") and not String.ends_with?(text, "**") ->
+        maybe_buffer_delimiter(text, "*", phase)
+
+      String.ends_with?(text, "_") and not String.ends_with?(text, "__") ->
+        maybe_buffer_delimiter(text, "_", phase)
+
+      true ->
+        text
+    end
+  end
+
+  defp maybe_buffer_delimiter(text, delimiter, phase) do
+    prefix = String.slice(text, 0, String.length(text) - String.length(delimiter))
+
+    if phase == :partial or unclosed_delimiter?(prefix, delimiter) do
+      prefix
+    else
+      text
+    end
+  end
+
+  defp unclosed_delimiter?(text, delimiter) do
+    text
+    |> emphasis_stack()
+    |> Enum.any?(&String.contains?(&1, delimiter))
+  end
+
+  defp repair_inline_markdown(text) do
+    if odd_inline_backticks?(text) do
+      text <> "`"
+    else
+      text
+      |> close_partial_link()
+      |> close_partial_emphasis()
+    end
+  end
+
+  defp open_fence(text) do
+    text
+    |> String.split("\n", trim: false)
+    |> Enum.reduce(nil, fn line, open -> next_fence_state(line, open) end)
+  end
+
+  defp next_fence_state(line, nil), do: opening_fence(line)
+
+  defp next_fence_state(line, marker) do
+    if closing_fence?(line, marker), do: nil, else: marker
+  end
+
+  defp opening_fence(line) do
+    case Regex.run(~r/^ {0,3}(`{3,}|~{3,})/, line, capture: :all_but_first) do
+      [marker] -> marker
+      _other -> nil
+    end
+  end
+
+  defp closing_fence?(line, open_marker) do
+    case Regex.run(~r/^ {0,3}(`{3,}|~{3,})(.*)$/, line, capture: :all_but_first) do
+      [marker, suffix] ->
+        String.first(marker) == String.first(open_marker) and
+          byte_size(marker) >= byte_size(open_marker) and String.trim(suffix) == ""
+
+      _other ->
+        false
+    end
+  end
+
+  defp newline_before_closer(text) do
+    if String.ends_with?(text, "\n"), do: "", else: "\n"
+  end
+
+  defp odd_inline_backticks?(text) do
+    ~r/(?<!\\)`(?!``)/
+    |> Regex.scan(text)
+    |> length()
+    |> rem(2) == 1
+  end
+
+  defp close_partial_link(text) do
+    cond do
+      unmatched_link_destination?(text) -> text <> ")"
+      unmatched_link_label?(text) -> text <> "]()"
+      true -> text
+    end
+  end
+
+  defp unmatched_link_destination?(text) do
+    case :binary.matches(text, "](") do
+      [] ->
+        false
+
+      matches ->
+        {position, _length} = List.last(matches)
+        suffix = binary_part(text, position + 2, byte_size(text) - position - 2)
+        count_character(suffix, "(") >= count_character(suffix, ")")
+    end
+  end
+
+  defp unmatched_link_label?(text) do
+    opens = count_unescaped(text, "[")
+    closes = count_unescaped(text, "]")
+    opens > closes
+  end
+
+  defp close_partial_emphasis(text) do
+    scan_text =
+      ~r/`[^`]*`/
+      |> Regex.replace(text, "")
+      |> then(&Regex.replace(~r/\]\([^)]*\)/, &1, ""))
+
+    text <> Enum.join(emphasis_stack(scan_text), "")
+  end
+
+  defp emphasis_stack(text) do
+    ~r/(?<!\\)(\*\*|__|\*|_)/
+    |> Regex.scan(text, capture: :all_but_first, return: :index)
+    |> List.flatten()
+    |> Enum.reduce([], fn {position, length}, stack ->
+      delimiter = binary_part(text, position, length)
+      previous = previous_grapheme(text, position)
+      following = following_grapheme(text, position + length)
+      {can_open?, can_close?} = delimiter_flanking(delimiter, previous, following)
+
+      case stack do
+        [^delimiter | rest] when can_close? -> rest
+        _other when can_open? -> [delimiter | stack]
+        _other -> stack
+      end
+    end)
+  end
+
+  defp delimiter_flanking(delimiter, previous, following) do
+    can_open? = not is_nil(following) and not whitespace?(following)
+    can_close? = not is_nil(previous) and not whitespace?(previous)
+
+    if delimiter in ["_", "__"] and alphanumeric?(previous) and alphanumeric?(following) do
+      {false, false}
+    else
+      {can_open?, can_close?}
+    end
+  end
+
+  defp previous_grapheme(_text, 0), do: nil
+  defp previous_grapheme(text, position), do: text |> binary_part(0, position) |> String.last()
+
+  defp following_grapheme(text, position) when position >= byte_size(text), do: nil
+
+  defp following_grapheme(text, position) do
+    text |> binary_part(position, byte_size(text) - position) |> String.first()
+  end
+
+  defp whitespace?(grapheme), do: Regex.match?(~r/^\s$/u, grapheme)
+  defp alphanumeric?(nil), do: false
+  defp alphanumeric?(grapheme), do: Regex.match?(~r/^[\p{L}\p{N}]$/u, grapheme)
+
+  defp count_unescaped(text, character) do
+    text
+    |> String.codepoints()
+    |> Enum.reduce({0, false}, fn
+      "\\", {count, escaped?} -> {count, not escaped?}
+      _value, {count, true} -> {count, false}
+      ^character, {count, false} -> {count + 1, false}
+      _value, {count, false} -> {count, false}
+    end)
+    |> elem(0)
+  end
+
+  defp count_character(text, character) do
+    text
+    |> String.codepoints()
+    |> Enum.count(&(&1 == character))
+  end
+
+  defp buffer_partial_table(text) do
+    lines = String.split(text, "\n", trim: false)
+
+    case partial_table_start(lines) || partial_table_row(lines) do
+      nil -> text
+      index -> buffered_prefix(lines, index)
+    end
+  end
+
+  defp buffered_prefix(_lines, 0), do: ""
+
+  defp buffered_prefix(lines, index) do
+    lines |> Enum.take(index) |> Enum.join("\n") |> Kernel.<>("\n")
+  end
+
+  defp partial_table_start(lines) do
+    count = length(lines)
+
+    cond do
+      count >= 2 and possible_table_header?(Enum.at(lines, count - 2)) and
+        not table_divider_before?(lines, count - 2) and
+        not complete_table_divider?(
+          Enum.at(lines, count - 1),
+          table_cell_count(Enum.at(lines, count - 2))
+        ) and table_divider_prefix?(Enum.at(lines, count - 1)) ->
+        count - 2
+
+      count >= 1 and possible_table_header?(List.last(lines)) and
+          not confirmed_table_divider_before?(lines, count - 1) ->
+        count - 1
+
+      true ->
+        nil
+    end
+  end
+
+  defp partial_table_row(lines) do
+    last_index = length(lines) - 1
+    last_line = List.last(lines)
+
+    if last_line != "" and String.contains?(last_line, "|") and
+         table_divider_before?(lines, last_index) do
+      last_index
+    end
+  end
+
+  defp confirmed_table_divider_before?(lines, index) when index >= 2 do
+    header = Enum.at(lines, index - 2)
+    divider = Enum.at(lines, index - 1)
+    possible_table_header?(header) and complete_table_divider?(divider, table_cell_count(header))
+  end
+
+  defp confirmed_table_divider_before?(_lines, _index), do: false
+
+  defp table_divider_before?(lines, before_index) do
+    if before_index >= 2 do
+      lines
+      |> Enum.take(before_index)
+      |> Enum.chunk_every(2, 1, :discard)
+      |> Enum.any?(fn [header, divider] ->
+        possible_table_header?(header) and
+          complete_table_divider?(divider, table_cell_count(header))
+      end)
+    else
+      false
+    end
+  end
+
+  defp possible_table_header?(line) do
+    String.contains?(line, "|") and not table_divider_line?(line)
+  end
+
+  defp table_divider_prefix?(line), do: Regex.match?(~r/^\s*[|:\- ]*$/, line)
+
+  defp complete_table_divider?(line, expected_cells) do
+    cells = table_cells(line)
+
+    expected_cells > 0 and length(cells) == expected_cells and
+      Enum.all?(cells, &Regex.match?(~r/^:?-{3,}:?$/, String.trim(&1)))
+  end
+
+  defp table_divider_line?(line) do
+    cells = table_cells(line)
+    cells != [] and Enum.all?(cells, &Regex.match?(~r/^:?-{3,}:?$/, String.trim(&1)))
+  end
+
+  defp table_cell_count(line), do: line |> table_cells() |> length()
+
+  defp table_cells(line) do
+    line
+    |> String.trim()
+    |> remove_optional_leading_pipe()
+    |> remove_optional_trailing_pipe()
+    |> String.split("|", trim: false)
+  end
+
+  defp remove_optional_leading_pipe("|" <> rest), do: rest
+  defp remove_optional_leading_pipe(line), do: line
+
+  defp remove_optional_trailing_pipe(line) do
+    if String.ends_with?(line, "|") do
+      binary_part(line, 0, byte_size(line) - 1)
+    else
+      line
+    end
+  end
+end

--- a/lib/jido/chat/post_payload.ex
+++ b/lib/jido/chat/post_payload.ex
@@ -4,6 +4,7 @@ defmodule Jido.Chat.PostPayload do
   """
 
   alias Jido.Chat.{Attachment, Card, FileUpload, Markdown, StreamChunk, Wire}
+  alias Jido.Chat.Markdown.StreamRenderer
 
   @schema Zoi.struct(
             __MODULE__,
@@ -313,16 +314,7 @@ defmodule Jido.Chat.PostPayload do
   defp normalize_card(card), do: {card, card, to_text_value(card)}
 
   defp stream_fallback_text(chunks) when is_list(chunks) do
-    chunks
-    |> Enum.map(fn
-      %StreamChunk{} = chunk -> StreamChunk.fallback_text(chunk)
-      value when is_binary(value) -> value
-      value when is_map(value) -> value |> StreamChunk.new() |> StreamChunk.fallback_text()
-      value -> to_string(value)
-    end)
-    |> Enum.reject(&(&1 in [nil, ""]))
-    |> Enum.join("")
-    |> blank_to_nil()
+    StreamRenderer.render(chunks)
   rescue
     _ -> nil
   end
@@ -355,9 +347,6 @@ defmodule Jido.Chat.PostPayload do
       {:error, _reason} -> inspect(value)
     end
   end
-
-  defp blank_to_nil(""), do: nil
-  defp blank_to_nil(value), do: value
 
   defp present?(nil), do: false
   defp present?(""), do: false

--- a/lib/jido/chat/stream_chunk.ex
+++ b/lib/jido/chat/stream_chunk.ex
@@ -9,7 +9,16 @@ defmodule Jido.Chat.StreamChunk do
             __MODULE__,
             %{
               kind:
-                Zoi.enum([:text, :markdown, :status, :plan, :data, :step_start, :step_finish])
+                Zoi.enum([
+                  :text,
+                  :markdown,
+                  :status,
+                  :plan,
+                  :data,
+                  :step_start,
+                  :step_finish,
+                  :timeline
+                ])
                 |> Zoi.default(:text),
               text: Zoi.string() |> Zoi.nullish(),
               payload: Zoi.any() |> Zoi.nullish(),
@@ -52,23 +61,110 @@ defmodule Jido.Chat.StreamChunk do
   @spec fallback_text(t() | String.t()) :: String.t()
   def fallback_text(value) when is_binary(value), do: value
 
+  def fallback_text(%__MODULE__{kind: kind, text: text})
+      when kind in [:text, :markdown] and is_binary(text),
+      do: text
+
   def fallback_text(%__MODULE__{kind: kind, text: text, payload: payload}) do
     cond do
       is_binary(text) and text != "" ->
-        text
+        plain_text(text)
 
-      kind in [:step_start, :step_finish] ->
-        payload_label(payload)
+      kind in [:step_start, :step_finish, :status] ->
+        payload |> payload_label() |> plain_text()
 
       kind == :plan ->
         payload_lines(payload)
 
-      kind == :status ->
-        payload_label(payload)
+      kind == :timeline ->
+        timeline_lines(payload)
 
       true ->
-        payload_label(payload) || ""
+        payload |> payload_label() |> plain_text()
     end
+  end
+
+  @doc "Returns a deterministic Markdown fallback for a text or structured chunk."
+  @spec markdown_fallback(term()) :: String.t()
+  def markdown_fallback(value) when is_binary(value), do: value
+  def markdown_fallback(%{} = value) when not is_struct(value), do: value |> new() |> markdown_fallback()
+
+  def markdown_fallback(%__MODULE__{kind: kind} = chunk) when kind in [:text, :markdown],
+    do: chunk.text || ""
+
+  def markdown_fallback(%__MODULE__{kind: :status} = chunk) do
+    case fallback_text(chunk) do
+      "" -> ""
+      text -> bracketed_markdown("Status", text)
+    end
+  end
+
+  def markdown_fallback(%__MODULE__{kind: :plan} = chunk) do
+    case payload_items(chunk.payload, [:steps, :items]) do
+      [] -> bracketed_markdown("Plan", fallback_text(chunk))
+      items -> "\n**Plan**\n\n" <> Enum.map_join(items, "\n", &("- " <> item_label(&1))) <> "\n"
+    end
+  end
+
+  def markdown_fallback(%__MODULE__{kind: :step_start} = chunk),
+    do: checklist_markdown(" ", fallback_text(chunk))
+
+  def markdown_fallback(%__MODULE__{kind: :step_finish} = chunk),
+    do: checklist_markdown("x", fallback_text(chunk))
+
+  def markdown_fallback(%__MODULE__{kind: :timeline} = chunk) do
+    case payload_items(chunk.payload, [:events, :entries, :items]) do
+      [] ->
+        bracketed_markdown("Timeline", fallback_text(chunk))
+
+      items ->
+        "\n**Timeline**\n\n" <>
+          Enum.map_join(items, "\n", &("- " <> timeline_item(&1))) <> "\n"
+    end
+  end
+
+  def markdown_fallback(%__MODULE__{kind: :data}), do: ""
+  def markdown_fallback(value), do: to_string(value)
+
+  defp checklist_markdown(_mark, ""), do: ""
+  defp checklist_markdown(mark, text), do: "\n- [#{mark}] #{inline_text(text)}\n"
+
+  defp bracketed_markdown(_label, ""), do: ""
+  defp bracketed_markdown(label, text), do: "\n> **#{label}:** #{inline_text(text)}\n"
+
+  defp payload_items(payload, _keys) when is_list(payload), do: payload
+
+  defp payload_items(payload, keys) when is_map(payload) do
+    Enum.find_value(keys, [], fn key ->
+      case Map.get(payload, key, Map.get(payload, Atom.to_string(key))) do
+        items when is_list(items) -> items
+        _other -> nil
+      end
+    end)
+  end
+
+  defp payload_items(_payload, _keys), do: []
+
+  defp timeline_item(item) when is_map(item) do
+    {at, label} = raw_timeline_item(item)
+    label = inline_text(label)
+    if at in [nil, ""], do: label, else: "#{inline_text(at)} — #{label}"
+  end
+
+  defp timeline_item(item), do: item_label(item)
+
+  defp item_label(item), do: item |> raw_item_label() |> inline_text()
+
+  defp map_value(map, keys) do
+    Enum.find_value(keys, fn key -> Map.get(map, key, Map.get(map, Atom.to_string(key))) end)
+  end
+
+  defp inline_text(text) do
+    text
+    |> to_string()
+    |> String.trim()
+    |> String.replace(~r/\s+/u, " ")
+    |> String.replace(~r/([\\`*_\[\]])/u, "\\\\\\1")
   end
 
   @doc "Serializes a stream chunk into a plain map with type marker."
@@ -93,11 +189,54 @@ defmodule Jido.Chat.StreamChunk do
 
   defp payload_lines(payload) when is_list(payload) do
     payload
-    |> Enum.map(&to_string/1)
+    |> Enum.map(&plain_item_label/1)
     |> Enum.join("\n")
   end
 
-  defp payload_lines(payload), do: payload_label(payload) || ""
+  defp payload_lines(payload) when is_map(payload) do
+    case payload_items(payload, [:steps, :items]) do
+      [] -> payload |> payload_label() |> plain_text()
+      items -> Enum.map_join(items, "\n", &plain_item_label/1)
+    end
+  end
+
+  defp payload_lines(payload), do: payload |> payload_label() |> plain_text()
+
+  defp timeline_lines(payload) do
+    case payload_items(payload, [:events, :entries, :items]) do
+      [] -> payload |> payload_label() |> plain_text()
+      items -> Enum.map_join(items, "\n", &plain_timeline_item/1)
+    end
+  end
+
+  defp plain_timeline_item(item) when is_map(item) do
+    {at, label} = raw_timeline_item(item)
+    label = plain_text(label)
+    if at in [nil, ""], do: label, else: "#{plain_text(at)} — #{label}"
+  end
+
+  defp plain_timeline_item(item), do: plain_item_label(item)
+
+  defp plain_item_label(item), do: item |> raw_item_label() |> plain_text()
+
+  defp raw_timeline_item(item) do
+    {map_value(item, [:at, :time, :timestamp]), raw_item_label(item)}
+  end
+
+  defp raw_item_label(item) when is_binary(item), do: item
+
+  defp raw_item_label(item) when is_map(item) do
+    map_value(item, [:label, :title, :text, :description, :name]) ||
+      inspect(item, limit: 50, printable_limit: 200)
+  end
+
+  defp raw_item_label(item), do: to_string(item)
+
+  defp plain_text(nil), do: ""
+
+  defp plain_text(text) do
+    text |> to_string() |> String.trim() |> String.replace(~r/\s+/u, " ")
+  end
 
   defp normalize_opts(opts) when is_list(opts), do: Map.new(opts)
   defp normalize_opts(opts) when is_map(opts), do: opts

--- a/test/jido/chat/adapter_conformance_test.exs
+++ b/test/jido/chat/adapter_conformance_test.exs
@@ -175,6 +175,39 @@ defmodule Jido.Chat.AdapterConformanceTest do
     end
   end
 
+  defmodule FailingStreamAdapter do
+    use Adapter
+
+    @impl true
+    def channel_type, do: :failing_stream
+
+    @impl true
+    def transform_incoming(payload), do: {:ok, Incoming.new(payload)}
+
+    @impl true
+    def send_message("send-failure", _text, _opts), do: {:error, :send_failed}
+
+    def send_message(room_id, _text, _opts) do
+      {:ok,
+       Response.new(%{
+         external_message_id: "msg_#{room_id}",
+         external_room_id: room_id
+       })}
+    end
+
+    @impl true
+    def edit_message(_room_id, _message_id, _text, _opts), do: {:error, :edit_failed}
+
+    @impl true
+    def capabilities do
+      %{
+        send_message: :native,
+        edit_message: :native,
+        stream: :fallback
+      }
+    end
+  end
+
   defmodule NilChannelTypeAdapter do
     use Adapter
 
@@ -347,6 +380,85 @@ defmodule Jido.Chat.AdapterConformanceTest do
     assert final_text =~ "alpha"
     assert final_text =~ "Plan"
     assert final_text =~ "- one"
+  end
+
+  test "final stream fallback sends exact Markdown and rejects streams without visible text" do
+    markdown = "Before **bold**\n\n| A |  | C |\n| --- | --- | --- |\n| 1 |  | 3 |"
+    chunks = Jido.Chat.StreamMarkdownFixtures.one_character_chunks(markdown)
+
+    assert Adapter.render_stream(chunks) == markdown
+
+    assert {:ok, %Response{} = response} =
+             Adapter.stream(FallbackAdapter, "room-final", chunks, fallback_mode: :final)
+
+    assert response.metadata.text == markdown
+    assert_received {:send_message, "room-final", ^markdown}
+
+    assert {:error, :empty_stream} =
+             Adapter.stream(FallbackAdapter, "room-empty", [], fallback_mode: :final)
+
+    assert {:error, :empty_stream} =
+             Adapter.stream(FallbackAdapter, "room-empty-edit", [],
+               fallback_mode: :post_edit,
+               placeholder_text: "working"
+             )
+
+    assert {:error, :empty_stream} =
+             Adapter.stream(
+               FallbackAdapter,
+               "room-tool",
+               [%{kind: :data, payload: %{tool: "search"}}],
+               fallback_mode: :final
+             )
+
+    refute_received {:send_message, "room-empty", _text}
+    refute_received {:send_message, "room-empty-edit", _text}
+    refute_received {:send_message, "room-tool", _text}
+  end
+
+  test "post-edit fallback never sends or edits empty text" do
+    assert {:ok, %Response{} = response} =
+             Adapter.stream(
+               FallbackAdapter,
+               "room-visible",
+               ["", "**", "done", "**"],
+               fallback_mode: :post_edit,
+               placeholder_text: "",
+               update_every: 1
+             )
+
+    assert response.metadata.final_text == "**done**"
+
+    assert_received {:send_message, "room-visible", first_text}
+    assert String.trim(first_text) != ""
+
+    edits =
+      Stream.repeatedly(fn ->
+        receive do
+          {:edit_message, "room-visible", _message_id, text} -> {:ok, text}
+        after
+          0 -> :done
+        end
+      end)
+      |> Enum.take_while(&(&1 != :done))
+      |> Enum.map(fn {:ok, text} -> text end)
+
+    assert Enum.all?(edits, &(String.trim(&1) != ""))
+    assert List.last([first_text | edits]) == "**done**"
+  end
+
+  test "post-edit stream fallback returns send and edit failures" do
+    assert {:error, :send_failed} =
+             Adapter.stream(FailingStreamAdapter, "send-failure", ["content"],
+               fallback_mode: :post_edit,
+               placeholder_text: "working"
+             )
+
+    assert {:error, :edit_failed} =
+             Adapter.stream(FailingStreamAdapter, "edit-failure", ["content"],
+               fallback_mode: :post_edit,
+               placeholder_text: "working"
+             )
   end
 
   test "typed card and modal helpers expose stable adapter-facing payloads" do

--- a/test/jido/chat/markdown_stream_renderer_test.exs
+++ b/test/jido/chat/markdown_stream_renderer_test.exs
@@ -1,0 +1,243 @@
+defmodule Jido.Chat.Markdown.StreamRendererTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Chat.Markdown.StreamRenderer
+  alias Jido.Chat.StreamChunk
+  alias Jido.Chat.StreamMarkdownFixtures
+
+  test "one-character streams flush to the non-streamed Markdown" do
+    for {name, markdown} <- StreamMarkdownFixtures.supported_documents() do
+      {renderer, updates} =
+        markdown
+        |> StreamMarkdownFixtures.one_character_chunks()
+        |> Enum.reduce({StreamRenderer.new(), []}, fn character, {renderer, updates} ->
+          {renderer, update} = StreamRenderer.push(renderer, character)
+          {renderer, [update | updates]}
+        end)
+
+      assert StreamRenderer.flush(renderer) == markdown, "fixture #{name} changed on flush"
+      assert StreamRenderer.render([markdown]) == markdown
+
+      updates
+      |> Enum.reject(&is_nil/1)
+      |> Enum.each(fn update ->
+        assert safe_snapshot?(update), "fixture #{name} emitted unsafe Markdown:\n#{update}"
+      end)
+    end
+  end
+
+  test "partial emphasis, links, and code fences get safe closing syntax" do
+    {renderer, emphasis} = StreamRenderer.new() |> StreamRenderer.push("**bold")
+    assert String.ends_with?(emphasis, "**")
+
+    {renderer, link} = StreamRenderer.push(renderer, " [guide](https://jido.run")
+    assert link =~ "[guide](https://jido.run)"
+
+    {_renderer, fence} = StreamRenderer.push(renderer, "\n\n```elixir\nIO.puts(:ok)")
+    assert String.ends_with?(fence, "\n```")
+
+    assert StreamRenderer.render(["**bold"]) == "**bold**"
+    assert StreamRenderer.render(["[guide](https://jido.run"]) == "[guide](https://jido.run)"
+    assert StreamRenderer.render(["```elixir\n:ok"]) == "```elixir\n:ok\n```"
+    assert StreamRenderer.render(["Price * tax and trailing_"]) == "Price * tax and trailing_"
+  end
+
+  test "code fence repairs preserve the opening marker and marker length" do
+    source = "````markdown\nliteral ``` content\nliteral ~~~ content"
+    {renderer, snapshot} = StreamRenderer.new() |> StreamRenderer.push(source)
+
+    assert snapshot == source <> "\n````"
+
+    {_renderer, closed_snapshot} = StreamRenderer.push(renderer, "\n````\n")
+    assert closed_snapshot == source <> "\n````\n"
+
+    tilde_source = "~~~~text\nliteral ``` and ~~~ content"
+    {_renderer, tilde_snapshot} = StreamRenderer.new() |> StreamRenderer.push(tilde_source)
+    assert tilde_snapshot == tilde_source <> "\n~~~~"
+  end
+
+  test "a possible table header is buffered until its divider is complete" do
+    {renderer, update} = StreamRenderer.new() |> StreamRenderer.push("| Name |  | State |\n")
+    assert update == nil
+
+    {renderer, update} = StreamRenderer.push(renderer, "| --- | ---")
+    assert update == nil
+
+    {renderer, update} = StreamRenderer.push(renderer, " | --- |\n")
+    assert update == "| Name |  | State |\n| --- | --- | --- |\n"
+
+    {renderer, update} = StreamRenderer.push(renderer, "| alpha |  ")
+    assert update == nil
+
+    {renderer, update} = StreamRenderer.push(renderer, "| ready |\n")
+
+    assert update ==
+             "| Name |  | State |\n| --- | --- | --- |\n| alpha |  | ready |\n"
+
+    assert StreamRenderer.flush(renderer) ==
+             "| Name |  | State |\n| --- | --- | --- |\n| alpha |  | ready |\n"
+  end
+
+  test "table parsing preserves adjacent empty cells before one optional outer pipe" do
+    {renderer, update} = StreamRenderer.new() |> StreamRenderer.push("| Name |||\n")
+    assert update == nil
+
+    {renderer, update} = StreamRenderer.push(renderer, "| --- | --- | --- |\n")
+    assert update == "| Name |||\n| --- | --- | --- |\n"
+
+    {renderer, update} = StreamRenderer.push(renderer, "| alpha |||\n")
+    assert update == "| Name |||\n| --- | --- | --- |\n| alpha |||\n"
+
+    assert StreamRenderer.flush(renderer) ==
+             "| Name |||\n| --- | --- | --- |\n| alpha |||\n"
+  end
+
+  test "plain one-character pushes preserve final content" do
+    renderer =
+      Enum.reduce(1..10_000, StreamRenderer.new(), fn _index, renderer ->
+        {renderer, _update} = StreamRenderer.push(renderer, "a")
+        renderer
+      end)
+
+    assert StreamRenderer.flush(renderer) == String.duplicate("a", 10_000)
+  end
+
+  test "incremental snapshots preserve leading blank chunks" do
+    {renderer, update} = StreamRenderer.new() |> StreamRenderer.push("\n")
+    assert update == nil
+
+    {_renderer, update} = StreamRenderer.push(renderer, "visible")
+    assert update == "\nvisible"
+  end
+
+  test "structured stream chunks have deterministic Markdown fallbacks" do
+    for kind <- [:text, :markdown] do
+      text = "  first line\n\nsecond line  \n"
+      chunk = StreamChunk.new(%{kind: kind, text: text})
+
+      assert StreamChunk.fallback_text(chunk) == text
+      assert StreamChunk.markdown_fallback(chunk) == text
+    end
+
+    assert StreamChunk.new(%{kind: :status, text: "Working"}) |> StreamChunk.fallback_text() ==
+             "Working"
+
+    assert StreamChunk.new(%{kind: :plan, payload: [%{label: "Inspect"}, "Change"]})
+           |> StreamChunk.fallback_text() == "Inspect\nChange"
+
+    assert StreamChunk.new(%{kind: :step_finish, payload: %{label: "Inspect"}})
+           |> StreamChunk.fallback_text() == "Inspect"
+
+    assert StreamChunk.new(%{
+             kind: :timeline,
+             payload: [%{at: "10:00", label: "Started"}, %{label: "Finished"}]
+           })
+           |> StreamChunk.fallback_text() == "10:00 — Started\nFinished"
+
+    assert StreamChunk.markdown_fallback(%{kind: :status, text: "Working"}) ==
+             "\n> **Status:** Working\n"
+
+    assert StreamChunk.markdown_fallback(%{kind: :plan, payload: ["Inspect", "Change"]}) ==
+             "\n**Plan**\n\n- Inspect\n- Change\n"
+
+    assert StreamChunk.markdown_fallback(%{kind: :step_start, payload: %{label: "Inspect"}}) ==
+             "\n- [ ] Inspect\n"
+
+    assert StreamChunk.markdown_fallback(%{kind: :step_finish, payload: %{label: "Inspect"}}) ==
+             "\n- [x] Inspect\n"
+
+    assert StreamChunk.markdown_fallback(%{
+             kind: :timeline,
+             payload: [%{at: "10:00", label: "Started"}, %{label: "Finished"}]
+           }) == "\n**Timeline**\n\n- 10:00 — Started\n- Finished\n"
+
+    assert StreamChunk.markdown_fallback(%{kind: :data, payload: %{tool: "search"}}) == ""
+
+    assert StreamChunk.markdown_fallback(%{kind: :status, text: "Wait *now*\nor later"}) ==
+             "\n> **Status:** Wait \\*now\\* or later\n"
+  end
+
+  test "the non-streamed payload fallback uses the same structured renderer" do
+    payload =
+      Jido.Chat.PostPayload.stream(
+        [
+          %{kind: :status, text: "Working"},
+          %{kind: :plan, payload: ["Inspect", "Change"]}
+        ],
+        %{}
+      )
+
+    assert payload.fallback_text ==
+             "\n> **Status:** Working\n\n**Plan**\n\n- Inspect\n- Change\n"
+  end
+
+  defp safe_snapshot?(snapshot) do
+    String.trim(snapshot) != "" and balanced_fences?(snapshot) and closed_links?(snapshot) and
+      balanced_emphasis?(snapshot) and aligned_table?(snapshot)
+  end
+
+  defp balanced_fences?(snapshot) do
+    snapshot
+    |> String.split("\n")
+    |> Enum.count(&Regex.match?(~r/^\s*(`{3,}|~{3,})/, &1))
+    |> rem(2) == 0
+  end
+
+  defp closed_links?(snapshot) do
+    labels_closed? = count(snapshot, "[") == count(snapshot, "]")
+
+    destinations_closed? =
+      snapshot
+      |> String.split("](")
+      |> Enum.drop(1)
+      |> Enum.all?(&String.contains?(&1, ")"))
+
+    labels_closed? and destinations_closed?
+  end
+
+  defp balanced_emphasis?(snapshot) do
+    text =
+      snapshot
+      |> String.replace(~r/```.*?```/s, "")
+      |> String.replace(~r/`[^`]*`/, "")
+      |> String.replace(~r/\]\([^)]*\)/, "")
+
+    strong_count = count(text, "**")
+    single_asterisk_count = text |> String.replace("**", "") |> count("*")
+    underscore_count = count(text, "_")
+
+    rem(strong_count, 2) == 0 and rem(single_asterisk_count, 2) == 0 and
+      rem(underscore_count, 2) == 0
+  end
+
+  defp aligned_table?(snapshot) do
+    lines = String.split(snapshot, "\n", trim: true)
+
+    case Enum.find_index(lines, &Regex.match?(~r/^\s*\|?\s*:?-{3,}/, &1)) do
+      nil ->
+        true
+
+      0 ->
+        false
+
+      divider_index ->
+        header_cells = table_cell_count(Enum.at(lines, divider_index - 1))
+
+        lines
+        |> Enum.drop(divider_index)
+        |> Enum.take_while(&String.contains?(&1, "|"))
+        |> Enum.all?(&(table_cell_count(&1) == header_cells))
+    end
+  end
+
+  defp table_cell_count(line) do
+    line
+    |> String.trim()
+    |> String.trim_leading("|")
+    |> String.trim_trailing("|")
+    |> String.split("|", trim: false)
+    |> length()
+  end
+
+  defp count(text, pattern), do: length(:binary.matches(text, pattern))
+end

--- a/test/jido/chat/structs_test.exs
+++ b/test/jido/chat/structs_test.exs
@@ -484,7 +484,9 @@ defmodule Jido.Chat.StructsTest do
       assert %StreamChunk{kind: :status, text: "working"} = Enum.at(payload.stream, 1)
       assert %StreamChunk{kind: :step_start} = Enum.at(payload.stream, 2)
       assert %StreamChunk{kind: :text, text: "done"} = Enum.at(payload.stream, 3)
-      assert payload.fallback_text == "helloworkingDraft responsedone"
+
+      assert payload.fallback_text ==
+               "hello\n> **Status:** working\n\n- [ ] Draft response\ndone"
     end
 
     test "event placeholder structs parse cleanly" do

--- a/test/support/stream_markdown_fixtures.ex
+++ b/test/support/stream_markdown_fixtures.ex
@@ -1,0 +1,20 @@
+defmodule Jido.Chat.StreamMarkdownFixtures do
+  @moduledoc false
+
+  @doc "Returns Markdown documents that cover supported stream boundaries."
+  @spec supported_documents() :: [{atom(), String.t()}]
+  def supported_documents do
+    [
+      {:split_emphasis, "Before **bold _and italic_** after"},
+      {:split_link, "Read [the guide](https://jido.run/docs?q=chat) now."},
+      {:list, "Plan:\n\n- first\n- second\n\nDone."},
+      {:code_fence, "```elixir\nIO.puts(\"hello\")\n```\n\nDone."},
+      {:structural_whitespace, "Heading\n\nParagraph  \nnext line\n\n"},
+      {:empty_table_cells, "| Name |  | State |\n| --- | --- | --- |\n| alpha |  | ready |\n|  | beta |  |"}
+    ]
+  end
+
+  @doc "Splits text into one-character stream chunks."
+  @spec one_character_chunks(String.t()) :: [String.t()]
+  def one_character_chunks(text), do: String.codepoints(text)
+end


### PR DESCRIPTION
## Summary

- Add a stateful Markdown stream renderer for safe partial and final output.
- Repair incomplete emphasis, links, lists, tables, and code fences.
- Preserve structural whitespace, adjacent empty table cells, and full fence markers.
- Add deterministic text fallbacks for structured plan, status, step, and timeline chunks.
- Share renderer behavior across native streaming and post-plus-edit fallback paths.
- Avoid repeated full Markdown scans for ordinary incremental text pushes.

## Validation

- Focused renderer and adapter tests — 21 passed.
- Full test suite — 143 passed.
- `mix quality` — passed, including Credo, Dialyzer, and Doctor.
- `git diff --check` — passed.
- Post-fix review `20260821-100918-9487e8db` — ready to merge with no findings.

## Post-Deploy Monitoring & Validation

- Exercise one-character chunks, split delimiters, long fences, tables, and tool-only streams.
- Confirm partial updates never send an invalid empty post or edit.
- Compare final streamed output with non-streamed rendering for supported syntax.
- Watch long streams for latency growth and excessive edit frequency.
- Confirm provider adapters use the same conformance fixtures after they update their core dependency.

Related: agentjido/jido_chat#43

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
