### PR TITLE
feat(cards): extend cards and modal inputs

### DIFF
--- a/lib/jido/chat/adapter.ex
+++ b/lib/jido/chat/adapter.ex
@@ -30,6 +30,9 @@ defmodule Jido.Chat.Adapter do
     MessageSubject,
     Modal,
     ModalResult,
+    OptionsLoadError,
+    OptionsLoadEvent,
+    OptionsLoadResult,
     Participant,
     Postable,
     PostPayload,
@@ -67,6 +70,8 @@ defmodule Jido.Chat.Adapter do
   @type thread_page_result :: {:ok, ThreadPage.t()} | {:error, term()}
   @type ephemeral_result :: {:ok, EphemeralMessage.t()} | {:error, term()}
   @type modal_result :: {:ok, ModalResult.t()} | {:error, term()}
+  @type options_load_result ::
+          {:ok, OptionsLoadResult.t()} | {:error, OptionsLoadError.t()}
   @type media_result :: {:ok, binary()} | {:error, term()}
   @type user_result :: {:ok, UserInfo.t()} | {:error, term()}
   @type subject_result :: {:ok, MessageSubject.t()} | {:error, term()}
@@ -192,6 +197,10 @@ defmodule Jido.Chat.Adapter do
   @callback open_modal(external_room_id(), payload :: map(), opts :: keyword()) ::
               {:ok, ModalResult.t() | map()} | {:error, term()}
 
+  @callback load_options(OptionsLoadEvent.t(), opts :: keyword()) ::
+              {:ok, OptionsLoadResult.t() | map()}
+              | {:error, OptionsLoadError.t() | map() | :timeout | term()}
+
   @callback fetch_messages(external_room_id(), opts :: keyword()) ::
               {:ok, MessagePage.t() | map()} | {:error, term()}
 
@@ -259,6 +268,7 @@ defmodule Jido.Chat.Adapter do
                       post_channel_message: 3,
                       stream: 3,
                       open_modal: 3,
+                      load_options: 2,
                       fetch_messages: 2,
                       fetch_channel_messages: 2,
                       list_threads: 2,
@@ -957,6 +967,68 @@ defmodule Jido.Chat.Adapter do
     })
   end
 
+  @doc """
+  Loads options for an external or dynamic select.
+
+  Adapters must validate provider-specific option and option-group limits. The
+  canonical result has no provider-specific maximum.
+  """
+  @spec load_options(module(), OptionsLoadEvent.t() | map(), keyword()) :: options_load_result()
+  def load_options(adapter_module, event, opts \\ []) when is_atom(adapter_module) do
+    event = OptionsLoadEvent.new(event)
+    timeout_ms = options_timeout(event, opts)
+
+    if callback_exported?(adapter_module, :load_options, 2) do
+      adapter_module
+      |> invoke_options_loader(event, opts, timeout_ms)
+      |> normalize_options_load_result(timeout_ms)
+    else
+      {:error,
+       OptionsLoadError.new(%{
+         code: "unsupported",
+         message: "Adapter does not support external option loading"
+       })}
+    end
+  end
+
+  defp normalize_options_load_result(:deadline_exceeded, timeout_ms),
+    do: {:error, OptionsLoadError.timeout(timeout_ms)}
+
+  defp normalize_options_load_result({:completed, result}, timeout_ms) do
+    case result do
+      {:ok, %OptionsLoadResult{} = result} ->
+        {:ok, result}
+
+      {:ok, result} when is_map(result) ->
+        {:ok, OptionsLoadResult.new(result)}
+
+      {:error, %OptionsLoadError{} = error} ->
+        {:error, error}
+
+      {:error, :timeout} ->
+        {:error, OptionsLoadError.timeout(timeout_ms)}
+
+      {:error, error} when is_map(error) ->
+        {:error, OptionsLoadError.new(error)}
+
+      {:error, reason} ->
+        {:error,
+         OptionsLoadError.new(%{
+           code: "adapter_error",
+           message: inspect(reason),
+           metadata: %{reason: reason}
+         })}
+
+      other ->
+        {:error,
+         OptionsLoadError.new(%{
+           code: "invalid_options_load_result",
+           message: "Adapter returned an invalid options-load result",
+           metadata: %{result: inspect(other)}
+         })}
+    end
+  end
+
   @doc "Validates capability declaration coherence with implemented callbacks."
   @spec validate_capabilities(module()) :: :ok | {:error, term()}
   def validate_capabilities(adapter_module) do
@@ -1606,6 +1678,7 @@ defmodule Jido.Chat.Adapter do
       post_channel_message: inferred_capability_status(adapter_module, :post_channel_message),
       stream: inferred_capability_status(adapter_module, :stream),
       open_modal: inferred_capability_status(adapter_module, :open_modal),
+      load_options: inferred_capability_status(adapter_module, :load_options),
       webhook: inferred_capability_status(adapter_module, :webhook),
       verify_webhook: inferred_capability_status(adapter_module, :verify_webhook),
       parse_event: inferred_capability_status(adapter_module, :parse_event),
@@ -1634,6 +1707,13 @@ defmodule Jido.Chat.Adapter do
       markdown: :unsupported,
       cards: :unsupported,
       modals: support_status(adapter_module, :open_modal, 3),
+      card_charts: :fallback,
+      card_tables: :fallback,
+      link_action_ids: :fallback,
+      modal_date_input: :unsupported,
+      modal_number_input: :unsupported,
+      external_select: :unsupported,
+      options_load: support_status(adapter_module, :load_options, 2),
       ephemeral:
         cond do
           callback_exported?(adapter_module, :post_ephemeral, 4) -> :native
@@ -1747,6 +1827,8 @@ defmodule Jido.Chat.Adapter do
   defp capability_callback(:post_channel_message), do: {:post_channel_message, 3}
   defp capability_callback(:stream), do: {:stream, 3}
   defp capability_callback(:open_modal), do: {:open_modal, 3}
+  defp capability_callback(:load_options), do: {:load_options, 2}
+  defp capability_callback(:options_load), do: {:load_options, 2}
   defp capability_callback(:webhook), do: {:handle_webhook, 3}
   defp capability_callback(:verify_webhook), do: {:verify_webhook, 2}
   defp capability_callback(:parse_event), do: {:parse_event, 2}
@@ -1762,6 +1844,58 @@ defmodule Jido.Chat.Adapter do
       callback_exported?(adapter_module, :fetch_subject, 2) -> :native
       callback_exported?(adapter_module, :fetch_thread, 2) -> :fallback
       true -> :unsupported
+    end
+  end
+
+  defp options_timeout(%OptionsLoadEvent{timeout_ms: timeout_ms}, opts) do
+    Keyword.get(opts, :timeout_ms) || timeout_ms || 3_000
+  end
+
+  defp invoke_options_loader(adapter_module, event, opts, timeout_ms) do
+    caller = self()
+    reply_ref = make_ref()
+
+    {worker, monitor_ref} =
+      spawn_monitor(fn ->
+        outcome =
+          try do
+            {:returned, adapter_module.load_options(event, opts)}
+          catch
+            kind, reason -> {:raised, kind, reason, __STACKTRACE__}
+          end
+
+        send(caller, {reply_ref, outcome})
+      end)
+
+    receive do
+      {^reply_ref, {:returned, result}} ->
+        Process.demonitor(monitor_ref, [:flush])
+        {:completed, result}
+
+      {^reply_ref, {:raised, kind, reason, stacktrace}} ->
+        Process.demonitor(monitor_ref, [:flush])
+        :erlang.raise(kind, reason, stacktrace)
+
+      {:DOWN, ^monitor_ref, :process, ^worker, reason} ->
+        exit(reason)
+    after
+      timeout_ms ->
+        stop_options_loader(worker, monitor_ref, reply_ref)
+        :deadline_exceeded
+    end
+  end
+
+  defp stop_options_loader(worker, monitor_ref, reply_ref) do
+    Process.exit(worker, :kill)
+
+    receive do
+      {:DOWN, ^monitor_ref, :process, ^worker, _reason} -> :ok
+    end
+
+    receive do
+      {^reply_ref, _outcome} -> :ok
+    after
+      0 -> :ok
     end
   end
 

--- a/lib/jido/chat/capabilities.ex
+++ b/lib/jido/chat/capabilities.ex
@@ -28,6 +28,13 @@ defmodule Jido.Chat.Capabilities do
           | :presence
           | :read_receipts
           | :assistant_events
+          | :card_charts
+          | :card_tables
+          | :modal_date_input
+          | :modal_number_input
+          | :external_select
+          | :options_load
+          | :link_action_ids
 
   @type capabilities :: [capability()]
 
@@ -49,7 +56,14 @@ defmodule Jido.Chat.Capabilities do
     :typing,
     :presence,
     :read_receipts,
-    :assistant_events
+    :assistant_events,
+    :card_charts,
+    :card_tables,
+    :modal_date_input,
+    :modal_number_input,
+    :external_select,
+    :options_load,
+    :link_action_ids
   ]
 
   @doc "Returns all supported capability atoms."
@@ -207,6 +221,16 @@ defmodule Jido.Chat.Capabilities do
     |> maybe_add_capability(:streaming, supported_status?(capabilities[:stream]))
     |> maybe_add_capability(:read_receipts, supported_status?(capabilities[:mark_as_read]))
     |> maybe_add_capability(:assistant_events, supported_status?(capabilities[:assistant_events]))
+    |> maybe_add_capability(:card_charts, supported_status?(capabilities[:card_charts]))
+    |> maybe_add_capability(:card_tables, supported_status?(capabilities[:card_tables]))
+    |> maybe_add_capability(:modal_date_input, supported_status?(capabilities[:modal_date_input]))
+    |> maybe_add_capability(
+      :modal_number_input,
+      supported_status?(capabilities[:modal_number_input])
+    )
+    |> maybe_add_capability(:external_select, supported_status?(capabilities[:external_select]))
+    |> maybe_add_capability(:options_load, supported_status?(capabilities[:options_load]))
+    |> maybe_add_capability(:link_action_ids, supported_status?(capabilities[:link_action_ids]))
   end
 
   defp normalize_adapter_capabilities(_), do: [:text]

--- a/lib/jido/chat/card.ex
+++ b/lib/jido/chat/card.ex
@@ -103,18 +103,37 @@ defmodule Jido.Chat.Card do
   end
 
   @doc "Builds a link button component."
-  @spec link_button(String.t(), String.t(), keyword() | map()) :: component()
-  def link_button(label, url, opts \\ []) when is_binary(label) and is_binary(url) do
+  @spec link_button(String.t(), String.t(), keyword() | map() | String.t()) :: component()
+  def link_button(label, url, opts \\ [])
+
+  def link_button(label, url, action_id)
+      when is_binary(label) and is_binary(url) and is_binary(action_id) do
+    link_button(label, url, %{action_id: action_id})
+  end
+
+  def link_button(label, url, opts)
+      when is_binary(label) and is_binary(url) and (is_list(opts) or is_map(opts)) do
     opts = normalize_opts(opts)
 
     Component.new(%{
       kind: :link_button,
+      id:
+        opts[:action_id] || opts["action_id"] || opts[:id] || opts["id"] ||
+          stable_link_action_id(label, url),
       label: label,
       url: url,
       style: opts[:style] || opts["style"],
       disabled: opts[:disabled] || opts["disabled"] || false,
       metadata: opts[:metadata] || opts["metadata"] || %{}
     })
+  end
+
+  @doc "Builds a link button with an explicit action ID and options."
+  @spec link_button(String.t(), String.t(), String.t(), keyword() | map()) :: component()
+  def link_button(label, url, action_id, opts)
+      when is_binary(label) and is_binary(url) and is_binary(action_id) do
+    opts = normalize_opts(opts) |> Map.put(:action_id, action_id)
+    link_button(label, url, opts)
   end
 
   @doc "Builds a text link component."
@@ -141,6 +160,20 @@ defmodule Jido.Chat.Card do
       label: label,
       value: value,
       text: opts[:text] || opts["text"],
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a select option group."
+  @spec select_option_group(String.t(), [component() | map()], keyword() | map()) :: component()
+  def select_option_group(label, options, opts \\ [])
+      when is_binary(label) and is_list(options) do
+    opts = normalize_opts(opts)
+
+    Component.new(%{
+      kind: :option_group,
+      label: label,
+      options: options,
       metadata: opts[:metadata] || opts["metadata"] || %{}
     })
   end
@@ -178,6 +211,34 @@ defmodule Jido.Chat.Card do
     })
   end
 
+  @doc "Builds a select whose options load from an external source."
+  @spec external_select(String.t(), keyword() | map()) :: component()
+  def external_select(action_id, opts \\ []) when is_binary(action_id) do
+    opts = normalize_opts(opts)
+
+    Component.new(%{
+      kind: :external_select,
+      id: action_id,
+      label: opts[:label] || opts["label"],
+      title: opts[:title] || opts["title"],
+      value: opts[:value] || opts["value"],
+      options: opts[:options] || opts["options"] || [],
+      option_groups: opts[:option_groups] || opts["option_groups"] || [],
+      options_source: normalize_options_source(opts[:options_source] || opts["options_source"]),
+      min_query_length: option(opts, :min_query_length),
+      timeout_ms: option(opts, :timeout_ms),
+      fallback_text: opts[:fallback_text] || opts["fallback_text"],
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a dynamic select. This is an alias for `external_select/2`."
+  @spec dynamic_select(String.t(), keyword() | map()) :: component()
+  def dynamic_select(action_id, opts \\ []) do
+    opts = normalize_opts(opts) |> Map.put(:options_source, :dynamic)
+    external_select(action_id, opts)
+  end
+
   @doc "Builds a table component."
   @spec table([String.t()], [[String.t()]], keyword() | map()) :: component()
   def table(columns, rows, opts \\ []) when is_list(columns) and is_list(rows) do
@@ -186,10 +247,57 @@ defmodule Jido.Chat.Card do
     Component.new(%{
       kind: :table,
       title: opts[:title] || opts["title"],
+      caption: opts[:caption] || opts["caption"],
       columns: columns,
       rows: rows,
+      page_size: option(opts, :page_size),
       metadata: opts[:metadata] || opts["metadata"] || %{}
     })
+  end
+
+  @doc "Builds a pie chart component."
+  @spec pie_chart(list(), keyword() | map()) :: component()
+  def pie_chart(data, opts \\ []), do: chart(:pie_chart, data, opts)
+
+  @doc "Builds a bar chart component."
+  @spec bar_chart(list(), keyword() | map()) :: component()
+  def bar_chart(data, opts \\ []), do: chart(:bar_chart, data, opts)
+
+  @spec bar_chart([String.t()], list(), keyword() | map()) :: component()
+  def bar_chart(categories, series, opts), do: chart(:bar_chart, categories, series, opts)
+
+  @doc "Builds an area chart component."
+  @spec area_chart(list(), keyword() | map()) :: component()
+  def area_chart(data, opts \\ []), do: chart(:area_chart, data, opts)
+
+  @spec area_chart([String.t()], list(), keyword() | map()) :: component()
+  def area_chart(categories, series, opts), do: chart(:area_chart, categories, series, opts)
+
+  @doc "Builds a line chart component."
+  @spec line_chart(list(), keyword() | map()) :: component()
+  def line_chart(data, opts \\ []), do: chart(:line_chart, data, opts)
+
+  @spec line_chart([String.t()], list(), keyword() | map()) :: component()
+  def line_chart(categories, series, opts), do: chart(:line_chart, categories, series, opts)
+
+  @doc "Builds a chart component from a chart type and data points."
+  @spec chart(:pie | :bar | :area | :line | atom() | String.t(), list(), keyword() | map()) ::
+          component()
+  def chart(type, data, opts \\ []) when is_list(data) do
+    build_chart(normalize_chart_kind(type), data, opts)
+  end
+
+  @doc "Builds a named-series chart with ordered shared categories."
+  @spec chart(atom() | String.t(), [String.t()], list(), keyword() | map()) :: component()
+  def chart(type, categories, series, opts)
+      when is_list(categories) and is_list(series) do
+    opts =
+      opts
+      |> normalize_opts()
+      |> Map.put(:categories, categories)
+      |> Map.put(:series, series)
+
+    build_chart(normalize_chart_kind(type), [], opts)
   end
 
   @doc "Builds an image component."
@@ -245,6 +353,7 @@ defmodule Jido.Chat.Card do
       %Markdown{} = markdown -> Markdown.stringify(markdown)
       other -> other
     end)
+    |> Map.put(:fallback_text, fallback_text(card))
     |> Wire.to_plain()
   end
 
@@ -353,9 +462,19 @@ defmodule Jido.Chat.Card do
         options = Enum.map(component.options, &select_option_label/1)
         [Markdown.heading(4, label), Markdown.list(options)]
 
+      :external_select ->
+        external_select_to_markdown(component)
+
       :table ->
         table_rows = [component.columns | component.rows]
-        [Markdown.table(table_rows)]
+
+        []
+        |> maybe_prepend_component_title(component.title)
+        |> maybe_append_component_text(component.caption)
+        |> Kernel.++([Markdown.table(table_rows)])
+
+      kind when kind in [:pie_chart, :bar_chart, :area_chart, :line_chart] ->
+        chart_to_markdown(component)
 
       :image ->
         label = component.alt_text || component.title || component.image_url || "image"
@@ -366,6 +485,12 @@ defmodule Jido.Chat.Card do
 
       :select_option ->
         [Markdown.paragraph(select_option_label(component))]
+
+      :option_group ->
+        [
+          Markdown.heading(4, component.label || component.title || "Options"),
+          Markdown.list(Enum.map(component.options, &select_option_label/1))
+        ]
     end
   end
 
@@ -397,6 +522,7 @@ defmodule Jido.Chat.Card do
     |> Map.from_struct()
     |> Map.update!(:items, fn items -> Enum.map(items, &component_to_plain/1) end)
     |> Map.update!(:options, fn options -> Enum.map(options, &component_to_plain/1) end)
+    |> Map.update!(:option_groups, fn groups -> Enum.map(groups, &component_to_plain/1) end)
     |> Map.update!(:markdown, fn
       nil -> nil
       %Markdown{} = markdown -> Markdown.stringify(markdown)
@@ -407,4 +533,95 @@ defmodule Jido.Chat.Card do
 
   defp normalize_opts(opts) when is_list(opts), do: Map.new(opts)
   defp normalize_opts(opts) when is_map(opts), do: opts
+
+  defp build_chart(kind, data, opts) when is_list(data) do
+    opts = normalize_opts(opts)
+
+    Component.new(%{
+      kind: kind,
+      title: opts[:title] || opts["title"],
+      caption: opts[:caption] || opts["caption"],
+      alt_text: opts[:alt_text] || opts["alt_text"],
+      fallback_text: opts[:fallback_text] || opts["fallback_text"],
+      data: data,
+      categories: opts[:categories] || opts["categories"] || [],
+      series: opts[:series] || opts["series"] || [],
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  defp chart_to_markdown(component) do
+    description =
+      component.fallback_text || component.alt_text ||
+        "#{chart_kind_label(component.kind)}. #{chart_data_text(component)}."
+
+    []
+    |> maybe_prepend_component_title(component.title)
+    |> maybe_append_component_text(component.caption)
+    |> Kernel.++([Markdown.paragraph(description)])
+  end
+
+  defp chart_kind_label(:pie_chart), do: "Pie chart"
+  defp chart_kind_label(:bar_chart), do: "Bar chart"
+  defp chart_kind_label(:area_chart), do: "Area chart"
+  defp chart_kind_label(:line_chart), do: "Line chart"
+
+  defp chart_data_text(%Component{series: [_ | _]} = component) do
+    Enum.map_join(component.series, "; ", fn series ->
+      "#{series.name} — " <>
+        Enum.map_join(Stream.zip(component.categories, series.values), ", ", fn {category, value} ->
+          "#{category}: #{format_number(value)}"
+        end)
+    end)
+  end
+
+  defp chart_data_text(%Component{data: data}) do
+    Enum.map_join(data, "; ", fn point ->
+      prefix = if point.series, do: "#{point.series} — ", else: ""
+      "#{prefix}#{point.label}: #{format_number(point.value)}"
+    end)
+  end
+
+  defp format_number(value) when is_number(value), do: to_string(value)
+
+  defp external_select_to_markdown(component) do
+    label = component.label || component.title || component.id || "Select"
+
+    options =
+      Stream.concat(component.options, Stream.flat_map(component.option_groups, & &1.options))
+
+    description =
+      component.fallback_text ||
+        if(Enum.empty?(options),
+          do: "Options load as you type.",
+          else: "Initial options: #{Enum.map_join(options, ", ", &select_option_label/1)}."
+        )
+
+    [Markdown.heading(4, label), Markdown.paragraph(description)]
+  end
+
+  defp stable_link_action_id(label, url) do
+    digest = :crypto.hash(:sha256, label <> "\0" <> url) |> Base.encode16(case: :lower)
+    "link:" <> binary_part(digest, 0, 16)
+  end
+
+  defp normalize_options_source(nil), do: :external
+  defp normalize_options_source(source) when source in [:external, :dynamic], do: source
+  defp normalize_options_source("external"), do: :external
+  defp normalize_options_source("dynamic"), do: :dynamic
+  defp normalize_options_source(source), do: source
+
+  defp normalize_chart_kind(:pie), do: :pie_chart
+  defp normalize_chart_kind(:bar), do: :bar_chart
+  defp normalize_chart_kind(:area), do: :area_chart
+  defp normalize_chart_kind(:line), do: :line_chart
+  defp normalize_chart_kind("pie"), do: :pie_chart
+  defp normalize_chart_kind("bar"), do: :bar_chart
+  defp normalize_chart_kind("area"), do: :area_chart
+  defp normalize_chart_kind("line"), do: :line_chart
+  defp normalize_chart_kind(kind), do: kind
+
+  defp option(opts, key) do
+    Map.get(opts, key, Map.get(opts, Atom.to_string(key)))
+  end
 end

--- a/lib/jido/chat/card/chart_data.ex
+++ b/lib/jido/chat/card/chart_data.ex
@@ -1,0 +1,49 @@
+defmodule Jido.Chat.Card.ChartData do
+  @moduledoc """
+  One provider-neutral data point in a canonical card chart.
+  """
+
+  alias Jido.Chat.Wire
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              label: Zoi.string() |> Zoi.min(1),
+              value: Zoi.number(),
+              series: Zoi.string() |> Zoi.nullish(),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+  @type input :: t() | map() | {String.t(), number()}
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the schema for chart data."
+  def schema, do: @schema
+
+  @doc "Creates a chart data point."
+  @spec new(input()) :: t()
+  def new(%__MODULE__{} = point), do: point
+  def new({label, value}), do: new(%{label: label, value: value})
+
+  def new(attrs) when is_map(attrs) do
+    Jido.Chat.Schema.parse!(__MODULE__, @schema, attrs)
+  end
+
+  @doc "Serializes the chart data point."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = point) do
+    point
+    |> Map.from_struct()
+    |> Wire.to_plain()
+    |> Map.put("__type__", "card_chart_data")
+  end
+
+  @doc "Builds chart data from serialized data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+end

--- a/lib/jido/chat/card/chart_series.ex
+++ b/lib/jido/chat/card/chart_series.ex
@@ -1,0 +1,50 @@
+defmodule Jido.Chat.Card.ChartSeries do
+  @moduledoc """
+  One named series whose ordered values align with chart categories.
+  """
+
+  alias Jido.Chat.Wire
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              name: Zoi.string() |> Zoi.min(1),
+              values: Zoi.list() |> Zoi.min(1),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+          |> Zoi.refine({__MODULE__, :validate, []})
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the schema for a chart series."
+  def schema, do: @schema
+
+  @doc "Creates a named chart series."
+  @spec new(t() | map() | {String.t(), [number()]}) :: t()
+  def new(%__MODULE__{} = series), do: series
+  def new({name, values}), do: new(%{name: name, values: values})
+  def new(attrs) when is_map(attrs), do: Jido.Chat.Schema.parse!(__MODULE__, @schema, attrs)
+
+  @doc false
+  def validate(_schema, %__MODULE__{values: values}) do
+    if Enum.all?(values, &is_number/1), do: :ok, else: {:error, "series values must be numeric"}
+  end
+
+  @doc "Serializes the chart series."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = series) do
+    series
+    |> Map.from_struct()
+    |> Wire.to_plain()
+    |> Map.put("__type__", "card_chart_series")
+  end
+
+  @doc "Builds a chart series from serialized data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+end

--- a/lib/jido/chat/card/component.ex
+++ b/lib/jido/chat/card/component.ex
@@ -1,10 +1,14 @@
 defmodule Jido.Chat.Card.Component do
   @moduledoc """
   Canonical card component used by `Jido.Chat.Card`.
+
+  Validation enforces portable semantic limits, such as positive page sizes.
+  Provider count and text limits belong to each adapter renderer.
   """
 
   alias Jido.Chat.Markdown
   alias Jido.Chat.Wire
+  alias Jido.Chat.Card.{ChartData, ChartSeries}
 
   @kinds [
     :text,
@@ -18,7 +22,13 @@ defmodule Jido.Chat.Card.Component do
     :select,
     :select_option,
     :radio_select,
+    :external_select,
     :table,
+    :pie_chart,
+    :bar_chart,
+    :area_chart,
+    :line_chart,
+    :option_group,
     :image,
     :divider
   ]
@@ -35,17 +45,28 @@ defmodule Jido.Chat.Card.Component do
               value: Zoi.string() |> Zoi.nullish(),
               image_url: Zoi.string() |> Zoi.nullish(),
               alt_text: Zoi.string() |> Zoi.nullish(),
+              fallback_text: Zoi.string() |> Zoi.nullish(),
+              caption: Zoi.string() |> Zoi.nullish(),
               style: Zoi.string() |> Zoi.nullish(),
               disabled: Zoi.boolean() |> Zoi.default(false),
               markdown: Zoi.any() |> Zoi.nullish(),
               items: Zoi.list() |> Zoi.default([]),
               options: Zoi.list() |> Zoi.default([]),
+              option_groups: Zoi.list() |> Zoi.default([]),
+              options_source: Zoi.enum([:static, :external, :dynamic]) |> Zoi.nullish(),
+              min_query_length: Zoi.integer() |> Zoi.nullish(),
+              timeout_ms: Zoi.integer() |> Zoi.nullish(),
               columns: Zoi.list() |> Zoi.default([]),
               rows: Zoi.list() |> Zoi.default([]),
+              page_size: Zoi.integer() |> Zoi.nullish(),
+              data: Zoi.list() |> Zoi.default([]),
+              categories: Zoi.list() |> Zoi.default([]),
+              series: Zoi.list() |> Zoi.default([]),
               metadata: Zoi.map() |> Zoi.default(%{})
             },
             coerce: true
           )
+          |> Zoi.refine({__MODULE__, :validate, []})
 
   @type t :: unquote(Zoi.type_spec(@schema))
   @type input :: t() | map() | String.t()
@@ -62,9 +83,14 @@ defmodule Jido.Chat.Card.Component do
 
   def new(attrs) when is_map(attrs) do
     attrs
+    |> normalize_kind()
+    |> normalize_options_source()
     |> normalize_markdown()
     |> normalize_items()
     |> normalize_options()
+    |> normalize_option_groups()
+    |> normalize_data()
+    |> normalize_series()
     |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
   end
 
@@ -81,6 +107,13 @@ defmodule Jido.Chat.Card.Component do
     |> Map.from_struct()
     |> Map.update!(:items, &Enum.map(&1, fn item -> item |> normalize() |> to_map() end))
     |> Map.update!(:options, &Enum.map(&1, fn option -> option |> normalize() |> to_map() end))
+    |> Map.update!(:option_groups, fn groups ->
+      Enum.map(groups, fn group -> group |> normalize() |> to_map() end)
+    end)
+    |> Map.update!(:data, &Enum.map(&1, fn point -> point |> ChartData.new() |> ChartData.to_map() end))
+    |> Map.update!(:series, fn series ->
+      Enum.map(series, fn item -> item |> ChartSeries.new() |> ChartSeries.to_map() end)
+    end)
     |> Map.update!(:markdown, fn
       nil -> nil
       %Markdown{} = markdown -> Markdown.to_map(markdown)
@@ -110,6 +143,29 @@ defmodule Jido.Chat.Card.Component do
     end
   end
 
+  defp normalize_kind(attrs) do
+    normalize_existing_atom_field(attrs, :kind, @kinds)
+  end
+
+  defp normalize_options_source(attrs) do
+    normalize_existing_atom_field(attrs, :options_source, [:static, :external, :dynamic])
+  end
+
+  defp normalize_existing_atom_field(attrs, key, allowed) do
+    string_key = Atom.to_string(key)
+
+    case attrs[key] || attrs[string_key] do
+      value when is_binary(value) ->
+        atom = String.to_existing_atom(value)
+        if atom in allowed, do: attrs |> Map.delete(string_key) |> Map.put(key, atom), else: attrs
+
+      _ ->
+        attrs
+    end
+  rescue
+    ArgumentError -> attrs
+  end
+
   defp normalize_items(attrs) do
     items = attrs[:items] || attrs["items"] || []
     attrs |> Map.delete("items") |> Map.put(:items, Enum.map(items, &normalize/1))
@@ -118,5 +174,83 @@ defmodule Jido.Chat.Card.Component do
   defp normalize_options(attrs) do
     options = attrs[:options] || attrs["options"] || []
     attrs |> Map.delete("options") |> Map.put(:options, Enum.map(options, &normalize/1))
+  end
+
+  defp normalize_option_groups(attrs) do
+    groups = attrs[:option_groups] || attrs["option_groups"] || []
+
+    attrs
+    |> Map.delete("option_groups")
+    |> Map.put(:option_groups, Enum.map(groups, &normalize/1))
+  end
+
+  defp normalize_data(attrs) do
+    data = attrs[:data] || attrs["data"] || []
+    attrs |> Map.delete("data") |> Map.put(:data, Enum.map(data, &ChartData.new/1))
+  end
+
+  defp normalize_series(attrs) do
+    series = attrs[:series] || attrs["series"] || []
+    attrs |> Map.delete("series") |> Map.put(:series, Enum.map(series, &ChartSeries.new/1))
+  end
+
+  @doc false
+  def validate(_schema, %__MODULE__{} = component) do
+    cond do
+      component.page_size != nil and component.page_size < 1 ->
+        {:error, "page_size must be greater than zero"}
+
+      component.min_query_length != nil and component.min_query_length < 0 ->
+        {:error, "min_query_length must be zero or greater"}
+
+      component.timeout_ms != nil and component.timeout_ms < 1 ->
+        {:error, "timeout_ms must be greater than zero"}
+
+      component.kind in [:pie_chart, :bar_chart, :area_chart, :line_chart] and
+        component.data == [] and (component.categories == [] or component.series == []) ->
+        {:error, "chart data or categories with named series must not be empty"}
+
+      component.data != [] and (component.categories != [] or component.series != []) ->
+        {:error, "chart data and named series are mutually exclusive"}
+
+      component.series != [] and not valid_series_shape?(component) ->
+        {:error, "each named series must have one value for each category and a unique name"}
+
+      component.kind == :table and not valid_table_shape?(component) ->
+        {:error, "table columns must not be empty and every row must match the column count"}
+
+      component.kind == :external_select and blank?(component.id) ->
+        {:error, "external select id must not be empty"}
+
+      component.kind == :option_group and blank?(component.label || component.title) ->
+        {:error, "option group label must not be empty"}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp blank?(nil), do: true
+  defp blank?(value) when is_binary(value), do: String.trim(value) == ""
+  defp blank?(_value), do: false
+
+  defp valid_series_shape?(component) do
+    names = Enum.map(component.series, & &1.name)
+
+    component.categories != [] and Enum.all?(component.categories, &valid_category?/1) and
+      Enum.uniq(names) == names and
+      Enum.all?(component.series, &(length(&1.values) == length(component.categories)))
+  end
+
+  defp valid_category?(category) when is_binary(category), do: String.trim(category) != ""
+  defp valid_category?(_category), do: false
+
+  defp valid_table_shape?(component) do
+    column_count = length(component.columns)
+
+    component.columns != [] and Enum.all?(component.columns, &is_binary/1) and
+      Enum.all?(component.rows, fn row ->
+        is_list(row) and length(row) == column_count
+      end)
   end
 end

--- a/lib/jido/chat/event_envelope.ex
+++ b/lib/jido/chat/event_envelope.ex
@@ -12,6 +12,9 @@ defmodule Jido.Chat.EventEnvelope do
     MessageUpdatedEvent,
     ModalCloseEvent,
     ModalSubmitEvent,
+    OptionsLoadEvent,
+    OptionsLoadError,
+    OptionsLoadResult,
     ReactionEvent,
     Message,
     SlashCommandEvent,
@@ -26,6 +29,7 @@ defmodule Jido.Chat.EventEnvelope do
     :action,
     :modal_submit,
     :modal_close,
+    :options_load,
     :slash_command,
     :assistant_thread_started,
     :assistant_context_changed
@@ -55,6 +59,7 @@ defmodule Jido.Chat.EventEnvelope do
           | :action
           | :modal_submit
           | :modal_close
+          | :options_load
           | :slash_command
           | :assistant_thread_started
           | :assistant_context_changed
@@ -141,6 +146,9 @@ defmodule Jido.Chat.EventEnvelope do
   defp serialize_payload(%ActionEvent{} = payload), do: ActionEvent.to_map(payload)
   defp serialize_payload(%ModalSubmitEvent{} = payload), do: ModalSubmitEvent.to_map(payload)
   defp serialize_payload(%ModalCloseEvent{} = payload), do: ModalCloseEvent.to_map(payload)
+  defp serialize_payload(%OptionsLoadEvent{} = payload), do: OptionsLoadEvent.to_map(payload)
+  defp serialize_payload(%OptionsLoadResult{} = payload), do: OptionsLoadResult.to_map(payload)
+  defp serialize_payload(%OptionsLoadError{} = payload), do: OptionsLoadError.to_map(payload)
   defp serialize_payload(%SlashCommandEvent{} = payload), do: SlashCommandEvent.to_map(payload)
 
   defp serialize_payload(%AssistantThreadStartedEvent{} = payload),
@@ -171,6 +179,15 @@ defmodule Jido.Chat.EventEnvelope do
 
   defp deserialize_payload(%{"__type__" => "modal_close_event"} = payload),
     do: ModalCloseEvent.from_map(payload)
+
+  defp deserialize_payload(%{"__type__" => "options_load_event"} = payload),
+    do: OptionsLoadEvent.from_map(payload)
+
+  defp deserialize_payload(%{"__type__" => "options_load_result"} = payload),
+    do: OptionsLoadResult.from_map(payload)
+
+  defp deserialize_payload(%{"__type__" => "options_load_error"} = payload),
+    do: OptionsLoadError.from_map(payload)
 
   defp deserialize_payload(%{"__type__" => "slash_command_event"} = payload),
     do: SlashCommandEvent.from_map(payload)

--- a/lib/jido/chat/event_normalizer.ex
+++ b/lib/jido/chat/event_normalizer.ex
@@ -12,6 +12,7 @@ defmodule Jido.Chat.EventNormalizer do
     MessageUpdatedEvent,
     ModalCloseEvent,
     ModalSubmitEvent,
+    OptionsLoadEvent,
     ReactionEvent,
     SlashCommandEvent
   }
@@ -90,6 +91,16 @@ defmodule Jido.Chat.EventNormalizer do
 
   def ensure_modal_close_event(other, _adapter_name),
     do: {:error, {:invalid_modal_close_event, other}}
+
+  @spec ensure_options_load_event(OptionsLoadEvent.t() | map() | term(), atom()) ::
+          {:ok, OptionsLoadEvent.t()} | {:error, term()}
+  def ensure_options_load_event(%OptionsLoadEvent{} = event, _adapter_name), do: {:ok, event}
+
+  def ensure_options_load_event(map, adapter_name) when is_map(map),
+    do: ensure_event_struct(map, adapter_name, OptionsLoadEvent, :invalid_options_load_event)
+
+  def ensure_options_load_event(other, _adapter_name),
+    do: {:error, {:invalid_options_load_event, other}}
 
   @spec ensure_slash_command_event(SlashCommandEvent.t() | map() | term(), atom()) ::
           {:ok, SlashCommandEvent.t()} | {:error, term()}
@@ -245,6 +256,10 @@ defmodule Jido.Chat.EventNormalizer do
 
   defp infer_event_type(payload) when is_map(payload) do
     cond do
+      Map.get(payload, :event_type) == :options_load or
+          Map.get(payload, "event_type") == "options_load" ->
+        :options_load
+
       Map.has_key?(payload, :emoji) or Map.has_key?(payload, "emoji") ->
         :reaction
 
@@ -282,6 +297,7 @@ defmodule Jido.Chat.EventNormalizer do
   defp payload_thread_id(_adapter_name, %ActionEvent{} = payload), do: payload.thread_id
   defp payload_thread_id(_adapter_name, %ModalSubmitEvent{} = payload), do: payload.thread_id
   defp payload_thread_id(_adapter_name, %ModalCloseEvent{} = payload), do: payload.thread_id
+  defp payload_thread_id(_adapter_name, %OptionsLoadEvent{} = payload), do: payload.thread_id
   defp payload_thread_id(_adapter_name, %SlashCommandEvent{} = payload), do: payload.thread_id
 
   defp payload_thread_id(_adapter_name, %AssistantThreadStartedEvent{} = payload),
@@ -299,6 +315,7 @@ defmodule Jido.Chat.EventNormalizer do
   defp payload_channel_id(%ActionEvent{} = payload), do: payload.channel_id
   defp payload_channel_id(%ModalSubmitEvent{} = payload), do: payload.channel_id
   defp payload_channel_id(%ModalCloseEvent{} = payload), do: payload.channel_id
+  defp payload_channel_id(%OptionsLoadEvent{} = payload), do: payload.channel_id
   defp payload_channel_id(%SlashCommandEvent{} = payload), do: payload.channel_id
   defp payload_channel_id(%AssistantThreadStartedEvent{} = payload), do: payload.channel_id
   defp payload_channel_id(%AssistantContextChangedEvent{} = payload), do: payload.channel_id
@@ -311,6 +328,7 @@ defmodule Jido.Chat.EventNormalizer do
   defp payload_message_id(%ActionEvent{} = payload), do: payload.message_id
   defp payload_message_id(%ModalSubmitEvent{} = payload), do: payload.message_id
   defp payload_message_id(%ModalCloseEvent{} = payload), do: payload.message_id
+  defp payload_message_id(%OptionsLoadEvent{} = payload), do: payload.message_id
   defp payload_message_id(%SlashCommandEvent{} = payload), do: payload.message_id
   defp payload_message_id(%AssistantThreadStartedEvent{} = payload), do: payload.message_id
   defp payload_message_id(%AssistantContextChangedEvent{} = payload), do: payload.message_id

--- a/lib/jido/chat/event_router.ex
+++ b/lib/jido/chat/event_router.ex
@@ -47,6 +47,10 @@ defmodule Jido.Chat.EventRouter do
   def ensure_modal_close_event(event, adapter_name),
     do: EventNormalizer.ensure_modal_close_event(event, adapter_name)
 
+  @spec ensure_options_load_event(term(), atom()) :: {:ok, term()} | {:error, term()}
+  def ensure_options_load_event(event, adapter_name),
+    do: EventNormalizer.ensure_options_load_event(event, adapter_name)
+
   @spec ensure_slash_command_event(term(), atom()) :: {:ok, term()} | {:error, term()}
   def ensure_slash_command_event(event, adapter_name),
     do: EventNormalizer.ensure_slash_command_event(event, adapter_name)
@@ -162,6 +166,21 @@ defmodule Jido.Chat.EventRouter do
         dispatchers
       ) do
     dispatchers.process_modal_close.(
+      chat,
+      adapter_name,
+      envelope.payload || envelope.raw || %{},
+      opts
+    )
+  end
+
+  def route_event(
+        chat,
+        adapter_name,
+        %EventEnvelope{event_type: :options_load} = envelope,
+        opts,
+        dispatchers
+      ) do
+    dispatchers.process_options_load.(
       chat,
       adapter_name,
       envelope.payload || envelope.raw || %{},

--- a/lib/jido/chat/modal.ex
+++ b/lib/jido/chat/modal.ex
@@ -64,6 +64,47 @@ defmodule Jido.Chat.Modal do
     })
   end
 
+  @doc "Builds a date input element."
+  @spec date_input(String.t(), String.t(), keyword() | map()) :: Element.t()
+  def date_input(id, label, opts \\ []) when is_binary(id) and is_binary(label) do
+    opts = normalize_opts(opts)
+
+    Element.new(%{
+      kind: :date_input,
+      id: id,
+      label: label,
+      value: option(opts, :value),
+      placeholder: opts[:placeholder] || opts["placeholder"],
+      help_text: opts[:help_text] || opts["help_text"],
+      fallback_text: opts[:fallback_text] || opts["fallback_text"],
+      required: opts[:required] || opts["required"] || false,
+      min_date: option(opts, :min_date),
+      max_date: option(opts, :max_date),
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a number input element."
+  @spec number_input(String.t(), String.t(), keyword() | map()) :: Element.t()
+  def number_input(id, label, opts \\ []) when is_binary(id) and is_binary(label) do
+    opts = normalize_opts(opts)
+
+    Element.new(%{
+      kind: :number_input,
+      id: id,
+      label: label,
+      value: option(opts, :value),
+      placeholder: opts[:placeholder] || opts["placeholder"],
+      help_text: opts[:help_text] || opts["help_text"],
+      fallback_text: opts[:fallback_text] || opts["fallback_text"],
+      required: opts[:required] || opts["required"] || false,
+      min_value: option(opts, :min_value),
+      max_value: option(opts, :max_value),
+      step: option(opts, :step),
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
   @doc "Builds a select option element."
   @spec select_option(String.t(), String.t(), keyword() | map()) :: Element.t()
   def select_option(label, value, opts \\ []) when is_binary(label) and is_binary(value) do
@@ -75,6 +116,21 @@ defmodule Jido.Chat.Modal do
       label: label,
       value: value,
       help_text: opts[:help_text] || opts["help_text"],
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a select option group element."
+  @spec select_option_group(String.t(), [Element.t() | map()], keyword() | map()) :: Element.t()
+  def select_option_group(label, options, opts \\ [])
+      when is_binary(label) and is_list(options) do
+    opts = normalize_opts(opts)
+
+    Element.new(%{
+      kind: :option_group,
+      id: opts[:id] || opts["id"] || label,
+      label: label,
+      options: options,
       metadata: opts[:metadata] || opts["metadata"] || %{}
     })
   end
@@ -117,12 +173,51 @@ defmodule Jido.Chat.Modal do
     })
   end
 
+  @doc "Builds a select whose options load from an external source."
+  @spec external_select(String.t(), String.t(), keyword() | map()) :: Element.t()
+  def external_select(id, label, opts \\ []) when is_binary(id) and is_binary(label) do
+    opts = normalize_opts(opts)
+
+    Element.new(%{
+      kind: :external_select,
+      id: id,
+      label: label,
+      value: option(opts, :value),
+      placeholder: opts[:placeholder] || opts["placeholder"],
+      help_text: opts[:help_text] || opts["help_text"],
+      fallback_text: opts[:fallback_text] || opts["fallback_text"],
+      required: opts[:required] || opts["required"] || false,
+      options: opts[:options] || opts["options"] || [],
+      option_groups: opts[:option_groups] || opts["option_groups"] || [],
+      options_source: normalize_options_source(opts[:options_source] || opts["options_source"]),
+      min_query_length: option(opts, :min_query_length),
+      timeout_ms: option(opts, :timeout_ms),
+      metadata: opts[:metadata] || opts["metadata"] || %{}
+    })
+  end
+
+  @doc "Builds a dynamic select. This is an alias for `external_select/3`."
+  @spec dynamic_select(String.t(), String.t(), keyword() | map()) :: Element.t()
+  def dynamic_select(id, label, opts \\ []) do
+    opts = normalize_opts(opts) |> Map.put(:options_source, :dynamic)
+    external_select(id, label, opts)
+  end
+
+  @doc "Returns deterministic accessible text for a modal."
+  @spec fallback_text(t()) :: String.t()
+  def fallback_text(%__MODULE__{} = modal) do
+    ([modal.title] ++ Enum.map(modal.elements, &element_fallback_text/1))
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join("\n")
+  end
+
   @doc "Returns a plain map suitable for adapter-specific modal rendering."
   @spec to_adapter_payload(t()) :: map()
   def to_adapter_payload(%__MODULE__{} = modal) do
     modal
     |> Map.from_struct()
     |> Map.update!(:elements, fn elements -> Enum.map(elements, &element_to_plain/1) end)
+    |> Map.put(:fallback_text, fallback_text(modal))
     |> Wire.to_plain()
   end
 
@@ -155,6 +250,73 @@ defmodule Jido.Chat.Modal do
     element
     |> Map.from_struct()
     |> Map.update!(:options, fn options -> Enum.map(options, &element_to_plain/1) end)
+    |> Map.update!(:option_groups, fn groups -> Enum.map(groups, &element_to_plain/1) end)
     |> Wire.to_plain()
+  end
+
+  defp element_fallback_text(%Element{fallback_text: text}) when is_binary(text), do: text
+
+  defp element_fallback_text(%Element{kind: :date_input} = element) do
+    input_description(element, "date input") <>
+      optional_sentence("Minimum date", element.min_date) <>
+      optional_sentence("Maximum date", element.max_date) <>
+      help_sentence(element.help_text)
+  end
+
+  defp element_fallback_text(%Element{kind: :number_input} = element) do
+    input_description(element, "number input") <>
+      optional_sentence("Minimum", element.min_value) <>
+      optional_sentence("Maximum", element.max_value) <>
+      optional_sentence("Step", element.step) <>
+      help_sentence(element.help_text)
+  end
+
+  defp element_fallback_text(%Element{kind: :text_input} = element) do
+    input_description(element, if(element.multiline, do: "multiline text input", else: "text input")) <>
+      help_sentence(element.help_text)
+  end
+
+  defp element_fallback_text(%Element{kind: kind} = element)
+       when kind in [:select, :radio_select, :external_select] do
+    type =
+      case kind do
+        :select -> "select input"
+        :radio_select -> "radio select input"
+        :external_select -> "external select input"
+      end
+
+    input_description(element, type) <> help_sentence(element.help_text)
+  end
+
+  defp element_fallback_text(%Element{kind: :option_group} = element) do
+    labels = Enum.map_join(element.options, ", ", &(&1.label || &1.value))
+    "#{element.label}: #{labels}."
+  end
+
+  defp element_fallback_text(%Element{kind: :select_option} = element),
+    do: element.label || element.value || "Option"
+
+  defp input_description(element, type) do
+    requirement = if element.required, do: ", required", else: ""
+    "#{element.label || element.id} (#{type}#{requirement})."
+  end
+
+  defp optional_sentence(_label, nil), do: ""
+  defp optional_sentence(label, value), do: " #{label}: #{format_value(value)}."
+
+  defp help_sentence(nil), do: ""
+  defp help_sentence(value), do: " #{value}"
+
+  defp format_value(value) when is_number(value), do: to_string(value)
+  defp format_value(value), do: to_string(value)
+
+  defp normalize_options_source(nil), do: :external
+  defp normalize_options_source(source) when source in [:external, :dynamic], do: source
+  defp normalize_options_source("external"), do: :external
+  defp normalize_options_source("dynamic"), do: :dynamic
+  defp normalize_options_source(source), do: source
+
+  defp option(opts, key) do
+    Map.get(opts, key, Map.get(opts, Atom.to_string(key)))
   end
 end

--- a/lib/jido/chat/modal/element.ex
+++ b/lib/jido/chat/modal/element.ex
@@ -1,11 +1,23 @@
 defmodule Jido.Chat.Modal.Element do
   @moduledoc """
   Canonical modal element used by `Jido.Chat.Modal`.
+
+  Validation enforces portable input rules. Provider length and option-count
+  limits belong to each adapter renderer.
   """
 
   alias Jido.Chat.Wire
 
-  @kinds [:text_input, :select, :radio_select, :select_option]
+  @kinds [
+    :text_input,
+    :date_input,
+    :number_input,
+    :select,
+    :radio_select,
+    :external_select,
+    :select_option,
+    :option_group
+  ]
 
   @schema Zoi.struct(
             __MODULE__,
@@ -16,15 +28,26 @@ defmodule Jido.Chat.Modal.Element do
               value: Zoi.string() |> Zoi.nullish(),
               placeholder: Zoi.string() |> Zoi.nullish(),
               help_text: Zoi.string() |> Zoi.nullish(),
+              fallback_text: Zoi.string() |> Zoi.nullish(),
               required: Zoi.boolean() |> Zoi.default(false),
               multiline: Zoi.boolean() |> Zoi.default(false),
               min_length: Zoi.integer() |> Zoi.nullish(),
               max_length: Zoi.integer() |> Zoi.nullish(),
+              min_date: Zoi.string() |> Zoi.nullish(),
+              max_date: Zoi.string() |> Zoi.nullish(),
+              min_value: Zoi.number() |> Zoi.nullish(),
+              max_value: Zoi.number() |> Zoi.nullish(),
+              step: Zoi.number() |> Zoi.nullish(),
               options: Zoi.list() |> Zoi.default([]),
+              option_groups: Zoi.list() |> Zoi.default([]),
+              options_source: Zoi.enum([:static, :external, :dynamic]) |> Zoi.nullish(),
+              min_query_length: Zoi.integer() |> Zoi.nullish(),
+              timeout_ms: Zoi.integer() |> Zoi.nullish(),
               metadata: Zoi.map() |> Zoi.default(%{})
             },
             coerce: true
           )
+          |> Zoi.refine({__MODULE__, :validate, []})
 
   @type t :: unquote(Zoi.type_spec(@schema))
   @type input :: t() | map()
@@ -41,7 +64,11 @@ defmodule Jido.Chat.Modal.Element do
 
   def new(attrs) when is_map(attrs) do
     attrs
+    |> normalize_kind()
+    |> normalize_options_source()
+    |> normalize_temporal_values()
     |> normalize_options()
+    |> normalize_option_groups()
     |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
   end
 
@@ -56,6 +83,9 @@ defmodule Jido.Chat.Modal.Element do
     element
     |> Map.from_struct()
     |> Map.update!(:options, &Enum.map(&1, fn option -> option |> normalize() |> to_map() end))
+    |> Map.update!(:option_groups, fn groups ->
+      Enum.map(groups, fn group -> group |> normalize() |> to_map() end)
+    end)
     |> Wire.to_plain()
     |> Map.put("__type__", "modal_element")
   end
@@ -68,4 +98,113 @@ defmodule Jido.Chat.Modal.Element do
     options = attrs[:options] || attrs["options"] || []
     attrs |> Map.delete("options") |> Map.put(:options, Enum.map(options, &normalize/1))
   end
+
+  defp normalize_kind(attrs), do: normalize_existing_atom_field(attrs, :kind, @kinds)
+
+  defp normalize_options_source(attrs) do
+    normalize_existing_atom_field(attrs, :options_source, [:static, :external, :dynamic])
+  end
+
+  defp normalize_existing_atom_field(attrs, key, allowed) do
+    string_key = Atom.to_string(key)
+
+    case attrs[key] || attrs[string_key] do
+      value when is_binary(value) ->
+        atom = String.to_existing_atom(value)
+        if atom in allowed, do: attrs |> Map.delete(string_key) |> Map.put(key, atom), else: attrs
+
+      _ ->
+        attrs
+    end
+  rescue
+    ArgumentError -> attrs
+  end
+
+  defp normalize_option_groups(attrs) do
+    groups = attrs[:option_groups] || attrs["option_groups"] || []
+
+    attrs
+    |> Map.delete("option_groups")
+    |> Map.put(:option_groups, Enum.map(groups, &normalize/1))
+  end
+
+  defp normalize_temporal_values(attrs) do
+    Enum.reduce([:value, :min_date, :max_date], attrs, fn key, acc ->
+      string_key = Atom.to_string(key)
+
+      case Map.get(acc, key, Map.get(acc, string_key)) do
+        %Date{} = date ->
+          acc |> Map.delete(string_key) |> Map.put(key, Date.to_iso8601(date))
+
+        value when key == :value and is_number(value) ->
+          acc |> Map.delete(string_key) |> Map.put(key, to_string(value))
+
+        _ ->
+          acc
+      end
+    end)
+  end
+
+  @doc false
+  def validate(_schema, %__MODULE__{} = element) do
+    cond do
+      element.min_length != nil and element.min_length < 0 ->
+        {:error, "min_length must be zero or greater"}
+
+      element.max_length != nil and element.max_length < 0 ->
+        {:error, "max_length must be zero or greater"}
+
+      bounded_above?(element.min_length, element.max_length) ->
+        {:error, "min_length must not be greater than max_length"}
+
+      element.min_query_length != nil and element.min_query_length < 0 ->
+        {:error, "min_query_length must be zero or greater"}
+
+      element.timeout_ms != nil and element.timeout_ms < 1 ->
+        {:error, "timeout_ms must be greater than zero"}
+
+      element.step != nil and element.step <= 0 ->
+        {:error, "step must be greater than zero"}
+
+      bounded_above?(element.min_value, element.max_value) ->
+        {:error, "min_value must not be greater than max_value"}
+
+      element.kind == :date_input and not valid_date_bounds?(element) ->
+        {:error, "date values must use ISO 8601 and min_date must not exceed max_date"}
+
+      element.kind == :number_input and not valid_number_value?(element.value) ->
+        {:error, "number input value must be numeric"}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp bounded_above?(nil, _max), do: false
+  defp bounded_above?(_min, nil), do: false
+  defp bounded_above?(min, max), do: min > max
+
+  defp valid_date_bounds?(element) do
+    with {:ok, _value} <- parse_optional_date(element.value),
+         {:ok, min_date} <- parse_optional_date(element.min_date),
+         {:ok, max_date} <- parse_optional_date(element.max_date) do
+      is_nil(min_date) or is_nil(max_date) or Date.compare(min_date, max_date) != :gt
+    else
+      _ -> false
+    end
+  end
+
+  defp parse_optional_date(nil), do: {:ok, nil}
+  defp parse_optional_date(value), do: Date.from_iso8601(value)
+
+  defp valid_number_value?(nil), do: true
+
+  defp valid_number_value?(value) when is_binary(value) do
+    case Float.parse(value) do
+      {_number, ""} -> true
+      _ -> false
+    end
+  end
+
+  defp valid_number_value?(_value), do: false
 end

--- a/lib/jido/chat/modal_submit_event.ex
+++ b/lib/jido/chat/modal_submit_event.ex
@@ -42,6 +42,7 @@ defmodule Jido.Chat.ModalSubmitEvent do
   @doc "Creates a normalized modal submit event payload."
   def new(attrs) when is_map(attrs) do
     attrs
+    |> normalize_values()
     |> normalize_author()
     |> normalize_handles()
     |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
@@ -123,4 +124,22 @@ defmodule Jido.Chat.ModalSubmitEvent do
 
   defp serialize_handle(nil, _fun), do: nil
   defp serialize_handle(value, fun), do: fun.(value)
+
+  defp normalize_values(attrs) do
+    case attrs[:values] || attrs["values"] do
+      %{} = values -> attrs |> Map.delete("values") |> Map.put(:values, stringify_values(values))
+      _ -> attrs
+    end
+  end
+
+  defp stringify_values(%Date{} = value), do: Date.to_iso8601(value)
+  defp stringify_values(value) when is_integer(value), do: Integer.to_string(value)
+  defp stringify_values(value) when is_float(value), do: Float.to_string(value)
+
+  defp stringify_values(value) when is_map(value) do
+    Map.new(value, fn {key, nested} -> {key, stringify_values(nested)} end)
+  end
+
+  defp stringify_values(value) when is_list(value), do: Enum.map(value, &stringify_values/1)
+  defp stringify_values(value), do: value
 end

--- a/lib/jido/chat/options_load_error.ex
+++ b/lib/jido/chat/options_load_error.ex
@@ -1,0 +1,74 @@
+defmodule Jido.Chat.OptionsLoadError do
+  @moduledoc """
+  Typed error or timeout from a dynamic select option loader.
+  """
+
+  alias Jido.Chat.Wire
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              kind: Zoi.enum([:error, :timeout]) |> Zoi.default(:error),
+              code: Zoi.string() |> Zoi.default("options_load_failed"),
+              message: Zoi.string() |> Zoi.default("Options could not be loaded"),
+              retryable: Zoi.boolean() |> Zoi.default(false),
+              timeout_ms: Zoi.integer() |> Zoi.nullish(),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+          |> Zoi.refine({__MODULE__, :validate, []})
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the schema for an options-load error."
+  def schema, do: @schema
+
+  @doc "Creates an options-load error."
+  @spec new(t() | map()) :: t()
+  def new(%__MODULE__{} = error), do: error
+  def new(attrs) when is_map(attrs), do: Jido.Chat.Schema.parse!(__MODULE__, @schema, attrs)
+
+  @doc "Creates a retryable options-load timeout."
+  @spec timeout(pos_integer(), keyword() | map()) :: t()
+  def timeout(timeout_ms, opts \\ []) do
+    opts = Map.new(opts)
+
+    new(
+      Map.merge(opts, %{
+        kind: :timeout,
+        code: "options_load_timeout",
+        message: "Options did not load before the timeout",
+        retryable: true,
+        timeout_ms: timeout_ms
+      })
+    )
+  end
+
+  @doc false
+  def validate(_schema, %__MODULE__{kind: :timeout, timeout_ms: timeout_ms})
+      when not is_integer(timeout_ms) or timeout_ms < 1,
+      do: {:error, "timeout_ms must be greater than zero for a timeout"}
+
+  def validate(_schema, %__MODULE__{timeout_ms: timeout_ms})
+      when is_integer(timeout_ms) and timeout_ms < 1,
+      do: {:error, "timeout_ms must be greater than zero"}
+
+  def validate(_schema, %__MODULE__{}), do: :ok
+
+  @doc "Serializes the options-load error."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = error) do
+    error
+    |> Map.from_struct()
+    |> Wire.to_plain()
+    |> Map.put("__type__", "options_load_error")
+  end
+
+  @doc "Builds an options-load error from serialized data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+end

--- a/lib/jido/chat/options_load_event.ex
+++ b/lib/jido/chat/options_load_event.ex
@@ -1,0 +1,102 @@
+defmodule Jido.Chat.OptionsLoadEvent do
+  @moduledoc """
+  Normalized request to load options for an external or dynamic select.
+  """
+
+  alias Jido.Chat.{Author, Wire}
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              id: Zoi.string(),
+              adapter: Zoi.any() |> Zoi.nullish(),
+              adapter_name: Zoi.atom() |> Zoi.nullish(),
+              action_id: Zoi.string() |> Zoi.min(1),
+              query: Zoi.string() |> Zoi.default(""),
+              limit: Zoi.integer() |> Zoi.nullish(),
+              timeout_ms: Zoi.integer() |> Zoi.nullish(),
+              thread_id: Zoi.string() |> Zoi.nullish(),
+              channel_id: Zoi.string() |> Zoi.nullish(),
+              message_id: Zoi.string() |> Zoi.nullish(),
+              view_id: Zoi.string() |> Zoi.nullish(),
+              user: Zoi.struct(Author) |> Zoi.nullish(),
+              raw: Zoi.map() |> Zoi.default(%{}),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+          |> Zoi.refine({__MODULE__, :validate, []})
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the schema for an options-load event."
+  def schema, do: @schema
+
+  @doc "Creates a normalized options-load event."
+  @spec new(t() | map()) :: t()
+  def new(%__MODULE__{} = event), do: event
+
+  def new(attrs) when is_map(attrs) do
+    attrs
+    |> Map.put_new(:id, attrs[:id] || attrs["id"] || Jido.Chat.ID.generate!())
+    |> normalize_adapter_name()
+    |> normalize_author()
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc false
+  def validate(_schema, %__MODULE__{limit: limit}) when is_integer(limit) and limit < 1,
+    do: {:error, "limit must be greater than zero"}
+
+  def validate(_schema, %__MODULE__{timeout_ms: timeout_ms})
+      when is_integer(timeout_ms) and timeout_ms < 1,
+      do: {:error, "timeout_ms must be greater than zero"}
+
+  def validate(_schema, %__MODULE__{}), do: :ok
+
+  @doc "Serializes the options-load event."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = event) do
+    event
+    |> Map.from_struct()
+    |> Map.update!(:adapter, &Wire.encode_module/1)
+    |> Wire.to_plain()
+    |> Map.put("__type__", "options_load_event")
+  end
+
+  @doc "Builds an options-load event from serialized data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map) do
+    adapter = map[:adapter] || map["adapter"]
+
+    map
+    |> Map.drop(["__type__", :__type__, "adapter", :adapter])
+    |> Map.put(:adapter, Wire.decode_module(adapter))
+    |> new()
+  end
+
+  defp normalize_author(%{user: %Author{}} = attrs), do: attrs
+  defp normalize_author(%{"user" => %Author{}} = attrs), do: attrs
+
+  defp normalize_author(attrs) do
+    case attrs[:user] || attrs["user"] do
+      %{} = user -> attrs |> Map.delete("user") |> Map.put(:user, Author.new(user))
+      _ -> attrs
+    end
+  end
+
+  defp normalize_adapter_name(attrs) do
+    case attrs[:adapter_name] || attrs["adapter_name"] do
+      name when is_binary(name) ->
+        attrs |> Map.delete("adapter_name") |> Map.put(:adapter_name, String.to_existing_atom(name))
+
+      _ ->
+        attrs
+    end
+  rescue
+    ArgumentError -> attrs
+  end
+end

--- a/lib/jido/chat/options_load_option.ex
+++ b/lib/jido/chat/options_load_option.ex
@@ -1,0 +1,44 @@
+defmodule Jido.Chat.OptionsLoadOption do
+  @moduledoc """
+  Provider-neutral option returned by a dynamic select loader.
+  """
+
+  alias Jido.Chat.Wire
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              label: Zoi.string() |> Zoi.min(1),
+              value: Zoi.string() |> Zoi.min(1),
+              description: Zoi.string() |> Zoi.nullish(),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the schema for an option-load option."
+  def schema, do: @schema
+
+  @doc "Creates an option-load option."
+  @spec new(t() | map()) :: t()
+  def new(%__MODULE__{} = option), do: option
+  def new(attrs) when is_map(attrs), do: Jido.Chat.Schema.parse!(__MODULE__, @schema, attrs)
+
+  @doc "Serializes the option."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = option) do
+    option
+    |> Map.from_struct()
+    |> Wire.to_plain()
+    |> Map.put("__type__", "options_load_option")
+  end
+
+  @doc "Builds an option from serialized data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+end

--- a/lib/jido/chat/options_load_option_group.ex
+++ b/lib/jido/chat/options_load_option_group.ex
@@ -1,0 +1,52 @@
+defmodule Jido.Chat.OptionsLoadOptionGroup do
+  @moduledoc """
+  A labeled group of provider-neutral dynamic select options.
+  """
+
+  alias Jido.Chat.{OptionsLoadOption, Wire}
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              label: Zoi.string() |> Zoi.min(1),
+              options: Zoi.list() |> Zoi.min(1),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the schema for an option group."
+  def schema, do: @schema
+
+  @doc "Creates an option group."
+  @spec new(t() | map()) :: t()
+  def new(%__MODULE__{} = group), do: group
+
+  def new(attrs) when is_map(attrs) do
+    options = attrs[:options] || attrs["options"] || []
+
+    attrs
+    |> Map.delete("options")
+    |> Map.put(:options, Enum.map(options, &OptionsLoadOption.new/1))
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Serializes the option group."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = group) do
+    group
+    |> Map.from_struct()
+    |> Map.update!(:options, &Enum.map(&1, fn option -> OptionsLoadOption.to_map(option) end))
+    |> Wire.to_plain()
+    |> Map.put("__type__", "options_load_option_group")
+  end
+
+  @doc "Builds an option group from serialized data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+end

--- a/lib/jido/chat/options_load_result.ex
+++ b/lib/jido/chat/options_load_result.ex
@@ -1,0 +1,72 @@
+defmodule Jido.Chat.OptionsLoadResult do
+  @moduledoc """
+  Successful, typed output from a dynamic select option loader.
+
+  The core does not set a provider maximum for option or group counts. An
+  adapter can apply its own limits before it renders this result.
+  """
+
+  alias Jido.Chat.{OptionsLoadOption, OptionsLoadOptionGroup, Wire}
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              options: Zoi.list() |> Zoi.default([]),
+              option_groups: Zoi.list() |> Zoi.default([]),
+              has_more: Zoi.boolean() |> Zoi.default(false),
+              cursor: Zoi.string() |> Zoi.nullish(),
+              metadata: Zoi.map() |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc "Returns the schema for options-load output."
+  def schema, do: @schema
+
+  @doc "Creates successful options-load output."
+  @spec new(t() | map()) :: t()
+  def new(%__MODULE__{} = result), do: result
+
+  def new(attrs) when is_map(attrs) do
+    options = attrs[:options] || attrs["options"] || []
+    groups = attrs[:option_groups] || attrs["option_groups"] || attrs[:groups] || attrs["groups"] || []
+
+    attrs
+    |> Map.delete("options")
+    |> Map.delete("option_groups")
+    |> Map.delete(:groups)
+    |> Map.delete("groups")
+    |> Map.put(:options, Enum.map(options, &OptionsLoadOption.new/1))
+    |> Map.put(:option_groups, Enum.map(groups, &OptionsLoadOptionGroup.new/1))
+    |> then(&Jido.Chat.Schema.parse!(__MODULE__, @schema, &1))
+  end
+
+  @doc "Builds output from an option list."
+  @spec ok([OptionsLoadOption.t() | map()], keyword() | map()) :: t()
+  def ok(options, opts \\ []) when is_list(options) do
+    opts = Map.new(opts)
+    new(Map.put(opts, :options, options))
+  end
+
+  @doc "Serializes options-load output."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = result) do
+    result
+    |> Map.from_struct()
+    |> Map.update!(:options, &Enum.map(&1, fn option -> OptionsLoadOption.to_map(option) end))
+    |> Map.update!(:option_groups, fn groups ->
+      Enum.map(groups, fn group -> OptionsLoadOptionGroup.to_map(group) end)
+    end)
+    |> Wire.to_plain()
+    |> Map.put("__type__", "options_load_result")
+  end
+
+  @doc "Builds options-load output from serialized data."
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map), do: map |> Map.drop(["__type__", :__type__]) |> new()
+end

--- a/lib/jido/chat/serialization.ex
+++ b/lib/jido/chat/serialization.ex
@@ -22,6 +22,11 @@ defmodule Jido.Chat.Serialization do
     ModalResponse,
     ModalResult,
     ModalSubmitEvent,
+    OptionsLoadError,
+    OptionsLoadEvent,
+    OptionsLoadOption,
+    OptionsLoadOptionGroup,
+    OptionsLoadResult,
     PostPayload,
     ReactionEvent,
     ReplyContext,
@@ -100,6 +105,14 @@ defmodule Jido.Chat.Serialization do
   def revive(%{"__type__" => "action_event"} = map), do: ActionEvent.from_map(map)
   def revive(%{"__type__" => "modal_submit_event"} = map), do: ModalSubmitEvent.from_map(map)
   def revive(%{"__type__" => "modal_close_event"} = map), do: ModalCloseEvent.from_map(map)
+  def revive(%{"__type__" => "options_load_event"} = map), do: OptionsLoadEvent.from_map(map)
+  def revive(%{"__type__" => "options_load_result"} = map), do: OptionsLoadResult.from_map(map)
+  def revive(%{"__type__" => "options_load_error"} = map), do: OptionsLoadError.from_map(map)
+  def revive(%{"__type__" => "options_load_option"} = map), do: OptionsLoadOption.from_map(map)
+
+  def revive(%{"__type__" => "options_load_option_group"} = map),
+    do: OptionsLoadOptionGroup.from_map(map)
+
   def revive(%{"__type__" => "slash_command_event"} = map), do: SlashCommandEvent.from_map(map)
 
   def revive(%{"__type__" => "assistant_thread_started_event"} = map),
@@ -112,6 +125,13 @@ defmodule Jido.Chat.Serialization do
   def revive(%{"__type__" => "markdown_node"} = map), do: Jido.Chat.Markdown.Node.from_map(map)
   def revive(%{"__type__" => "card"} = map), do: Card.from_map(map)
   def revive(%{"__type__" => "card_component"} = map), do: Jido.Chat.Card.Component.from_map(map)
+
+  def revive(%{"__type__" => "card_chart_data"} = map),
+    do: Jido.Chat.Card.ChartData.from_map(map)
+
+  def revive(%{"__type__" => "card_chart_series"} = map),
+    do: Jido.Chat.Card.ChartSeries.from_map(map)
+
   def revive(%{"__type__" => "modal"} = map), do: Modal.from_map(map)
   def revive(%{"__type__" => "modal_element"} = map), do: Jido.Chat.Modal.Element.from_map(map)
   def revive(%{"__type__" => "message"} = map), do: Message.from_map(map)

--- a/lib/jido_chat.ex
+++ b/lib/jido_chat.ex
@@ -29,6 +29,9 @@ defmodule Jido.Chat do
     MessageUpdatedEvent,
     ModalCloseEvent,
     ModalSubmitEvent,
+    OptionsLoadError,
+    OptionsLoadEvent,
+    OptionsLoadResult,
     Participant,
     ReactionEvent,
     Room,
@@ -720,6 +723,18 @@ defmodule Jido.Chat do
     end
   end
 
+  @doc "Processes an options-load event through its adapter callback."
+  @spec process_options_load(t(), atom(), OptionsLoadEvent.t() | map(), keyword()) ::
+          {:ok, t(), OptionsLoadResult.t()} | {:error, OptionsLoadError.t() | term()}
+  def process_options_load(%__MODULE__{} = chat, adapter_name, event, opts \\ [])
+      when is_atom(adapter_name) and is_list(opts) do
+    with {:ok, options_event} <- EventRouter.ensure_options_load_event(event, adapter_name),
+         {:ok, adapter_module} <- AdapterRegistry.resolve(chat, adapter_name),
+         {:ok, result} <- Adapter.load_options(adapter_module, options_event, opts) do
+      {:ok, chat, result}
+    end
+  end
+
   @doc "Processes normalized slash command events and dispatches handlers."
   @spec process_slash_command(t(), atom(), SlashCommandEvent.t() | map(), keyword()) ::
           {:ok, t(), SlashCommandEvent.t()} | {:error, term()}
@@ -747,6 +762,7 @@ defmodule Jido.Chat do
       process_action: &process_action/4,
       process_modal_submit: &process_modal_submit/4,
       process_modal_close: &process_modal_close/4,
+      process_options_load: &process_options_load/4,
       process_slash_command: &process_slash_command/4,
       process_assistant_thread_started: &process_assistant_thread_started/3,
       process_assistant_context_changed: &process_assistant_context_changed/3

--- a/test/jido/chat/capabilities_test.exs
+++ b/test/jido/chat/capabilities_test.exs
@@ -57,7 +57,7 @@ defmodule Jido.Chat.CapabilitiesTest do
            )
   end
 
-  test "channel_capabilities/1 defaults to [:text] for adapters without an explicit matrix" do
+  test "channel_capabilities/1 derives fallbacks for adapters without an explicit matrix" do
     defmodule AdapterWithoutCapabilities do
       @behaviour Jido.Chat.Adapter
 
@@ -71,7 +71,13 @@ defmodule Jido.Chat.CapabilitiesTest do
       def send_message(_, _, _), do: {:error, :not_implemented}
     end
 
-    assert Capabilities.channel_capabilities(AdapterWithoutCapabilities) == [:text, :streaming]
+    assert Capabilities.channel_capabilities(AdapterWithoutCapabilities) == [
+             :text,
+             :streaming,
+             :card_charts,
+             :card_tables,
+             :link_action_ids
+           ]
   end
 
   test "channel_capabilities/1 derives delivery support from adapter capability matrices" do
@@ -90,7 +96,14 @@ defmodule Jido.Chat.CapabilitiesTest do
           send_message: :native,
           post_message: :native,
           cards: :native,
+          card_charts: :fallback,
+          card_tables: :native,
           modals: :native,
+          modal_date_input: :native,
+          modal_number_input: :fallback,
+          external_select: :native,
+          options_load: :native,
+          link_action_ids: :fallback,
           open_thread: :native,
           list_threads: :native,
           add_reaction: :native,
@@ -119,7 +132,14 @@ defmodule Jido.Chat.CapabilitiesTest do
              :threads,
              :reactions,
              :typing,
-             :streaming
+             :streaming,
+             :card_charts,
+             :card_tables,
+             :modal_date_input,
+             :modal_number_input,
+             :external_select,
+             :options_load,
+             :link_action_ids
            ]
   end
 

--- a/test/jido/chat/cards_modals_extensions_test.exs
+++ b/test/jido/chat/cards_modals_extensions_test.exs
@@ -1,0 +1,533 @@
+defmodule Jido.Chat.CardsModalsExtensionsTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Chat.{
+    Adapter,
+    Card,
+    CapabilityMatrix,
+    EventEnvelope,
+    Modal,
+    ModalSubmitEvent,
+    OptionsLoadError,
+    OptionsLoadEvent,
+    OptionsLoadOption,
+    OptionsLoadOptionGroup,
+    OptionsLoadResult
+  }
+
+  alias Jido.Chat.Card.{ChartData, ChartSeries}
+
+  defmodule OptionsAdapter do
+    @behaviour Jido.Chat.Adapter
+
+    @impl true
+    def channel_type, do: :options_test
+
+    @impl true
+    def capabilities do
+      %{
+        cards: :fallback,
+        card_charts: :fallback,
+        card_tables: :fallback,
+        modal_date_input: :native,
+        modal_number_input: :native,
+        external_select: :native,
+        options_load: :native
+      }
+    end
+
+    @impl true
+    def send_message(_external_room_id, _text, _opts), do: {:error, :not_used}
+
+    @impl true
+    def transform_incoming(_payload), do: {:error, :not_used}
+
+    @impl true
+    def load_options(%OptionsLoadEvent{query: "timeout"}, _opts), do: {:error, :timeout}
+
+    def load_options(%OptionsLoadEvent{query: "slow", raw: %{test_pid: test_pid}}, _opts) do
+      send(test_pid, {:options_load_started, self()})
+      Process.sleep(1_000)
+      send(test_pid, :options_load_completed)
+      {:ok, %{options: []}}
+    end
+
+    def load_options(%OptionsLoadEvent{action_id: "assignee"}, _opts) do
+      {:ok,
+       %{
+         options: [%{label: "Ada", value: "user:ada"}],
+         option_groups: [
+           %{label: "Teams", options: [%{label: "Core", value: "team:core"}]}
+         ]
+       }}
+    end
+  end
+
+  describe "chart and table components" do
+    test "constructors accept atom and string maps and keep chart data typed" do
+      pie = Card.pie_chart([{"Ready", 3}, %{"label" => "Failed", "value" => 1}])
+
+      bar =
+        Card.bar_chart(
+          [%{label: "Jan", value: 10}, %{label: "Feb", value: 12, series: "API"}],
+          %{"title" => "Requests", "caption" => "Monthly totals"}
+        )
+
+      assert pie.kind == :pie_chart
+
+      assert [%ChartData{label: "Ready", value: 3}, %ChartData{label: "Failed", value: 1}] =
+               pie.data
+
+      assert bar.title == "Requests"
+      assert bar.caption == "Monthly totals"
+      assert Enum.at(bar.data, 1).series == "API"
+
+      assert Card.area_chart([%{label: "Mon", value: 2}]).kind == :area_chart
+      assert Card.line_chart([%{label: "Mon", value: 2}]).kind == :line_chart
+    end
+
+    test "named series align unambiguously with ordered shared categories" do
+      chart =
+        Card.line_chart(
+          ["Jan", "Feb"],
+          [
+            %{name: "API", values: [10, 12]},
+            %{"name" => "Worker", "values" => [7, 9]}
+          ],
+          title: "Requests"
+        )
+
+      assert chart.categories == ["Jan", "Feb"]
+
+      assert [
+               %ChartSeries{name: "API", values: [10, 12]},
+               %ChartSeries{name: "Worker", values: [7, 9]}
+             ] = chart.series
+
+      assert Card.fallback_text(Card.new(%{components: [chart]})) ==
+               "Requests\n\nLine chart. API — Jan: 10, Feb: 12; Worker — Jan: 7, Feb: 9."
+
+      assert_raise Jido.Chat.Errors.Validation, fn ->
+        Card.line_chart(["Jan", "Feb"], [%{name: "API", values: [10]}], [])
+      end
+
+      assert_raise Jido.Chat.Errors.Validation, fn ->
+        Card.bar_chart(
+          ["Jan"],
+          [%{name: "API", values: [10]}, %{name: "API", values: [12]}],
+          []
+        )
+      end
+
+      assert_raise Jido.Chat.Errors.Validation, fn ->
+        Card.Component.new(%{
+          kind: :line_chart,
+          data: [%{label: "Jan", value: 10}],
+          categories: ["Jan"],
+          series: [%{name: "API", values: [10]}]
+        })
+      end
+    end
+
+    test "table accepts caption and any positive page size without provider limits" do
+      table =
+        Card.table(["Name", "State"], [["api", "ok"]],
+          caption: "Service health",
+          page_size: 50_000
+        )
+
+      assert table.caption == "Service health"
+      assert table.page_size == 50_000
+
+      assert_raise Jido.Chat.Errors.Validation, fn ->
+        Card.table(["Name"], [["api"]], page_size: 0)
+      end
+
+      assert_raise Jido.Chat.Errors.Validation, fn ->
+        Card.table(["Name", "State"], [["api"]])
+      end
+    end
+
+    test "charts and tables have deterministic readable fallbacks" do
+      card =
+        Card.new(%{
+          components: [
+            Card.line_chart([{"Mon", 2}, {"Tue", 4}],
+              title: "Traffic",
+              caption: "Requests per minute"
+            ),
+            Card.table(["Service", "State"], [["api", "ok"]], caption: "Current health")
+          ]
+        })
+
+      assert Card.fallback_text(card) ==
+               "Traffic\n\nRequests per minute\n\nLine chart. Mon: 2; Tue: 4.\n\nCurrent health\n\nService | State\n--------+------\napi     | ok"
+    end
+
+    test "each chart type and table exposes non-empty adapter fallback text" do
+      components = [
+        Card.pie_chart([{"Ready", 3}]),
+        Card.bar_chart([{"Ready", 3}]),
+        Card.area_chart([{"Ready", 3}]),
+        Card.line_chart([{"Ready", 3}]),
+        Card.table(["State"], [["ready"]], caption: "Health")
+      ]
+
+      Enum.each(components, fn component ->
+        card = Card.new(%{components: [component]})
+        assert Card.fallback_text(card) != ""
+        assert Card.to_adapter_payload(card)["fallback_text"] == Card.fallback_text(card)
+      end)
+    end
+
+    test "chart data boundaries reject empty data and non-numeric values" do
+      assert_raise Jido.Chat.Errors.Validation, fn -> Card.pie_chart([]) end
+
+      assert_raise Jido.Chat.Errors.Validation, fn ->
+        Card.bar_chart([%{label: "bad", value: "not-a-number"}])
+      end
+    end
+  end
+
+  describe "actions and selects" do
+    test "link buttons keep explicit IDs and generate deterministic IDs when absent" do
+      explicit =
+        Card.link_button("Logs", "https://example.com/logs", action_id: "deploy:logs")
+
+      generated_one = Card.link_button("Logs", "https://example.com/logs")
+      generated_two = Card.link_button("Logs", "https://example.com/logs")
+
+      assert explicit.id == "deploy:logs"
+      assert generated_one.id == generated_two.id
+      assert String.starts_with?(generated_one.id, "link:")
+
+      assert %Card.Component{id: "deploy:logs"} =
+               explicit |> Card.Component.to_map() |> Card.Component.from_map()
+
+      assert "deploy:logs" ==
+               explicit
+               |> Card.Component.to_map()
+               |> Jido.Chat.Serialization.revive()
+               |> Map.fetch!(:id)
+    end
+
+    test "external selects accept initial options and option groups" do
+      card_select =
+        Card.external_select("assignee",
+          label: "Assignee",
+          min_query_length: 2,
+          timeout_ms: 1_500,
+          options: [Card.select_option("Ada", "user:ada")],
+          option_groups: [
+            Card.select_option_group("Teams", [Card.select_option("Core", "team:core")])
+          ]
+        )
+
+      modal_select =
+        Modal.external_select("assignee", "Assignee",
+          min_query_length: 2,
+          timeout_ms: 1_500
+        )
+
+      assert card_select.kind == :external_select
+      assert card_select.options_source == :external
+      assert hd(card_select.option_groups).kind == :option_group
+      assert modal_select.kind == :external_select
+      assert modal_select.options_source == :external
+
+      assert_raise Jido.Chat.Errors.Validation, fn ->
+        Modal.external_select("bad", "Bad", min_query_length: -1)
+      end
+
+      assert_raise Jido.Chat.Errors.Validation, fn ->
+        Card.external_select("bad", timeout_ms: 0)
+      end
+    end
+  end
+
+  describe "modal inputs" do
+    test "date and number constructors validate portable boundaries" do
+      date =
+        Modal.date_input("start_date", "Start date",
+          value: ~D[2026-08-20],
+          min_date: ~D[2026-01-01],
+          max_date: "2026-12-31",
+          required: true
+        )
+
+      number =
+        Modal.number_input("amount", "Amount",
+          value: 12.5,
+          min_value: 0,
+          max_value: 100,
+          step: 0.5
+        )
+
+      assert date.value == "2026-08-20"
+      assert date.min_date == "2026-01-01"
+      assert number.value == "12.5"
+      assert number.step == 0.5
+
+      assert_raise Jido.Chat.Errors.Validation, fn ->
+        Modal.date_input("date", "Date", min_date: "2026-12-31", max_date: "2026-01-01")
+      end
+
+      assert_raise Jido.Chat.Errors.Validation, fn ->
+        Modal.number_input("number", "Number", min_value: 10, max_value: 1)
+      end
+
+      assert_raise Jido.Chat.Errors.Validation, fn ->
+        Modal.number_input("number", "Number", step: 0)
+      end
+    end
+
+    test "modal fallback text describes inputs and constraints" do
+      modal =
+        Modal.new(%{
+          title: "Report",
+          elements: [
+            Modal.date_input("day", "Day", required: true, min_date: "2026-01-01"),
+            Modal.number_input("count", "Count", min_value: 1, max_value: 10)
+          ]
+        })
+
+      assert Modal.fallback_text(modal) ==
+               "Report\nDay (date input, required). Minimum date: 2026-01-01.\nCount (number input). Minimum: 1. Maximum: 10."
+
+      assert Modal.to_adapter_payload(modal)["fallback_text"] == Modal.fallback_text(modal)
+    end
+
+    test "each input type has deterministic readable fallback text" do
+      modal =
+        Modal.new(%{
+          title: "Inputs",
+          elements: [
+            Modal.text_input("name", "Name"),
+            Modal.date_input("day", "Day"),
+            Modal.number_input("count", "Count"),
+            Modal.select("state", "State", [Modal.select_option("Ready", "ready")]),
+            Modal.radio_select("mode", "Mode", [Modal.select_option("Safe", "safe")]),
+            Modal.external_select("owner", "Owner")
+          ]
+        })
+
+      fallback = Modal.fallback_text(modal)
+      assert fallback == Modal.fallback_text(modal)
+
+      for label <- ["Name", "Day", "Count", "State", "Mode", "Owner"] do
+        assert fallback =~ label
+      end
+    end
+
+    test "submitted date and number values normalize to strings at the event boundary" do
+      event =
+        ModalSubmitEvent.new(%{
+          callback_id: "report",
+          values: %{
+            "day" => ~D[2026-08-20],
+            "count" => 12.5,
+            "nested" => %{"page" => 2, "enabled" => true}
+          }
+        })
+
+      assert event.values == %{
+               "day" => "2026-08-20",
+               "count" => "12.5",
+               "nested" => %{"page" => "2", "enabled" => true}
+             }
+    end
+  end
+
+  describe "typed options loading" do
+    test "input, output, groups, error, and timeout are typed" do
+      event =
+        OptionsLoadEvent.new(%{
+          "adapter_name" => "options_test",
+          "action_id" => "assignee",
+          "query" => "ad",
+          "limit" => 250_000
+        })
+
+      assert event.adapter_name == :options_test
+      assert event.limit == 250_000
+
+      assert {:ok,
+              %OptionsLoadResult{
+                options: [%OptionsLoadOption{label: "Ada"}],
+                option_groups: [%OptionsLoadOptionGroup{label: "Teams"}]
+              }} = Adapter.load_options(OptionsAdapter, event)
+
+      assert %OptionsLoadError{kind: :error, code: "upstream"} =
+               OptionsLoadError.new(%{code: "upstream", message: "Not available"})
+
+      assert %OptionsLoadError{kind: :timeout, timeout_ms: 1_500, retryable: true} =
+               OptionsLoadError.timeout(1_500)
+
+      timeout_event =
+        OptionsLoadEvent.new(%{action_id: "assignee", query: "timeout", timeout_ms: 40})
+
+      assert {:error, %OptionsLoadError{kind: :timeout, timeout_ms: 40}} =
+               Adapter.load_options(OptionsAdapter, timeout_event)
+
+      error = OptionsLoadError.new(%{code: "upstream", message: "Not available"})
+      timeout = OptionsLoadError.timeout(1_500)
+
+      assert %OptionsLoadError{kind: :error} =
+               error |> OptionsLoadError.to_map() |> Jido.Chat.Serialization.revive()
+
+      assert %OptionsLoadError{kind: :timeout} =
+               timeout |> OptionsLoadError.to_map() |> Jido.Chat.Serialization.revive()
+    end
+
+    test "adapter callbacks cannot exceed the resolved options-load timeout" do
+      event =
+        OptionsLoadEvent.new(%{
+          action_id: "assignee",
+          query: "slow",
+          timeout_ms: 500,
+          raw: %{test_pid: self()}
+        })
+
+      assert {:error, %OptionsLoadError{kind: :timeout, timeout_ms: 100}} =
+               Adapter.load_options(OptionsAdapter, event, timeout_ms: 100)
+
+      assert_receive {:options_load_started, worker}
+      refute Process.alive?(worker)
+      refute_receive :options_load_completed, 20
+    end
+
+    test "options-load envelopes route through the typed adapter callback" do
+      chat = Jido.Chat.new(adapters: %{options_test: OptionsAdapter})
+
+      envelope =
+        EventEnvelope.new(%{
+          adapter_name: :options_test,
+          event_type: :options_load,
+          payload: %{action_id: "assignee", query: "ad"}
+        })
+
+      assert {:ok, ^chat, %EventEnvelope{payload: %OptionsLoadResult{}} = routed} =
+               Jido.Chat.process_event(chat, :options_test, envelope)
+
+      assert %EventEnvelope{payload: %OptionsLoadResult{}} =
+               routed |> EventEnvelope.to_map() |> EventEnvelope.from_map()
+
+      timeout =
+        EventEnvelope.new(%{
+          adapter_name: :options_test,
+          event_type: :options_load,
+          payload: %{action_id: "assignee", query: "timeout", timeout_ms: 40}
+        })
+
+      assert {:error, %OptionsLoadError{kind: :timeout, timeout_ms: 40}} =
+               Jido.Chat.process_event(chat, :options_test, timeout)
+    end
+
+    test "invalid output, error, and timeout boundaries fail" do
+      assert_raise Jido.Chat.Errors.Validation, fn ->
+        OptionsLoadResult.new(%{options: [%{label: "Missing value"}]})
+      end
+
+      assert_raise Jido.Chat.Errors.Validation, fn -> OptionsLoadError.timeout(0) end
+
+      assert_raise Jido.Chat.Errors.Validation, fn ->
+        OptionsLoadEvent.new(%{action_id: "assignee", query: "", limit: 0})
+      end
+    end
+  end
+
+  describe "serialization and capabilities" do
+    test "string-key card and modal maps normalize all new element kinds" do
+      card =
+        Card.new(%{
+          "components" => [
+            %{
+              "kind" => "bar_chart",
+              "data" => [%{"label" => "Ready", "value" => 3}]
+            },
+            %{
+              "kind" => "table",
+              "caption" => "Health",
+              "columns" => ["State"],
+              "rows" => [["ready"]],
+              "page_size" => 100
+            }
+          ]
+        })
+
+      modal =
+        Modal.new(%{
+          "title" => "Report",
+          "elements" => [
+            %{"kind" => "date_input", "id" => "day", "label" => "Day"},
+            %{"kind" => "number_input", "id" => "count", "label" => "Count"},
+            %{
+              "kind" => "external_select",
+              "id" => "owner",
+              "label" => "Owner",
+              "options_source" => "dynamic"
+            }
+          ]
+        })
+
+      assert Enum.map(card.components, & &1.kind) == [:bar_chart, :table]
+      assert Enum.map(modal.elements, & &1.kind) == [:date_input, :number_input, :external_select]
+      assert List.last(modal.elements).options_source == :dynamic
+    end
+
+    test "new elements and options-load types serialize and revive" do
+      card =
+        Card.new(%{
+          components: [
+            Card.pie_chart([{"Ready", 3}]),
+            Card.external_select("assignee", options: [Card.select_option("Ada", "ada")])
+          ]
+        })
+
+      modal =
+        Modal.new(%{
+          title: "Report",
+          elements: [
+            Modal.date_input("day", "Day"),
+            Modal.number_input("count", "Count"),
+            Modal.external_select("assignee", "Assignee")
+          ]
+        })
+
+      event =
+        OptionsLoadEvent.new(%{
+          adapter: OptionsAdapter,
+          action_id: "assignee",
+          query: "ad"
+        })
+
+      result = OptionsLoadResult.new(%{options: [%{label: "Ada", value: "ada"}]})
+
+      assert %Card{components: [%Card.Component{data: [%ChartData{}]}, _]} =
+               card |> Card.to_map() |> Card.from_map()
+
+      assert %Modal{} = modal |> Modal.to_map() |> Modal.from_map()
+
+      assert %OptionsLoadEvent{adapter: OptionsAdapter} =
+               Jido.Chat.Serialization.revive(OptionsLoadEvent.to_map(event))
+
+      assert %OptionsLoadResult{} = Jido.Chat.Serialization.revive(OptionsLoadResult.to_map(result))
+
+      envelope = EventEnvelope.new(%{event_type: :options_load, payload: event})
+
+      assert %EventEnvelope{event_type: :options_load, payload: %OptionsLoadEvent{}} =
+               envelope |> EventEnvelope.to_map() |> EventEnvelope.from_map()
+    end
+
+    test "capability statuses include native, fallback, and unsupported new elements" do
+      matrix = Adapter.capability_matrix(OptionsAdapter)
+
+      assert CapabilityMatrix.status(matrix, :card_charts) == :fallback
+      assert CapabilityMatrix.status(matrix, :modal_date_input) == :native
+      assert CapabilityMatrix.status(matrix, :modal_number_input) == :native
+      assert CapabilityMatrix.status(matrix, :external_select) == :native
+      assert CapabilityMatrix.status(matrix, :unknown_element) == :unsupported
+      assert :link_action_ids in Jido.Chat.Capabilities.all()
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Extend canonical cards with pie, bar, area, and line charts plus typed chart data.
- Add table captions and page size, stable link action IDs, and readable fallbacks.
- Add date and number modal inputs and external dynamic selects.
- Add typed option-load events, results, options, groups, errors, and enforced timeouts.
- Add capability declarations and event normalization, routing, serialization, and revival.

## Validation

- Focused tests — 26 passed.
- Full tests — 150 passed.
- `mix quality` — passed, including Credo, Dialyzer, and Doctor.
- `git diff --check` — passed.
- Post-fix review `20260821-102757-561d5d15` — ready to merge with no findings.

## Post-Deploy Monitoring & Validation

- Round-trip every new card, modal, and options-load type.
- Confirm option loaders stop at the configured deadline and do not leave workers or mailbox messages.
- Confirm adapters negotiate all seven new capabilities.
- Watch for invalid provider limits and missing accessible fallback text.

Related: agentjido/jido_chat#44

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
